### PR TITLE
Update URL of the DDL2 imgCIF repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The imgCIF dictionary provides 
 data names for description of raw image data, usually from diffraction experiments. 
 Currently the main development of imgCIF takes place
-in the [cbflib repository](https://github.com/dials/cbflib/tree/main/doc).
+in the [cbflib repository](https://github.com/yayahjb/cbf_imgcif_dictionary).
 
 This repository holds a DDLm version of the imgCIF dictionary found in the
 main branch of that repository in this repository's main branch. This DDLm

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The imgCIF dictionary provides 
 data names for description of raw image data, usually from diffraction experiments. 
 Currently the main development of imgCIF takes place
-in the [cbflib repository](https://github.com/yayahjb/cbflib/tree/master/doc).
+in the [cbflib repository](https://github.com/dials/cbflib/tree/main/doc).
 
 This repository holds a DDLm version of the imgCIF dictionary found in the
 main branch of that repository in this repository's main branch. This DDLm


### PR DESCRIPTION
The previously referenced repository no longer exists, but it does redirect to the new one.