### PR TITLE
Update to latest DDL2 source dictionary and latest DDLm standards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,109 @@
+# Check that syntax is correct
+
+name: CIFSyntaxandStyleCheck
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+            - '.github/**'
+
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+            - '.github/**'
+  workflow_dispatch:   
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  syntax:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        - name: checkout
+          uses: actions/checkout@v4
+          
+      # Check syntax of all CIF files
+        - name: check_syntax
+          uses: COMCIFS/cif_syntax_check_action@master
+          id: cif_syntax_check
+  layout:
+    runs-on: ubuntu-latest
+    needs: syntax
+
+    steps:
+      - name: Get the cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+                 path: ~/.julia
+                 key: ${{ runner.os }}-julia-v2
+                 
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+                version: '1.10'
+
+      - name: Install Julia packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+               julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+                path: main
+      - name: checkout julia tools
+        uses: actions/checkout@v4
+        with:
+                repository: jamesrhester/julia_cif_tools
+                path: julia_cif_tools
+
+      - name: Checkout CIF master files
+        uses: actions/checkout@v4
+        with:
+                repository: COMCIFS/cif_core
+                path: cif_core
+      - name: Diagnostics
+        run: |
+            ls -a
+            pwd
+            which julia
+      - name: one_dict_layout
+        run: |
+               julia -e 'using Pkg; Pkg.status()'
+               for file in main/*.dic
+               do      
+                  echo "Checking $file"
+                  julia -O0 ./julia_cif_tools/linter.jl -i $PWD/cif_core $file cif_core/ddl.dic
+                  if [ $? != 0 ] 
+                  then 
+                    exit 1 ;
+                  fi 
+               done
+  ddlm:
+    runs-on: ubuntu-latest
+    needs: syntax
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout the coreCIF dictionary
+        uses: actions/checkout@v4
+        with:
+          repository: COMCIFS/cif_core
+          path: cif-dictionaries/cif_core
+
+      - name: Checkout the multiblock coreCIF dictionary
+        uses: actions/checkout@v4
+        with:
+          repository: COMCIFS/MultiBlock_Dictionary
+          path: cif-dictionaries/MultiBlock_Dictionary
+
+      - name: check_ddlm
+        uses: COMCIFS/dictionary_check_action@main
+        id: ddlm_check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,59 +32,6 @@ jobs:
         - name: check_syntax
           uses: COMCIFS/cif_syntax_check_action@master
           id: cif_syntax_check
-  layout:
-    runs-on: ubuntu-latest
-    needs: syntax
-
-    steps:
-      - name: Get the cache
-        uses: actions/cache@v4
-        id: cache
-        with:
-                 path: ~/.julia
-                 key: ${{ runner.os }}-julia-v2
-                 
-      - name: Install Julia
-        uses: julia-actions/setup-julia@v1
-        with:
-                version: '1.10'
-
-      - name: Install Julia packages
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-               julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("ArgParse")'
-      - name: checkout
-        uses: actions/checkout@v4
-        with:
-                path: main
-      - name: checkout julia tools
-        uses: actions/checkout@v4
-        with:
-                repository: jamesrhester/julia_cif_tools
-                path: julia_cif_tools
-
-      - name: Checkout CIF master files
-        uses: actions/checkout@v4
-        with:
-                repository: COMCIFS/cif_core
-                path: cif_core
-      - name: Diagnostics
-        run: |
-            ls -a
-            pwd
-            which julia
-      - name: one_dict_layout
-        run: |
-               julia -e 'using Pkg; Pkg.status()'
-               for file in main/*.dic
-               do      
-                  echo "Checking $file"
-                  julia -O0 ./julia_cif_tools/linter.jl -i $PWD/cif_core $file cif_core/ddl.dic
-                  if [ $? != 0 ] 
-                  then 
-                    exit 1 ;
-                  fi 
-               done
   ddlm:
     runs-on: ubuntu-latest
     needs: syntax

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ in testing. This implies that all dictionaries are in the same directory.
 `ddl2` version can be recovered by running
 
 ```
-julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img.dic
+julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img_expanded.dic
 ```

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The DDLm version was automatically obtained from the DDL2 version by running the
 command:
 
 ```
-julia ddl_to_ddl.jl -c cif_core.dic -i -k _diffrn.id -t "Identifier for data collection." -o cif_img.dic cif_img_1.8.6.dic ddl2
+julia ddl_to_ddl.jl -c multi_block_core.dic -i --short --strict -t CIF_IMG -o cif_img.dic cif_img_1.8.9.1.dic ddl2
 ```
 
 using the `ddl_to_ddl.jl` tool and associated translation dictionaries from the
-`https://github.com/jamesrhester/ddl_to_ddl` repository and the `cif_core.dic`
-found in the COMCIFS `cif_core` repository.
+`https://github.com/jamesrhester/ddl_to_ddl` repository and the `multi_block_core.dic`
+found in the [COMCIFS `MultiBlock_Dictionary` repository](https://github.com/COMCIFS/MultiBlock_Dictionary).
 
 In particular, the translation options above perform the following:
 
@@ -34,12 +34,24 @@ captured by DDLm attributes. For details see the `ddl_to_ddl` tool.
 3. Any common categories defined to be of class `Set` in `cif_core.dic` are
 restated to be `Set` categories in the translated dictionary
 
-4. All categories containing the string `diffrn` in their name have a child
-data name of `_diffrn.id` added to their key data names in keeping with the 
-implicit DDL2 convention.
+4. The dictionary title is changed to `cif_img` to conform to DDLm style.
 
-5. The `cif_core` dictionary is imported by the dictionary to show that these
-definitions build on those found in `cif_core`.
+5. (`--short`): The import of the MultiBlock dictionary will not specify a directory for simplicity
+in testing. This implies that all dictionaries are in the same directory.
 
-Finally, the result is pretty-printed and manual layout adjustments performed
-to meet the style guide requirements.
+6. (`--strict`): Modifications to satisfy DDLm style and strict semantic requirements:
+   (a) All DDL2-specific categories generated at (2) are dropped
+   (b) Data names defined as aliases have any separate definition blocks removed
+   (c) Version numbers enhanced to conform to semantic versioning
+   (d) Version numbers re-ordered to be ascending order
+   (e) Aliases defined in both `cif_img.dic` and the imported dictionary are removed from
+       `cif_img.dic`
+
+## Rederiving the DDL2 version
+
+`cif_img_expanded.dic` is generated as above, but without the `--strict` and `-t` options. The
+`ddl2` version can be recovered by running
+
+```
+julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img.dic
+```

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ in testing. This implies that all dictionaries are in the same directory.
 `ddl2` version can be recovered by running
 
 ```
-julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img_expanded.dic
+julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img_expanded.dic ddlm
 ```

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ restated to be `Set` categories in the translated dictionary
 in testing. This implies that all dictionaries are in the same directory.
 
 6. (`--strict`): Modifications to satisfy DDLm style and strict semantic requirements:
-   (a) All DDL2-specific categories generated at (2) are dropped
-   (b) Data names defined as aliases have any separate definition blocks removed
-   (c) Version numbers enhanced to conform to semantic versioning
-   (d) Version numbers re-ordered to be ascending order
-   (e) Aliases defined in both `cif_img.dic` and the imported dictionary are removed from
+    1. All DDL2-specific categories generated at (2) are dropped
+    2. Data names defined as aliases have any separate definition blocks removed
+    3. Version numbers enhanced to conform to semantic versioning
+    4. Version numbers re-ordered to be ascending order
+    5. Aliases defined in both `cif_img.dic` and the imported dictionary are removed from
        `cif_img.dic`
 
 ## Rederiving the DDL2 version

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -773,9 +773,8 @@ save_CIF_IMG_HEAD
     _name.object_id               CIF_IMG_HEAD
 
     _import.get
-        [{'dupl':Ignore
-          'file':multi_block_core.dic
-          'mode':Full  'save':multiblock_core}]
+        [{'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
+          'save':multiblock_core}]
 
 save_
 
@@ -6716,39 +6715,6 @@ save_diffrn_detector.details
 
 save_
 
-save_diffrn_detector.detector
-
-    _definition.id                '_diffrn_detector.detector'
-
-    loop_
-      _alias.definition_id
-      _alias.deprecation_date
-      _alias.ddl2_version
-      _alias.dictionary_uri
-         '_diffrn_radiation_detector'        .        1.0        cifdic.c91
-         '_diffrn_detector'                  .        2.0        cif_core.dic
-
-    _description.text
-;             The general class of the radiation detector.
-;
-    _name.category_id             diffrn_detector
-    _name.object_id               detector
-    _name.ddl2_mandatory          No
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
-
-    loop_
-      _description_example.case
-         'photographic film'
-         'scintillation counter'
-         'CCD plate'
-         'BF~3~ counter'
-
-save_
-
 save_diffrn_detector.diffrn_id
 
     _definition.id                '_diffrn_detector.diffrn_id'
@@ -6900,27 +6866,6 @@ save_diffrn_detector.number_of_axes
     _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
-
-save_
-
-save_diffrn_detector.type
-
-    _definition.id                '_diffrn_detector.type'
-    _alias.definition_id          '_diffrn_detector_type'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
-    _description.text
-;             The make, model or name of the detector device used.
-;
-    _name.category_id             diffrn_detector
-    _name.object_id               type
-    _name.ddl2_mandatory          No
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
 
 save_
 
@@ -7587,46 +7532,6 @@ save_diffrn_measurement.details
 
 save_
 
-save_diffrn_measurement.device
-
-    _definition.id                '_diffrn_measurement.device'
-    _alias.definition_id          '_diffrn_measurement_device'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
-    _description.text
-;             The general class of goniometer or device used to support
-              and orient the specimen.
-
-              If the value of _diffrn_measurement.device is not given,
-              it is implicitly equal to the value of
-              _diffrn_measurement.diffrn_id.
-
-              Either _diffrn_measurement.device or
-              _diffrn_measurement.id may be used to link to other
-              categories.  If the experimental setup admits multiple
-              devices, then _diffrn_measurement.id is used to provide
-              a unique link.
-;
-    _name.category_id             diffrn_measurement
-    _name.object_id               device
-    _name.ddl2_mandatory          Implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
-
-    loop_
-      _description_example.case
-         '3-circle camera'
-         '4-circle camera'
-         'kappa-geometry camera'
-         'oscillation camera'
-         'precession camera'
-
-save_
-
 save_diffrn_measurement.device_details
 
     _definition.id                '_diffrn_measurement.device_details'
@@ -7650,35 +7555,6 @@ save_diffrn_measurement.device_details
 ;                                 commercial goniometer modified locally to
                                   allow for 90\% \t arc
 ;
-
-save_
-
-save_diffrn_measurement.device_type
-
-    _definition.id                '_diffrn_measurement.device_type'
-    _alias.definition_id          '_diffrn_measurement_device_type'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
-    _description.text
-;             The make, model or name of the measurement device
-              (goniometer) used.
-;
-    _name.category_id             diffrn_measurement
-    _name.object_id               device_type
-    _name.ddl2_mandatory          No
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
-
-    loop_
-      _description_example.case
-         'Supper model q'
-         'Huber model r'
-         'Enraf-Nonius model s'
-         'home-made'
 
 save_
 
@@ -12236,67 +12112,6 @@ save_diffrn_source.diffrn_id
 
 save_
 
-save_diffrn_source.source
-
-    _definition.id                '_diffrn_source.source'
-
-    loop_
-      _alias.definition_id
-      _alias.deprecation_date
-      _alias.ddl2_version
-      _alias.dictionary_uri
-         '_diffrn_radiation_source'         .         1.0         cifdic.c91
-         '_diffrn_source'                   .         2.0         cif_core.dic
-
-    _description.text
-;              The general class of the radiation source.
-;
-    _name.category_id             diffrn_source
-    _name.object_id               source
-    _name.ddl2_mandatory          No
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
-
-    loop_
-      _description_example.case
-         'sealed X-ray tube'
-         'nuclear reactor'
-         'spallation source'
-         'electron microscope'
-         'rotating-anode X-ray tube'
-         'synchrotron'
-
-save_
-
-save_diffrn_source.type
-
-    _definition.id                '_diffrn_source.type'
-    _alias.definition_id          '_diffrn_source_type'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
-    _description.text
-;              The make, model or name of the source of radiation.
-;
-    _name.category_id             diffrn_source
-    _name.object_id               type
-    _name.ddl2_mandatory          No
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               Text
-
-    loop_
-      _description_example.case
-         'NSLS beamline X8C'
-         'Rigaku RU200'
-
-save_
-
 save_MAP
 
     _definition.id                MAP
@@ -13754,6 +13569,10 @@ save_
      (DDLm conversion) Specified Set categories ["diffrn_radiation", "diffrn_measurement", "diffrn_detector", "diffrn", "diffrn_source"]
 
      (DDLm conversion) Removed redundant aliases and definitions for aliased data names ["_diffrn_frame_data.binary_id", "_diffrn_frame_data.id", "_diffrn_scan_frame_monitor.value", "_diffrn_frame_data.details", "_diffrn_measurement_axis.id", "_diffrn_frame_data.array_id", "_diffrn_frame_data.detector_element_id", "_diffrn_detector_axis.id"]
+
+     (DDLm conversion) Removed DDL2-only categories
+
+     (DDLm conversion) Specified Set categories ["diffrn", "diffrn_detector", "diffrn_measurement", "diffrn_radiation", "diffrn_source"]
 
      (DDLm conversion) Removed DDL2-only categories
 

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -774,7 +774,7 @@ save_CIF_IMG_HEAD
 
     _import.get
         [{'dupl':Ignore
-          'file':multi_block_core.dic
+          'file':https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
           'mode':Full  'save':multiblock_core}]
 
 save_
@@ -983,7 +983,7 @@ save_array_data.array_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -1292,7 +1292,7 @@ save_array_data.external_data_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -1342,7 +1342,7 @@ save_array_data.header_convention
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -1367,7 +1367,7 @@ save_array_data.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -1687,7 +1687,7 @@ save_array_data_external_data.frame
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
     _description_example.case     4
@@ -1713,7 +1713,7 @@ save_array_data_external_data.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -1759,7 +1759,7 @@ save_array_data_external_data.uri
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -1783,7 +1783,7 @@ save_array_data_external_data.variant
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -1802,7 +1802,7 @@ save_array_data_external_data.version
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -1873,7 +1873,7 @@ save_array_element_size.array_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -1940,7 +1940,7 @@ save_array_element_size.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -2065,7 +2065,7 @@ save_array_intensities.array_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -2197,7 +2197,7 @@ save_array_intensities.linearity
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
     loop_
@@ -2303,7 +2303,7 @@ save_array_intensities.pixel_binning_method
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
     loop_
@@ -2486,7 +2486,7 @@ save_array_intensities.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -2682,7 +2682,7 @@ save_array_structure.encoding_type
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
     _type.ddl2_code               Uline
 
     loop_
@@ -2717,7 +2717,7 @@ save_array_structure.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -2743,7 +2743,7 @@ save_array_structure.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -2970,7 +2970,7 @@ save_array_structure_list.array_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -2989,7 +2989,7 @@ save_array_structure_list.array_section_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -3018,7 +3018,7 @@ save_array_structure_list.axis_set_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -3055,7 +3055,7 @@ save_array_structure_list.direction
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
     loop_
@@ -3131,7 +3131,7 @@ save_array_structure_list.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -3435,7 +3435,7 @@ save_array_structure_list_axis.axis_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -3464,7 +3464,7 @@ save_array_structure_list_axis.axis_set_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -3661,7 +3661,7 @@ save_array_structure_list_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -3781,7 +3781,7 @@ save_array_structure_list_section.array_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -3834,7 +3834,7 @@ save_array_structure_list_section.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -3952,7 +3952,7 @@ save_array_structure_list_section.variant
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -5785,7 +5785,7 @@ save_axis.depends_on
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -5855,7 +5855,7 @@ save_axis.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6072,7 +6072,7 @@ save_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -6179,7 +6179,7 @@ save_diffrn.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6309,7 +6309,7 @@ save_diffrn_data_frame.array_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          1
 
@@ -6329,7 +6329,7 @@ save_diffrn_data_frame.array_section_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6469,7 +6469,7 @@ save_diffrn_data_frame.center_units
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
     loop_
@@ -6563,7 +6563,7 @@ save_diffrn_data_frame.detector_element_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6582,7 +6582,7 @@ save_diffrn_data_frame.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6604,7 +6604,7 @@ save_diffrn_data_frame.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6629,7 +6629,7 @@ save_diffrn_data_frame.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -6766,7 +6766,7 @@ save_diffrn_detector.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6844,7 +6844,7 @@ save_diffrn_detector.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -6944,7 +6944,7 @@ save_diffrn_detector.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -6999,7 +6999,7 @@ save_diffrn_detector_axis.axis_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7026,7 +7026,7 @@ save_diffrn_detector_axis.detector_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7045,7 +7045,7 @@ save_diffrn_detector_axis.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7070,7 +7070,7 @@ save_diffrn_detector_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -7248,7 +7248,7 @@ save_diffrn_detector_element.detector_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7267,7 +7267,7 @@ save_diffrn_detector_element.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7285,7 +7285,7 @@ save_diffrn_detector_element.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7386,7 +7386,7 @@ save_diffrn_detector_element.reference_center_units
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
     loop_
@@ -7418,7 +7418,7 @@ save_diffrn_detector_element.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -7696,7 +7696,7 @@ save_diffrn_measurement.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7726,7 +7726,7 @@ save_diffrn_measurement.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7895,7 +7895,7 @@ save_diffrn_measurement.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -7956,7 +7956,7 @@ save_diffrn_measurement_axis.axis_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -7971,7 +7971,7 @@ save_diffrn_measurement_axis.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -8016,7 +8016,7 @@ save_diffrn_measurement_axis.measurement_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -8041,7 +8041,7 @@ save_diffrn_measurement_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -8399,7 +8399,7 @@ save_diffrn_radiation.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -9194,7 +9194,7 @@ save_diffrn_radiation.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -9214,7 +9214,7 @@ save_diffrn_radiation.wavelength_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -9303,7 +9303,7 @@ save_diffrn_refln.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -9322,7 +9322,7 @@ save_diffrn_refln.frame_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -9340,7 +9340,7 @@ save_diffrn_refln.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -9365,7 +9365,7 @@ save_diffrn_refln.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -9381,7 +9381,7 @@ save_diffrn_reflns.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -10094,7 +10094,7 @@ save_diffrn_scan.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -10115,7 +10115,7 @@ save_diffrn_scan.frame_id_end
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10137,7 +10137,7 @@ save_diffrn_scan.frame_id_start
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10176,7 +10176,7 @@ save_diffrn_scan.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10280,7 +10280,7 @@ save_diffrn_scan.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -10479,7 +10479,7 @@ save_diffrn_scan_axis.axis_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10497,7 +10497,7 @@ save_diffrn_scan_axis.diffrn_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10694,7 +10694,7 @@ save_diffrn_scan_axis.scan_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10719,7 +10719,7 @@ save_diffrn_scan_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -10809,7 +10809,7 @@ save_diffrn_scan_collection.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10832,7 +10832,7 @@ save_diffrn_scan_collection.scan_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -10902,7 +10902,7 @@ save_diffrn_scan_collection.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -10993,7 +10993,7 @@ save_diffrn_scan_frame.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11015,7 +11015,7 @@ save_diffrn_scan_frame.frame_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11366,7 +11366,7 @@ save_diffrn_scan_frame.scan_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11444,7 +11444,7 @@ save_diffrn_scan_frame.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -11616,7 +11616,7 @@ save_diffrn_scan_frame_axis.axis_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11635,7 +11635,7 @@ save_diffrn_scan_frame_axis.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11736,7 +11736,7 @@ save_diffrn_scan_frame_axis.frame_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -11818,7 +11818,7 @@ save_diffrn_scan_frame_axis.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -12032,7 +12032,7 @@ save_diffrn_scan_frame_monitor.detector_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12051,7 +12051,7 @@ save_diffrn_scan_frame_monitor.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12070,7 +12070,7 @@ save_diffrn_scan_frame_monitor.frame_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12167,7 +12167,7 @@ save_diffrn_scan_frame_monitor.scan_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12192,7 +12192,7 @@ save_diffrn_scan_frame_monitor.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -12232,7 +12232,7 @@ save_diffrn_source.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -12401,7 +12401,7 @@ save_map.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12419,7 +12419,7 @@ save_map.entry_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12437,7 +12437,7 @@ save_map.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12462,7 +12462,7 @@ save_map.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -12538,7 +12538,7 @@ save_map_segment.array_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12557,7 +12557,7 @@ save_map_segment.array_section_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12622,7 +12622,7 @@ save_map_segment.id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12640,7 +12640,7 @@ save_map_segment.map_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12672,7 +12672,7 @@ save_map_segment.mask_array_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12690,7 +12690,7 @@ save_map_segment.mask_array_section_id
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12738,7 +12738,7 @@ save_map_segment.variant
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -12883,7 +12883,7 @@ save_variant.diffrn_id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12901,7 +12901,7 @@ save_variant.entry_id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_
@@ -12925,7 +12925,7 @@ save_variant.role
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
     _type.ddl2_code               Uline
 
     loop_
@@ -12988,7 +12988,7 @@ save_variant.variant
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
     _enumeration.default          .
 
@@ -13012,7 +13012,7 @@ save_variant.variant_of
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _type.ddl2_code               Code
 
 save_

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -774,7 +774,7 @@ save_CIF_IMG_HEAD
 
     _import.get
         [{'dupl':Ignore
-          'file':https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
+          'file':multi_block_core.dic
           'mode':Full  'save':multiblock_core}]
 
 save_

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -5,7 +5,7 @@ data_CIF_IMG
     _dictionary.title             CIF_IMG
     _dictionary.class             Instance
     _dictionary.version           1.8.9
-    _dictionary.date              2025-09-12
+    _dictionary.date              2025-09-15
     _dictionary.ddl_conformance   3.14.0
     _dictionary.namespace         Ddlm
     _description.text
@@ -6149,7 +6149,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-12
+    _definition.update            2025-09-15
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6640,7 +6640,7 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-12
+    _definition.update            2025-09-15
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -7478,7 +7478,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-12
+    _definition.update            2025-09-15
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -8052,7 +8052,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-12
+    _definition.update            2025-09-15
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -12203,7 +12203,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-12
+    _definition.update            2025-09-15
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -13739,7 +13739,7 @@ save_
 ;
        Pick up minor type corrections from 1.8.9 dcitionary
 ;
-         1.8.9                    2025-09-12
+         1.8.9                    2025-09-15
 ;   Addition of missing diffrn.id pointers
 
     + Add _diffrn_detector_element.diffrn_id

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -1,13 +1,13 @@
 #\#CIF_2.0
 
-data_CIF_IMG.DIC
+data_CIF_IMG
 
-    _dictionary.title             cif_img.dic
+    _dictionary.title             CIF_IMG
     _dictionary.class             Instance
     _dictionary.version           1.8.9
     _dictionary.date              2025-06-10
     _dictionary.ddl_conformance   3.14.0
-    _dictionary.namespace         ddlm
+    _dictionary.namespace         Ddlm
     _description.text
 ;##############################################################################
 #                                                                            #
@@ -759,9 +759,9 @@ data_CIF_IMG.DIC
 +--------------------------------------------------------------------------------------------------------------------+
 ;
 
-save_HEAD
+save_CIF_IMG_HEAD
 
-    _definition.id                HEAD
+    _definition.id                CIF_IMG_HEAD
     _definition.scope             Category
     _definition.class             Head
     _description.text
@@ -769,8 +769,8 @@ save_HEAD
     The HEAD category is the parent category of all definitions in the
     dictionary
 ;
-    _name.category_id             HEAD
-    _name.object_id               HEAD
+    _name.category_id             CIF_IMG
+    _name.object_id               CIF_IMG_HEAD
 
     _import.get
         [{'dupl':Ignore
@@ -804,9 +804,9 @@ save_ARRAY_DATA
      For full processing and archiving, most of the tags in this
      dictionary will need to be populated.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_DATA
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -979,12 +979,12 @@ save_array_data.array_id
     _name.category_id             array_data
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          1
 
 save_
@@ -1010,14 +1010,15 @@ save_array_data.binary_id
 ;
     _name.category_id             array_data
     _name.object_id               binary_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _enumeration.default          1
+    _units.code                   none
 
 save_
 
@@ -1260,12 +1261,12 @@ save_array_data.data
 ;
     _name.category_id             array_data
     _name.object_id               data
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Array
     _type.contents                Complex
-    _type.ddl2_code               binary
+    _type.ddl2_code               Binary
     _units.code                   none
 
 save_
@@ -1286,12 +1287,12 @@ save_array_data.external_data_id
     _name.category_id             array_data
     _name.object_id               external_data_id
     _name.linked_item_id          '_array_data_external_data.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          1
 
 save_
@@ -1311,12 +1312,12 @@ save_array_data.header_contents
 ;
     _name.category_id             array_data
     _name.object_id               header_contents
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -1336,12 +1337,12 @@ save_array_data.header_convention
 ;
     _name.category_id             array_data
     _name.object_id               header_convention
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -1361,12 +1362,12 @@ save_array_data.variant
     _name.category_id             array_data
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -1382,9 +1383,9 @@ save_ARRAY_DATA_EXTERNAL_DATA
      record the location and essential characteristics of arrays of data for
     use in  ARRAY_DATA that are found external to the cif_img file.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_DATA_EXTERNAL_DATA
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _category_key.name            '_array_data_external_data.id'
     _nx_mapping.details
 ;    _array_data.array_id ARRAYID
@@ -1461,7 +1462,7 @@ save_array_data_external_data.archive_path
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -1475,7 +1476,7 @@ save_array_data_external_data.file_compression
 ;
     _name.category_id             array_data_external_data
     _name.object_id               file_compression
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _enumeration_set.state
@@ -1519,7 +1520,7 @@ save_array_data_external_data.format
 ;
     _name.category_id             array_data_external_data
     _name.object_id               format
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _enumeration_set.state
@@ -1686,7 +1687,7 @@ save_array_data_external_data.frame
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          1
     _description_example.case     4
     _description_example.detail
@@ -1707,12 +1708,12 @@ save_array_data_external_data.id
 ;
     _name.category_id             array_data_external_data
     _name.object_id               id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          1
 
 save_
@@ -1741,7 +1742,7 @@ save_array_data_external_data.path
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -1758,7 +1759,7 @@ save_array_data_external_data.uri
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -1777,12 +1778,12 @@ save_array_data_external_data.variant
 ;
     _name.category_id             array_data_external_data
     _name.object_id               variant
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -1801,7 +1802,7 @@ save_array_data_external_data.version
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -1815,9 +1816,9 @@ save_ARRAY_ELEMENT_SIZE
     Data items in the ARRAY_ELEMENT_SIZE category record the physical
      size of array elements along each array dimension.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_ELEMENT_SIZE
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -1867,12 +1868,12 @@ save_array_element_size.array_id
 ;
     _name.category_id             array_element_size
     _name.object_id               array_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -1886,12 +1887,13 @@ save_array_element_size.index
     _name.category_id             array_element_size
     _name.object_id               index
     _name.linked_item_id          '_array_structure_list.index'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
+    _units.code                   none
 
 save_
 
@@ -1905,13 +1907,13 @@ save_array_element_size.size
 ;
     _name.category_id             array_element_size
     _name.object_id               size
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              metres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Metres
     _units.code                   metres
 
 save_
@@ -1932,12 +1934,12 @@ save_array_element_size.variant
     _name.category_id             array_element_size
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -1963,9 +1965,9 @@ save_ARRAY_INTENSITIES
      value of _array_intensities.linearity will be 'raw'
      and _array_intensities.gain will not be used.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_INTENSITIES
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -2057,12 +2059,12 @@ save_array_intensities.array_id
     _name.category_id             array_intensities
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -2076,12 +2078,13 @@ save_array_intensities.binary_id
     _name.category_id             array_intensities
     _name.object_id               binary_id
     _name.linked_item_id          '_array_data.binary_id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
+    _units.code                   none
 
 save_
 
@@ -2094,12 +2097,12 @@ save_array_intensities.details
 ;
     _name.category_id             array_intensities
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case     'Gain_setting: low gain (vrf = -0.300)'
 
 save_
@@ -2114,13 +2117,13 @@ save_array_intensities.gain
 ;
     _name.category_id             array_intensities
     _name.object_id               gain
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Measurand
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              counts_per_photon
+    _type.ddl2_code               Float
+    _type.ddl2_units              Counts_per_photon
     _units.code                   counts_per_photon
 
 save_
@@ -2135,13 +2138,13 @@ save_array_intensities.gain_esd
     _name.category_id             array_intensities
     _name.object_id               gain_esd
     _name.linked_item_id          '_array_intensities.gain'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 SU
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              counts_per_photon
+    _type.ddl2_code               Float
+    _type.ddl2_units              Counts_per_photon
     _units.code                   counts_per_photon
 
 save_
@@ -2185,12 +2188,12 @@ save_array_intensities.linearity
 ;
     _name.category_id             array_intensities
     _name.object_id               linearity
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
     loop_
       _enumeration_set.state
@@ -2248,12 +2251,12 @@ save_array_intensities.offset
 ;
     _name.category_id             array_intensities
     _name.object_id               offset
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -2271,13 +2274,13 @@ save_array_intensities.overload
 ;
     _name.category_id             array_intensities
     _name.object_id               overload
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              counts
+    _type.ddl2_code               Float
+    _type.ddl2_units              Counts
     _units.code                   counts
 
 save_
@@ -2291,12 +2294,12 @@ save_array_intensities.pixel_binning_method
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_binning_method
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
     loop_
       _enumeration_set.state
@@ -2351,13 +2354,13 @@ save_array_intensities.pixel_fast_bin_size
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_fast_bin_size
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              pixels_per_element
+    _type.ddl2_code               Float
+    _type.ddl2_units              Pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
 
@@ -2382,13 +2385,13 @@ save_array_intensities.pixel_slow_bin_size
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_slow_bin_size
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              pixels_per_element
+    _type.ddl2_code               Float
+    _type.ddl2_units              Pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
 
@@ -2404,12 +2407,12 @@ save_array_intensities.scaling
 ;
     _name.category_id             array_intensities
     _name.object_id               scaling
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -2423,12 +2426,12 @@ save_array_intensities.undefined_value
 ;
     _name.category_id             array_intensities
     _name.object_id               undefined_value
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -2447,13 +2450,13 @@ save_array_intensities.underload
 ;
     _name.category_id             array_intensities
     _name.object_id               underload
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              counts
+    _type.ddl2_code               Float
+    _type.ddl2_units              Counts
     _units.code                   counts
 
 save_
@@ -2474,12 +2477,12 @@ save_array_intensities.variant
     _name.category_id             array_intensities
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -2494,9 +2497,9 @@ save_ARRAY_STRUCTURE
     Data items in the ARRAY_STRUCTURE category record the organization and
      encoding of array data that may be stored in the ARRAY_DATA category.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_STRUCTURE
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -2544,12 +2547,12 @@ save_array_structure.byte_order
 ;
     _name.category_id             array_structure
     _name.object_id               byte_order
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -2574,12 +2577,12 @@ save_array_structure.compression_type
 ;
     _name.category_id             array_structure
     _name.object_id               compression_type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -2624,12 +2627,12 @@ save_array_structure.compression_type_flag
 ;
     _name.category_id             array_structure
     _name.object_id               compression_type_flag
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -2670,12 +2673,12 @@ save_array_structure.encoding_type
 ;
     _name.category_id             array_structure
     _name.object_id               encoding_type
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               uline
+    _type.ddl2_code               Uline
 
     loop_
       _enumeration_set.state
@@ -2705,12 +2708,12 @@ save_array_structure.id
 ;
     _name.category_id             array_structure
     _name.object_id               id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          1
 
 save_
@@ -2731,12 +2734,12 @@ save_array_structure.variant
     _name.category_id             array_structure
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -2752,9 +2755,9 @@ save_ARRAY_STRUCTURE_LIST
 
      The relationship to physical axes may be given.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_STRUCTURE_LIST
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -2958,12 +2961,12 @@ save_array_structure_list.array_id
     _name.category_id             array_structure_list
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -2976,12 +2979,12 @@ save_array_structure_list.array_section_id
 ;
     _name.category_id             array_structure_list
     _name.object_id               array_section_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3005,12 +3008,12 @@ save_array_structure_list.axis_set_id
 ;
     _name.category_id             array_structure_list
     _name.object_id               axis_set_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3023,12 +3026,12 @@ save_array_structure_list.dimension
 ;
     _name.category_id             array_structure_list
     _name.object_id               dimension
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -3042,12 +3045,12 @@ save_array_structure_list.direction
 ;
     _name.category_id             array_structure_list
     _name.object_id               direction
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
     loop_
       _enumeration_set.state
@@ -3070,13 +3073,14 @@ save_array_structure_list.index
 ;
     _name.category_id             array_structure_list
     _name.object_id               index
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -3090,12 +3094,12 @@ save_array_structure_list.precedence
 ;
     _name.category_id             array_structure_list
     _name.object_id               precedence
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -3117,12 +3121,12 @@ save_array_structure_list.variant
     _name.category_id             array_structure_list
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -3151,9 +3155,9 @@ save_ARRAY_STRUCTURE_LIST_AXIS
      Axes may be specified either for an entire array or for just a section
      of an array.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_STRUCTURE_LIST_AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -3337,13 +3341,13 @@ save_array_structure_list_axis.angle
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angle
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -3363,13 +3367,13 @@ save_array_structure_list_axis.angle_increment
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angle_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -3392,13 +3396,13 @@ save_array_structure_list_axis.angular_pitch
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angular_pitch
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -3421,12 +3425,12 @@ save_array_structure_list_axis.axis_id
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3450,12 +3454,12 @@ save_array_structure_list_axis.axis_set_id
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_set_id
     _name.linked_item_id          '_array_structure_list.axis_set_id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3473,13 +3477,13 @@ save_array_structure_list_axis.displacement
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               displacement
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -3495,13 +3499,13 @@ save_array_structure_list_axis.displacement_increment
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               displacement_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -3524,12 +3528,12 @@ save_array_structure_list_axis.fract_displacement
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               fract_displacement
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.default          0.0
     _units.code                   none
 
@@ -3546,13 +3550,13 @@ save_array_structure_list_axis.fract_displacement_increment
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               fract_displacement_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -3570,13 +3574,13 @@ save_array_structure_list_axis.radial_pitch
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               radial_pitch
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -3595,13 +3599,13 @@ save_array_structure_list_axis.reference_angle
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               reference_angle
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _units.code                   degrees
 
 save_
@@ -3620,13 +3624,13 @@ save_array_structure_list_axis.reference_displacement
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               reference_displacement
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _units.code                   millimetres
 
 save_
@@ -3647,12 +3651,12 @@ save_array_structure_list_axis.variant
     _name.category_id             array_structure_list_axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -3685,9 +3689,9 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     _array_structure_list_section.array_id and not by the ordering implied
     by the stride.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               ARRAY_STRUCTURE_LIST_SECTION
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -3767,12 +3771,12 @@ save_array_structure_list_section.array_id
     _name.category_id             array_structure_list_section
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3795,12 +3799,12 @@ save_array_structure_list_section.end
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               end
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -3819,12 +3823,12 @@ save_array_structure_list_section.id
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -3846,12 +3850,13 @@ save_array_structure_list_section.index
     _name.category_id             array_structure_list_section
     _name.object_id               index
     _name.linked_item_id          '_array_structure_list.index'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
+    _units.code                   none
 
 save_
 
@@ -3884,12 +3889,12 @@ save_array_structure_list_section.start
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               start
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -3907,12 +3912,12 @@ save_array_structure_list_section.stride
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               stride
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _enumeration.default          1
     _units.code                   none
@@ -3935,12 +3940,12 @@ save_array_structure_list_section.variant
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               variant
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -4287,9 +4292,9 @@ save_AXIS
      Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
      Brookhaven National Laboratory.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -5768,7 +5773,7 @@ save_axis.depends_on
     _name.category_id             axis
     _name.object_id               depends_on
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
 save_
 
@@ -5782,12 +5787,12 @@ save_axis.equipment
 ;
     _name.category_id             axis
     _name.object_id               equipment
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -5813,12 +5818,12 @@ save_axis.equipment_component
 ;
     _name.category_id             axis
     _name.object_id               equipment_component
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
 save_
 
@@ -5834,12 +5839,12 @@ save_axis.id
 ;
     _name.category_id             axis
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -5854,13 +5859,13 @@ save_axis.offset[1]
 ;
     _name.category_id             axis
     _name.object_id               'offset[1]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -5877,13 +5882,13 @@ save_axis.offset[2]
 ;
     _name.category_id             axis
     _name.object_id               'offset[2]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -5900,13 +5905,13 @@ save_axis.offset[3]
 ;
     _name.category_id             axis
     _name.object_id               'offset[3]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -5923,13 +5928,13 @@ save_axis.rotation
 ;
     _name.category_id             axis
     _name.object_id               rotation
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -5947,12 +5952,12 @@ save_axis.rotation_axis
 ;
     _name.category_id             axis
     _name.object_id               rotation_axis
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
 save_
 
@@ -5966,12 +5971,12 @@ save_axis.system
 ;
     _name.category_id             axis
     _name.object_id               system
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -6017,12 +6022,12 @@ save_axis.type
 ;
     _name.category_id             axis
     _name.object_id               type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
 
     loop_
       _enumeration_set.state
@@ -6051,12 +6056,12 @@ save_axis.variant
     _name.category_id             axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -6072,12 +6077,12 @@ save_axis.vector[1]
 ;
     _name.category_id             axis
     _name.object_id               'vector[1]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.default          0.0
     _units.code                   none
 
@@ -6094,12 +6099,12 @@ save_axis.vector[2]
 ;
     _name.category_id             axis
     _name.object_id               'vector[2]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.default          0.0
     _units.code                   none
 
@@ -6116,12 +6121,12 @@ save_axis.vector[3]
 ;
     _name.category_id             axis
     _name.object_id               'vector[3]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.default          0.0
     _units.code                   none
 
@@ -6132,7 +6137,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-05
+    _definition.update            2025-09-10
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6142,9 +6147,9 @@ save_DIFFRN
                in the various diffrn_... categories in the mmCIF/PDBx
                dictionary
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _category_key.name            '_diffrn.id'
 
 save_
@@ -6162,12 +6167,12 @@ save_diffrn.id
 ;
     _name.category_id             diffrn
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6185,9 +6190,9 @@ save_DIFFRN_DATA_FRAME
               The items from the old category are provided
               as aliases but should not be used for new work.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_DATA_FRAME
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -6292,12 +6297,12 @@ save_diffrn_data_frame.array_id
     _name.category_id             diffrn_data_frame
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6311,12 +6316,12 @@ save_diffrn_data_frame.array_section_id
     _name.category_id             diffrn_data_frame
     _name.object_id               array_section_id
     _name.linked_item_id          '_array_structure_list_section.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6334,12 +6339,13 @@ save_diffrn_data_frame.binary_id
     _name.category_id             diffrn_data_frame
     _name.object_id               binary_id
     _name.linked_item_id          '_array_data.binary_id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
+    _units.code                   none
 
 save_
 
@@ -6355,12 +6361,12 @@ save_diffrn_data_frame.center_derived
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_derived
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
     _enumeration.default          yes
 
 save_
@@ -6386,12 +6392,12 @@ save_diffrn_data_frame.center_fast
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_fast
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -6415,12 +6421,12 @@ save_diffrn_data_frame.center_slow
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_slow
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -6448,12 +6454,12 @@ save_diffrn_data_frame.center_units
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_units
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
     loop_
       _enumeration_set.state
@@ -6489,12 +6495,12 @@ save_diffrn_data_frame.details
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case
 ;
     HEADER_BYTES = 512;
@@ -6542,12 +6548,12 @@ save_diffrn_data_frame.detector_element_id
     _name.category_id             diffrn_data_frame
     _name.object_id               detector_element_id
     _name.linked_item_id          '_diffrn_detector_element.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6561,12 +6567,12 @@ save_diffrn_data_frame.diffrn_id
     _name.category_id             diffrn_data_frame
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6583,12 +6589,12 @@ save_diffrn_data_frame.id
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6608,12 +6614,12 @@ save_diffrn_data_frame.variant
     _name.category_id             diffrn_data_frame
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -6623,16 +6629,16 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-05
+    _definition.update            2025-09-10
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
      detector used to measure the scattered radiation, including
      any analyser and post-sample collimation.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_DETECTOR
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -6689,12 +6695,12 @@ save_diffrn_detector.details
 ;
     _name.category_id             diffrn_detector
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case     'slow mode'
 
 save_
@@ -6716,12 +6722,12 @@ save_diffrn_detector.detector
 ;
     _name.category_id             diffrn_detector
     _name.object_id               detector
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -6745,12 +6751,12 @@ save_diffrn_detector.diffrn_id
     _name.category_id             diffrn_detector
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6772,13 +6778,13 @@ save_diffrn_detector.dtime
 ;
     _name.category_id             diffrn_detector
     _name.object_id               dtime
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              microseconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Microseconds
     _enumeration.range            0.0:
     _units.code                   microseconds
 
@@ -6801,12 +6807,12 @@ save_diffrn_detector.gain_setting
 ;
     _name.category_id             diffrn_detector
     _name.object_id               gain_setting
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -6823,12 +6829,12 @@ save_diffrn_detector.id
 ;
     _name.category_id             diffrn_detector
     _name.object_id               id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -6841,13 +6847,13 @@ save_diffrn_detector.layer_thickness
 ;
     _name.category_id             diffrn_detector
     _name.object_id               layer_thickness
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.range            0.0:
     _units.code                   millimetres
 
@@ -6875,12 +6881,12 @@ save_diffrn_detector.number_of_axes
 ;
     _name.category_id             diffrn_detector
     _name.object_id               number_of_axes
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -6898,12 +6904,12 @@ save_diffrn_detector.type
 ;
     _name.category_id             diffrn_detector
     _name.object_id               type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -6923,12 +6929,12 @@ save_diffrn_detector.variant
     _name.category_id             diffrn_detector
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -6943,9 +6949,9 @@ save_DIFFRN_DETECTOR_AXIS
     Data items in the DIFFRN_DETECTOR_AXIS category associate
      axes with detectors.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_DETECTOR_AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -6978,12 +6984,12 @@ save_diffrn_detector_axis.axis_id
     _name.category_id             diffrn_detector_axis
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7005,12 +7011,12 @@ save_diffrn_detector_axis.detector_id
     _name.category_id             diffrn_detector_axis
     _name.object_id               detector_id
     _name.linked_item_id          '_diffrn_detector.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7024,12 +7030,12 @@ save_diffrn_detector_axis.diffrn_id
     _name.category_id             diffrn_detector_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7049,12 +7055,12 @@ save_diffrn_detector_axis.variant
     _name.category_id             diffrn_detector_axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -7075,9 +7081,9 @@ save_DIFFRN_DETECTOR_ELEMENT
      is preferable to simply providing the centre of the
      detector element.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_DETECTOR_ELEMENT
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -7169,13 +7175,13 @@ save_diffrn_detector_element.center[1]
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               'center[1]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -7206,13 +7212,13 @@ save_diffrn_detector_element.center[2]
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               'center[2]'
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -7227,12 +7233,12 @@ save_diffrn_detector_element.detector_id
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               detector_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7246,12 +7252,12 @@ save_diffrn_detector_element.diffrn_id
     _name.category_id             diffrn_detector_element
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7264,12 +7270,12 @@ save_diffrn_detector_element.id
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7298,12 +7304,12 @@ save_diffrn_detector_element.reference_center_fast
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_fast
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -7331,12 +7337,12 @@ save_diffrn_detector_element.reference_center_slow
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_slow
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -7365,12 +7371,12 @@ save_diffrn_detector_element.reference_center_units
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_units
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
     loop_
       _enumeration_set.state
@@ -7397,12 +7403,12 @@ save_diffrn_detector_element.variant
     _name.category_id             diffrn_detector_element
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -7436,9 +7442,9 @@ save_DIFFRN_FRAME_DATA
 
      All _item.mandatory_code values have been changed to 'no'.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_FRAME_DATA
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -7461,7 +7467,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-05
+    _definition.update            2025-09-10
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -7469,9 +7475,9 @@ save_DIFFRN_MEASUREMENT
      during data measurement and the manner in which the
      diffraction data were measured.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_MEASUREMENT
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -7557,12 +7563,12 @@ save_diffrn_measurement.details
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case
 ;                                 440 frames, 0.20 degrees, 150 sec, detector
                                   distance 12 cm, detector angle 22.5 degrees
@@ -7593,12 +7599,12 @@ save_diffrn_measurement.device
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -7623,12 +7629,12 @@ save_diffrn_measurement.device_details
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device_details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case
 ;                                 commercial goniometer modified locally to
                                   allow for 90\% \t arc
@@ -7649,12 +7655,12 @@ save_diffrn_measurement.device_type
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device_type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -7675,12 +7681,12 @@ save_diffrn_measurement.diffrn_id
     _name.category_id             diffrn_measurement
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7705,12 +7711,12 @@ save_diffrn_measurement.id
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7726,12 +7732,12 @@ save_diffrn_measurement.method
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               method
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case
         'profile data from theta/2theta (\q/2\q) scans'
 
@@ -7751,12 +7757,12 @@ save_diffrn_measurement.number_of_axes
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               number_of_axes
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -7773,13 +7779,13 @@ save_diffrn_measurement.sample_detector_distance
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_distance
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _units.code                   millimetres
 
 save_
@@ -7796,12 +7802,12 @@ save_diffrn_measurement.sample_detector_distance_derived
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_distance_derived
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               ucode
+    _type.ddl2_code               Ucode
     _enumeration.default          yes
 
 save_
@@ -7817,13 +7823,13 @@ save_diffrn_measurement.sample_detector_voffset
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_voffset
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.range            :
     _units.code                   millimetres
 
@@ -7842,12 +7848,12 @@ save_diffrn_measurement.specimen_support
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               specimen_support
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -7874,12 +7880,12 @@ save_diffrn_measurement.variant
     _name.category_id             diffrn_measurement
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -7894,9 +7900,9 @@ save_DIFFRN_MEASUREMENT_AXIS
     Data items in the DIFFRN_MEASUREMENT_AXIS category associate
      axes with goniometers.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_MEASUREMENT_AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -7935,12 +7941,12 @@ save_diffrn_measurement_axis.axis_id
     _name.category_id             diffrn_measurement_axis
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -7950,7 +7956,7 @@ save_diffrn_measurement_axis.diffrn_id
     _name.category_id             diffrn_measurement_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
 
 save_
 
@@ -7964,12 +7970,12 @@ save_diffrn_measurement_axis.measurement_device
     _name.category_id             diffrn_measurement_axis
     _name.object_id               measurement_device
     _name.linked_item_id          '_diffrn_measurement.device'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -7991,12 +7997,12 @@ save_diffrn_measurement_axis.measurement_id
     _name.category_id             diffrn_measurement_axis
     _name.object_id               measurement_id
     _name.linked_item_id          '_diffrn_measurement.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -8016,12 +8022,12 @@ save_diffrn_measurement_axis.variant
     _name.category_id             diffrn_measurement_axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -8031,7 +8037,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-05
+    _definition.update            2025-09-10
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -8040,9 +8046,9 @@ save_DIFFRN_RADIATION
               Post-sample treatment of the beam is described by data
               items in the DIFFRN_DETECTOR category.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_RADIATION
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -8176,13 +8182,13 @@ save_diffrn_radiation.beam_flux
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons_per_second'
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons_per_second'
     _units.code                   photons_per_second'
 
 save_
@@ -8195,13 +8201,13 @@ save_diffrn_radiation.beam_flux_density
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_density
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons_per_second_per_micrometre_squared
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons_per_second_per_micrometre_squared
     _units.code                   photons_per_second_per_micrometre_squared
 
 save_
@@ -8217,13 +8223,13 @@ save_diffrn_radiation.beam_flux_density_integrated
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_density_integrated
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons_per_micrometre_squared
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons_per_micrometre_squared
     _units.code                   photons_per_micrometre_squared
 
 save_
@@ -8240,13 +8246,13 @@ save_diffrn_radiation.beam_flux_integrated
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_integrated
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons
     _units.code                   photons
 
 save_
@@ -8260,13 +8266,13 @@ save_diffrn_radiation.beam_flux_integration_time
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_integration_time
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -8282,13 +8288,13 @@ save_diffrn_radiation.beam_incident_flux
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_incident_flux
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons_per_second
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons_per_second
     _units.code                   photons_per_second
 
 save_
@@ -8306,13 +8312,13 @@ save_diffrn_radiation.beam_incident_flux_integrated
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_incident_flux_integrated
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              photons
+    _type.ddl2_code               Float
+    _type.ddl2_units              Photons
     _units.code                   photons
 
 save_
@@ -8326,13 +8332,13 @@ save_diffrn_radiation.beam_width
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_width
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              micrometres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Micrometres
     _units.code                   micrometres
 
 save_
@@ -8349,12 +8355,12 @@ save_diffrn_radiation.collimation
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               collimation
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -8374,12 +8380,12 @@ save_diffrn_radiation.diffrn_id
     _name.category_id             diffrn_radiation
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -8405,13 +8411,13 @@ save_diffrn_radiation.div_x_source
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_x_source
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _units.code                   degrees
 
 save_
@@ -8441,13 +8447,13 @@ save_diffrn_radiation.div_x_y_source
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_x_y_source
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees_squared
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees_squared
     _enumeration.default          0.0
     _units.code                   degrees_squared
 
@@ -8475,13 +8481,13 @@ save_diffrn_radiation.div_y_source
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_y_source
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -8499,13 +8505,13 @@ save_diffrn_radiation.filter_edge
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               filter_edge
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              angstroms
+    _type.ddl2_code               Float
+    _type.ddl2_units              Angstroms
     _enumeration.range            0.0:
     _units.code                   angstroms
 
@@ -8524,13 +8530,13 @@ save_diffrn_radiation.inhomogeneity
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               inhomogeneity
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.range            0.0:
     _units.code                   millimetres
 
@@ -8550,12 +8556,12 @@ save_diffrn_radiation.monochromator
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               monochromator
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -8580,13 +8586,13 @@ save_diffrn_radiation.polarisn_norm
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_norm
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.range            -90.0:90.0
     _units.code                   degrees
 
@@ -8604,13 +8610,13 @@ save_diffrn_radiation.polarisn_norm_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_norm_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.range            0.0:
     _units.code                   degrees
 
@@ -8634,12 +8640,12 @@ save_diffrn_radiation.polarisn_ratio
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_ratio
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -8656,12 +8662,12 @@ save_diffrn_radiation.polarisn_ratio_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_ratio_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -8694,13 +8700,13 @@ save_diffrn_radiation.polarizn_source_norm
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_norm
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.range            -90.0:90.0
     _enumeration.default          0.0
     _units.code                   degrees
@@ -8719,13 +8725,13 @@ save_diffrn_radiation.polarizn_source_norm_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_norm_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.range            0.0:
     _units.code                   degrees
 
@@ -8775,12 +8781,12 @@ save_diffrn_radiation.polarizn_source_ratio
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_ratio
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            -1.0:1.0
     _units.code                   none
 
@@ -8800,12 +8806,12 @@ save_diffrn_radiation.polarizn_source_ratio_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_ratio_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -8844,12 +8850,12 @@ save_diffrn_radiation.polarizn_stokes_i
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_I
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _enumeration.default          1.0
     _units.code                   none
@@ -8871,12 +8877,12 @@ save_diffrn_radiation.polarizn_stokes_i_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_I_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -8914,12 +8920,12 @@ save_diffrn_radiation.polarizn_stokes_q
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_Q
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -8941,12 +8947,12 @@ save_diffrn_radiation.polarizn_stokes_q_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_Q_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -8984,12 +8990,12 @@ save_diffrn_radiation.polarizn_stokes_u
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_U
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -9011,12 +9017,12 @@ save_diffrn_radiation.polarizn_stokes_u_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_U_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -9055,12 +9061,12 @@ save_diffrn_radiation.polarizn_stokes_v
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_V
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -9083,12 +9089,12 @@ save_diffrn_radiation.polarizn_stokes_v_esd
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_V_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -9108,12 +9114,12 @@ save_diffrn_radiation.probe
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               probe
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               line
+    _type.ddl2_code               Line
 
     loop_
       _enumeration_set.state
@@ -9137,12 +9143,12 @@ save_diffrn_radiation.type
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               line
+    _type.ddl2_code               Line
 
     loop_
       _description_example.case
@@ -9169,12 +9175,12 @@ save_diffrn_radiation.variant
     _name.category_id             diffrn_radiation
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -9189,12 +9195,12 @@ save_diffrn_radiation.wavelength_id
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               wavelength_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -9211,12 +9217,12 @@ save_diffrn_radiation.xray_symbol
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               xray_symbol
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               line
+    _type.ddl2_code               Line
 
     loop_
       _enumeration_set.state
@@ -9250,9 +9256,9 @@ save_DIFFRN_REFLN
      data set identified by _diffrn_reflns.diffrn_id and
      _diffrn_refln.frame_id
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_REFLN
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -9278,12 +9284,12 @@ save_diffrn_refln.diffrn_id
     _name.category_id             diffrn_refln
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -9297,12 +9303,12 @@ save_diffrn_refln.frame_id
     _name.category_id             diffrn_refln
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -9315,12 +9321,12 @@ save_diffrn_refln.id
 ;
     _name.category_id             diffrn_refln
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -9340,12 +9346,12 @@ save_diffrn_refln.variant
     _name.category_id             diffrn_refln
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -9356,7 +9362,7 @@ save_diffrn_reflns.diffrn_id
     _name.category_id             diffrn_reflns
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
 
 save_
 
@@ -9370,9 +9376,9 @@ save_DIFFRN_SCAN
     Data items in the DIFFRN_SCAN category describe the parameters of one
      or more scans, relating axis positions to frames.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -10014,12 +10020,12 @@ save_diffrn_scan.date_end
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_end
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               yyyy-mm-dd
+    _type.ddl2_code               Yyyy-mm-dd
 
 save_
 
@@ -10033,12 +10039,12 @@ save_diffrn_scan.date_end_estimated
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_end_estimated
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               yyyy-mm-dd
+    _type.ddl2_code               Yyyy-mm-dd
 
 save_
 
@@ -10050,12 +10056,12 @@ save_diffrn_scan.date_start
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_start
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               yyyy-mm-dd
+    _type.ddl2_code               Yyyy-mm-dd
 
 save_
 
@@ -10065,7 +10071,7 @@ save_diffrn_scan.diffrn_id
     _name.category_id             diffrn_scan
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
 
 save_
 
@@ -10082,12 +10088,12 @@ save_diffrn_scan.frame_id_end
     _name.category_id             diffrn_scan
     _name.object_id               frame_id_end
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10104,12 +10110,12 @@ save_diffrn_scan.frame_id_start
     _name.category_id             diffrn_scan
     _name.object_id               frame_id_start
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10122,12 +10128,12 @@ save_diffrn_scan.frames
 ;
     _name.category_id             diffrn_scan
     _name.object_id               frames
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _units.code                   none
 
@@ -10143,12 +10149,12 @@ save_diffrn_scan.id
 ;
     _name.category_id             diffrn_scan
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10164,13 +10170,13 @@ save_diffrn_scan.integration_time
 ;
     _name.category_id             diffrn_scan
     _name.object_id               integration_time
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -10186,13 +10192,13 @@ save_diffrn_scan.time_period
 ;
     _name.category_id             diffrn_scan
     _name.object_id               time_period
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -10220,13 +10226,13 @@ save_diffrn_scan.time_rstrt_incr
 ;
     _name.category_id             diffrn_scan
     _name.object_id               time_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -10247,12 +10253,12 @@ save_diffrn_scan.variant
     _name.category_id             diffrn_scan
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -10268,9 +10274,9 @@ save_DIFFRN_SCAN_AXIS
      axes for particular scans.  Unspecified axes are assumed to be at
      their zero points.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN_AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -10342,13 +10348,13 @@ save_diffrn_scan_axis.angle_increment
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -10363,13 +10369,13 @@ save_diffrn_scan_axis.angle_range
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_range
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -10398,13 +10404,13 @@ save_diffrn_scan_axis.angle_rstrt_incr
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -10418,13 +10424,13 @@ save_diffrn_scan_axis.angle_start
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_start
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -10446,12 +10452,12 @@ save_diffrn_scan_axis.axis_id
     _name.category_id             diffrn_scan_axis
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10464,12 +10470,12 @@ save_diffrn_scan_axis.diffrn_id
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               diffrn_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10493,13 +10499,13 @@ save_diffrn_scan_axis.displacement_increment
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -10514,13 +10520,13 @@ save_diffrn_scan_axis.displacement_range
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_range
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -10549,13 +10555,13 @@ save_diffrn_scan_axis.displacement_rstrt_incr
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -10569,13 +10575,13 @@ save_diffrn_scan_axis.displacement_start
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_start
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -10602,13 +10608,13 @@ save_diffrn_scan_axis.reference_angle
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               reference_angle
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -10634,13 +10640,13 @@ save_diffrn_scan_axis.reference_displacement
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               reference_displacement
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _units.code                   millimetres
 
 save_
@@ -10661,12 +10667,12 @@ save_diffrn_scan_axis.scan_id
     _name.category_id             diffrn_scan_axis
     _name.object_id               scan_id
     _name.linked_item_id          '_diffrn_scan.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10686,12 +10692,12 @@ save_diffrn_scan_axis.variant
     _name.category_id             diffrn_scan_axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -10709,9 +10715,9 @@ save_DIFFRN_SCAN_COLLECTION
      This category is a preliminary version being developed as
      synchrotron and XFEL collection strategies evolve.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN_COLLECTION
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -10757,12 +10763,12 @@ save_diffrn_scan_collection.details
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
 save_
 
@@ -10776,12 +10782,12 @@ save_diffrn_scan_collection.diffrn_id
     _name.category_id             diffrn_scan_collection
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10799,12 +10805,12 @@ save_diffrn_scan_collection.scan_id
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               scan_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10819,13 +10825,13 @@ save_diffrn_scan_collection.translation_width
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               translation_width
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              micrometres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Micrometres
     _enumeration.default          0.0
     _units.code                   micrometres
 
@@ -10843,12 +10849,12 @@ save_diffrn_scan_collection.type
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               type
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _enumeration.default          rotation
 
 save_
@@ -10869,12 +10875,12 @@ save_diffrn_scan_collection.variant
     _name.category_id             diffrn_scan_collection
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -10889,9 +10895,9 @@ save_DIFFRN_SCAN_FRAME
     Data items in the DIFFRN_SCAN_FRAME category describe
      the relationships of particular frames to scans.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN_FRAME
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -10941,12 +10947,12 @@ save_diffrn_scan_frame.date
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               date
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               yyyy-mm-dd
+    _type.ddl2_code               Yyyy-mm-dd
 
 save_
 
@@ -10960,12 +10966,12 @@ save_diffrn_scan_frame.diffrn_id
     _name.category_id             diffrn_scan_frame
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -10982,12 +10988,12 @@ save_diffrn_scan_frame.frame_id
     _name.category_id             diffrn_scan_frame
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -11003,12 +11009,12 @@ save_diffrn_scan_frame.frame_number
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               frame_number
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            0:
     _units.code                   none
 
@@ -11026,13 +11032,13 @@ save_diffrn_scan_frame.integration_time
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               integration_time
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -11070,12 +11076,12 @@ save_diffrn_scan_frame.polarizn_stokes_i
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_I
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _enumeration.default          1.0
     _units.code                   none
@@ -11097,12 +11103,12 @@ save_diffrn_scan_frame.polarizn_stokes_i_esd
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_I_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -11140,12 +11146,12 @@ save_diffrn_scan_frame.polarizn_stokes_q
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_Q
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -11167,12 +11173,12 @@ save_diffrn_scan_frame.polarizn_stokes_q_esd
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_Q_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -11210,12 +11216,12 @@ save_diffrn_scan_frame.polarizn_stokes_u
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_U
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -11237,12 +11243,12 @@ save_diffrn_scan_frame.polarizn_stokes_u_esd
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_U_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -11281,12 +11287,12 @@ save_diffrn_scan_frame.polarizn_stokes_v
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_V
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -11309,12 +11315,12 @@ save_diffrn_scan_frame.polarizn_stokes_v_esd
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_V_esd
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _enumeration.range            0.0:
     _units.code                   none
 
@@ -11333,12 +11339,12 @@ save_diffrn_scan_frame.scan_id
     _name.category_id             diffrn_scan_frame
     _name.object_id               scan_id
     _name.linked_item_id          '_diffrn_scan.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -11352,13 +11358,13 @@ save_diffrn_scan_frame.time_period
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               time_period
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -11384,13 +11390,13 @@ save_diffrn_scan_frame.time_rstrt_incr
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               time_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -11411,12 +11417,12 @@ save_diffrn_scan_frame.variant
     _name.category_id             diffrn_scan_frame
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -11435,9 +11441,9 @@ save_DIFFRN_SCAN_FRAME_AXIS
      those values should be given explicitly in this category and not
      simply inferred from values in DIFFRN_SCAN_AXIS.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN_FRAME_AXIS
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -11503,13 +11509,13 @@ save_diffrn_scan_frame_axis.angle
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -11528,13 +11534,13 @@ save_diffrn_scan_frame_axis.angle_increment
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -11555,13 +11561,13 @@ save_diffrn_scan_frame_axis.angle_rstrt_incr
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -11583,12 +11589,12 @@ save_diffrn_scan_frame_axis.axis_id
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -11602,12 +11608,12 @@ save_diffrn_scan_frame_axis.diffrn_id
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -11621,13 +11627,13 @@ save_diffrn_scan_frame_axis.displacement
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -11647,13 +11653,13 @@ save_diffrn_scan_frame_axis.displacement_increment
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement_increment
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -11675,13 +11681,13 @@ save_diffrn_scan_frame_axis.displacement_rstrt_incr
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement_rstrt_incr
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
 
@@ -11703,12 +11709,12 @@ save_diffrn_scan_frame_axis.frame_id
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -11728,13 +11734,13 @@ save_diffrn_scan_frame_axis.reference_angle
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               reference_angle
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              degrees
+    _type.ddl2_code               Float
+    _type.ddl2_units              Degrees
     _enumeration.default          0.0
     _units.code                   degrees
 
@@ -11758,13 +11764,13 @@ save_diffrn_scan_frame_axis.reference_displacement
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               reference_displacement
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              millimetres
+    _type.ddl2_code               Float
+    _type.ddl2_units              Millimetres
     _units.code                   millimetres
 
 save_
@@ -11785,12 +11791,12 @@ save_diffrn_scan_frame_axis.variant
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -11827,9 +11833,9 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      _diffrn_scan_frame_monitor.id may be
      omitted.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SCAN_FRAME_MONITOR
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -11999,12 +12005,12 @@ save_diffrn_scan_frame_monitor.detector_id
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               detector_id
     _name.linked_item_id          '_diffrn_detector.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12018,12 +12024,12 @@ save_diffrn_scan_frame_monitor.diffrn_id
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12037,12 +12043,12 @@ save_diffrn_scan_frame_monitor.frame_id
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12061,14 +12067,15 @@ save_diffrn_scan_frame_monitor.id
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _enumeration.range            1:
     _enumeration.default          1
+    _units.code                   none
 
 save_
 
@@ -12082,13 +12089,13 @@ save_diffrn_scan_frame_monitor.integration_time
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               integration_time
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
-    _type.ddl2_units              seconds
+    _type.ddl2_code               Float
+    _type.ddl2_units              Seconds
     _units.code                   seconds
 
 save_
@@ -12114,12 +12121,12 @@ save_diffrn_scan_frame_monitor.monitor_value
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               monitor_value
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _type.ddl2_code               float
+    _type.ddl2_code               Float
     _units.code                   none
 
 save_
@@ -12133,12 +12140,12 @@ save_diffrn_scan_frame_monitor.scan_id
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               scan_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12158,12 +12165,12 @@ save_diffrn_scan_frame_monitor.variant
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -12173,7 +12180,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-05
+    _definition.update            2025-09-10
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -12181,9 +12188,9 @@ save_DIFFRN_SOURCE
                This is a stub category for use of DIFFRN_SOURCE which is
                specified in the mmCIF_PDBx dictionary
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               DIFFRN_SOURCE
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _category_key.name            '_diffrn_source.diffrn_id'
 
 save_
@@ -12202,7 +12209,7 @@ save_diffrn_source.diffrn_id
     _name.category_id             diffrn_source
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
 
 save_
 
@@ -12224,12 +12231,12 @@ save_diffrn_source.source
 ;
     _name.category_id             diffrn_source
     _name.object_id               source
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -12259,12 +12266,12 @@ save_diffrn_source.type
 ;
     _name.category_id             diffrn_source
     _name.object_id               type
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
 
     loop_
       _description_example.case
@@ -12291,9 +12298,9 @@ save_MAP
 
      Examples are given in the MAP_SEGMENT category.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               MAP
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -12335,12 +12342,12 @@ save_map.details
 ;
     _name.category_id             map
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case
 ;   Example 1. Identifying an observed density map
                 and a calculated density map
@@ -12373,12 +12380,12 @@ save_map.diffrn_id
     _name.category_id             map
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12391,12 +12398,12 @@ save_map.entry_id
 ;
     _name.category_id             map
     _name.object_id               entry_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12409,12 +12416,12 @@ save_map.id
 ;
     _name.category_id             map
     _name.object_id               id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12434,12 +12441,12 @@ save_map.variant
     _name.category_id             map
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -12454,9 +12461,9 @@ save_MAP_SEGMENT
     Data items in the MAP_SEGMENT category record
      the details about each segment (section or brick) of a map.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               MAP_SEGMENT
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -12510,12 +12517,12 @@ save_map_segment.array_id
 ;
     _name.category_id             map_segment
     _name.object_id               array_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12529,12 +12536,12 @@ save_map_segment.array_section_id
     _name.category_id             map_segment
     _name.object_id               array_section_id
     _name.linked_item_id          '_array_structure_list_section.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12551,12 +12558,12 @@ save_map_segment.binary_id
 ;
     _name.category_id             map_segment
     _name.object_id               binary_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _units.code                   none
 
 save_
@@ -12570,12 +12577,12 @@ save_map_segment.details
 ;
     _name.category_id             map_segment
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case     'Example to be provided'
     _description_example.detail
 ;
@@ -12594,12 +12601,12 @@ save_map_segment.id
     _name.category_id             map_segment
     _name.object_id               id
     _name.linked_item_id          '_map.id'
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12612,12 +12619,12 @@ save_map_segment.map_id
 ;
     _name.category_id             map_segment
     _name.object_id               map_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12644,12 +12651,12 @@ save_map_segment.mask_array_id
 ;
     _name.category_id             map_segment
     _name.object_id               mask_array_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12662,12 +12669,12 @@ save_map_segment.mask_array_section_id
 ;
     _name.category_id             map_segment
     _name.object_id               mask_array_section_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12684,12 +12691,12 @@ save_map_segment.mask_binary_id
 ;
     _name.category_id             map_segment
     _name.object_id               mask_binary_id
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _type.ddl2_code               int
+    _type.ddl2_code               Int
     _units.code                   none
 
 save_
@@ -12710,12 +12717,12 @@ save_map_segment.variant
     _name.category_id             map_segment
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -12766,9 +12773,9 @@ save_VARIANT
      be combined, _variant.diffrn_id and/or _variant.entry_id may
      be used.
 ;
-    _name.category_id             HEAD
+    _name.category_id             CIF_IMG_HEAD
     _name.object_id               VARIANT
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
 
     loop_
       _category_key.name
@@ -12835,12 +12842,12 @@ save_variant.details
 ;
     _name.category_id             variant
     _name.object_id               details
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               text
+    _type.ddl2_code               Text
     _description_example.case     'indexed cell and refined beam centre'
 
 save_
@@ -12855,12 +12862,12 @@ save_variant.diffrn_id
     _name.category_id             variant
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12873,12 +12880,12 @@ save_variant.entry_id
 ;
     _name.category_id             variant
     _name.object_id               entry_id
-    _name.ddl2_mandatory          yes
+    _name.ddl2_mandatory          Yes
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12897,12 +12904,12 @@ save_variant.role
 ;
     _name.category_id             variant
     _name.object_id               role
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
-    _type.ddl2_code               uline
+    _type.ddl2_code               Uline
 
     loop_
       _enumeration_set.state
@@ -12939,12 +12946,12 @@ save_variant.timestamp
 ;
     _name.category_id             variant
     _name.object_id               timestamp
-    _name.ddl2_mandatory          no
+    _name.ddl2_mandatory          No
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               yyyy-mm-dd
+    _type.ddl2_code               Yyyy-mm-dd
 
 save_
 
@@ -12960,12 +12967,12 @@ save_variant.variant
 ;
     _name.category_id             variant
     _name.object_id               variant
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
     _enumeration.default          .
 
 save_
@@ -12984,12 +12991,12 @@ save_variant.variant_of
 ;
     _name.category_id             variant
     _name.object_id               variant_of
-    _name.ddl2_mandatory          implicit
+    _name.ddl2_mandatory          Implicit
     _type.purpose                 Describe
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _type.ddl2_code               code
+    _type.ddl2_code               Code
 
 save_
 
@@ -12997,393 +13004,309 @@ save_
       _dictionary_audit.version
       _dictionary_audit.date
       _dictionary_audit.revision
-         1.8.9                    2025-06-10
+         0.1.0                    1997-01-24
 ;
-       Addition of missing diffrn.id pointers
+   First draft of this dictionary in DDL 2.1 compliant format by John
+   Westbrook (JW).  This version is adapted from the Crystallographic
+   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
+   (AH).
 
-        + Add _diffrn_detector_element.diffrn_id
-        + Add _diffrn_measurement_axis.diffrn_id
-        + Add _diffrn_scan.diffrn_id
-        + Add _diffrn_scan_axis.diffrn_id
-        + Add _diffrn_scan_collection.diffrn_id
-        + Add _diffrn_scan_frame.diffrn_id
-        + Add _diffrn_scan_frame_axis.diffrn_id
-        + Add _diffrn_scan_frame_axis.diffrn_id
-        + Add _diffrn_scan_frame_monitor.diffrn_id
-;
-         1.8.8-dev2               2025-06-10
-;
-       Pick up minor type corrections from 1.8.9 dcitionary
-;
-         1.8.8-dev1               2025-05-25
-;
-       Minor corrections to 1.8.8 found while working on 1.8.9
-;
-         1.8.8                    2024-01-20
-;   Additional flux tags and change to ddl2 version being the master
-    instead of the html version being the master.  Make changes to
-    support conversions to DDLm and back to DDL2.  Mark tags aliased
-    from mmCIF_PDBx dictionary.
+   Modifications to the CBF draft.  (JW)
 
-    + Change from use of _item.type_code to _item_type.code
-    + Fix extraneous single quote after _array_data_external_data.file_compression
-    + Change 'photons per second' to photons_per_second in units
-    + Add micrometres, photons, photons_per_second, and 
-      photons_per_seconf_per_micrometre_squared to units
-    + Add stub DIFFRN category
-    + Add _diffrn.id
-    + Add  _diffrn_radiation.beam_flux_density
-    + Add _diffrn_radiation.beam_flux_density_integrated
-    + Add  _diffrn_radiation.beam_flux_integrated
-    + Add _diffrn_radiation.beam_flux_integration_time
-    + Add _diffrn_radiation.beam_incident_flux
-    + Add _diffrn_radiation.beam_incident_flux_integrated
-    + Add stub DIFFRN_SOURCE category
-    + Add _diffrn_source.diffrn_id
-    + Add _diffrn_source.source
-    + Add _diffrn_source.type
-;
-         1.8.7                    2023-01-26
-;   Various additions
+   + In this version the array description has been cast in the categories
+     ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
+     have been generalized to describe array data  of arbitrary dimension.
 
-    + Add _array_data_external_data.file_compression
-      2022-06-09 (jrh).
-    + Fix incorrect _diffrn_scan_axis.angle_range
-      example and clarify definition 2022-06-09 (jrh)
-    + Clarify wording describing _array_intensities.overload 
-      2022-12-31 (ab) 
-;
-         1.8.6                    2022-05-11
-;
-       Add missing archive tags to external data tags, clarify use of
-        those tags and correct typos (jrh, hjb)
+   + Array data in this description are contained in the category
+     ARRAY_DATA.  This departs from the CBF notion of data existing
+     in some special comment. In this description, data are handled as an
+     ordinary data item encapsulated in a character data type.   Although
+     data this manner deviates from CIF conventions, it does not violate
+     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
+     the binary representation which will permit some level of data
+     validation.  In this version, the placeholder type code "any" has
+     been used. This translates to a regular expression which will match
+     any pattern.
 
-        + Add _array_data_external_data.archive_format
-        + Add _array_data_external_data.archive_path
-;
-         1.8.5                    2021-07-09
-;
-       Handling of external data (jrh, ab, hjb)
+     It should be noted that DDL 2.1 already supports array data objects
+     although these have not been used in the current mmCIF dictionary.
+     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
+     ITEM_STRUCTURE_LIST categories to provide the information that is
+     carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
+     moving the array structure to the DDL level it would be possible to
+     define an array type as well as a regular expression defining the
+     data format.
 
-        + Remove preliminary versions of external data tags in ARRAY_DATA
-        + Add ARRAY_DATA_EXTERNAL_DATA
-        + Add _array_data.external_data_id
-        + Add _array_data_external_data.format
-        + Add _array_data_external_data.frame
-        + Add _array_data_external_data.id
-        + Add _array_data_external_data.path
-        + Add _array_data_external_data.uri
-        + Add _array_data_external_data.variant
-        + Add _array_data_external_data.version
+   + Multiple array sections can be properly handled within a single
+     datablock.
 ;
-         1.8.4                    2021-04-15
-;   Copy-editing refinements (bm)
-
-    + Add _item_related.related_name and
-      "_item_related.function_code replacedby" to deprecated items.
-    + Add "_item_default.value  ." to *_variant items
-    + Change uses of \%Angstroms to \%angstr\"oms
-    + Change category save frames to upper case names
-    + Fix misssing superscript terminating ^
-
-    Preliminary version of external data tags (jrh)
-
-    + Add _array_data.external_format
-    + Add _array_data.external_version
-    + Add _array_data.external_location_uri
-    + Add _array_data.external_path
-    + Add _array_data.external_frame
-    + Add _array_data.external_archive_path
-    + Add _array_data.external_archive_format
-
-    Note the second block of mads is a preliminary version.  When they are
-    done they may well be removed from here and reappear in a 1.8.5
-    dictionary.
-
+         0.2.0                    1997-12-02
 ;
-         1.8.3                    2021-02-28
-;   Correction as per Brian McMahon
+   Modifications to the CBF draft.  (JW)
 
-    + Fix _item.name for _array_structure_list.array_section_id
-    + Remove spurious _item_aliases.alias_name from
-      _diffrn_radiation.polarisn_ratio_esd
-    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
-    + Provide missing _diffrn_scan_frame_monitor.monitor_value definition
-    + Deprecate _diffrn_scan_frame_monitor.value
+   + Add category hierarchy for describing frame data developed from
+     discussions at the BNL imgCIF Workshop Oct 1997.   The following
+     changes are made in implementing the workshop draft.  Category
+     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
+     DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT.   The
+     parent item for '_diffrn_frame_data.array_id' is changed from
+     '_array_structure_list.array_id' to '_array_structure.id'. Item
+     '_diffrn_detector.array_id' is deleted.
+   + Add data item '_diffrn_frame_data.binary_id' to identify data
+     groups within a binary section.  The formal identification of the
+     binary section is still fuzzy.
 ;
-         1.8.2                    2021-02-21
+         0.3.0                    1998-07-04
 ;
-       Corrections and additions for ITVG 2021
+   Modifications for imgCIF.  (HJB)
 
-        + Add McStas as an axis coordinate system
-        + Add _array_intensities.underload as optional
-        + Add _diffrn_scan_collection.details as optional
-        + Add _diffrn_scan_collection.variant as optional
-;
-         1.8.1                    2021-01-30
-;
-       Copy-paste error corrections (JRH)
+   + Add binary type, which is a text field containing a variant on
+     MIME encoded data.
 
-        + Fix double underscore in _diffrn_data_frame.center_derived
-        + Fix wrong _item.name in _diffrn_scan.date_end_estimated
-        + Fix wrong _item.mandatory_code in _diffrn_scan_frame_monitor.frame_id
-        + Fix wrong _item.mandatory_code in _variant.variant_of
-;
-         1.8.0                    2021-01-24
-;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+   + Change type of '_array_data.data' to binary and specify internal
+     structure of raw binary data.
 
-    + Add _diffrn_data_frame.center_derived as optional
-    + Add _diffrn_measurement.sample_detector_distance_derived as optional
-    + Change _diffrn_scan.date_start to mandatory
-    + Add _diffrn_scan.date_end_estimated as mandatory
-    + Fix .array_id and .binary_id columns to be implicit in all cases to
-      facilitate mini_cbfs
+   + Add '_array_data.binary_id', and make
+     '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
+     into pointers to this item.
+;
+         0.4.0                    1998-08-11
+;
+       Modifications to the 0.3 imgCIF draft.  (HJB)
 
-;
-         1.7.11                   2018-12-03
-;
-       Changes for CBFlib 0.9.6 release (HJB)
+       + Reflow comment lines over 80 characters and corrected typos.
 
-        + Remove _array_structure_list.array_section_id
-        + Revisions to _category.NX_mapping_details in most categories for
-        array sections.
-        + Change to uniform use of entry:NXentry
-        + Change to uniform use of identification of NXdetector by detector
-        element
-        + Change to uniform use of data_ARRAYID_BINARYID
-        + Add _array_structure_list.array_section_id
-        + Add _map_segment.mask_array_section_id
-        + Add _diffrn_scan_collection.scan_id
-        + Add _diffrn_scan_collection.type
-        + Add _diffrn_scan_collection.translation_width
-        + Add _diffrn_radiation.beam_width
-        + Add _diffrn_radiation.beam_height
-        + Add _diffrn_radiation.beam_flux
-;
-         1.7.10                   2014-04-25
-;
-       Additions of esd's to polarization tags.  Change to NeXus mapping to use
-        NXtransformations instead of NXpoise (HJB)
+       + Update examples and descriptions of MIME encoded data.
 
-         + Add _diffrn_radiation.polarisn_norm_esd,
-         _diffrn_radiation.polarisn_ratio_esd,
-         _diffrn_radiation.polarizn_source_norm_esd,
-         _diffrn_radiation.polarizn_source_ratio_esd,
-         _diffrn_radiation.polarizn_Stokes_I_esd,
-         _diffrn_radiation.polarizn_Stokes_Q_esd,
-         _diffrn_radiation.polarizn_Stokes_U_esd,
-         _diffrn_radiation.polarizn_Stokes_V_esd,
-         _diffrn_scan_frame.polarizn_Stokes_I_esd,
-         _diffrn_scan_frame.polarizn_Stokes_Q_esd,
-         _diffrn_scan_frame.polarizn_Stokes_U_esd,
-         _diffrn_scan_frame.polarizn_Stokes_V_esd.
-         + Change NeXus mapping for ARRAY_STRUCTURE_LIST
-         ARRAY_STRUCTURE_LIST_AXIS, AXIS,
-         DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
-         DIFFRN_SCAN_FRAME_AXIS.
+       + Change name to cbfext98.dic.
 ;
-         1.7.9                    2014-04-05
-;  Corrections to Stokes parameter description. (HJB)
+         0.5.0                    1999-01-01
+;
+   Modifications for axis definitions and reduction of binary header.  (HJB)
 
-    + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
-    and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
-        component.
+   + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
 
-    + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
-    description and _diffrn_scan_frame.polarizn_Stokes_V description.
+   + Add AXIS category.
 
-;
-         1.7.8                    2014-02-22
-;  Minor changes to NeXus mapping. (HJB)
+   + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
+     from cif_mm.dic for clarity.
 
-       + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
-       NXdetector base class terminology
+   + Change '_array_structure.encoding_type' from type code to uline and
+     added X-Binary-Element-Type to MIME header.
 
-       + Add _diffrn_detector.gain_setting to handle
-       the reverse mapping from NeXus of the equivalent field in NXdetector.
-;
-         1.7.7                    2014-02-22
-;  Major changes to NeXus mapping to conform to JS functional
-    mapping prototype, add Stoke parameter tags for polarization
-    and beam intensity, and add an new tag for FEL axes (HJB)
+   + Add detector beam centre '_diffrn_detector_element.center[1]' and
+     '_diffrn_detector_element.center[2]'.
 
-       + Add
-       _axis.equipment_component,
-       _diffrn_radiation.polarizn_Stokes_I,
-       _diffrn_radiation.polarizn_Stokes_Q,
-       _diffrn_radiation.polarizn_Stokes_U,
-       _diffrn_radiation.polarizn_Stokes_V,
-       _diffrn_scan_frame.polarizn_Stokes_I,
-       _diffrn_scan_frame.polarizn_Stokes_Q,
-       _diffrn_scan_frame.polarizn_Stokes_U,
-       _diffrn_scan_frame.polarizn_Stokes_V.
-       + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
-       + Update dictionary version
-;
-         1.7.6                    2013-10-29
-;
-       To avoid a conflict with PDB software, remove the null value
-         enumeration for _variant.role (HJB)
-;
-         1.7.5                    2013-10-27
-;
-       At request of JW for the PDB move _category.NX_mapping_details
-        to be adjacent to other category tags. (HJB)
-;
-         1.7.4                    2013-10-23
-;
-       Minor cleanup and remove spurious tag
+   + Correct item name of '_diffrn_refln.frame_id'.
 
-         +  remove spurious _array_structure_list_section.array_set_id
-         references. (JS)
-         +  Change case of category names to conform to PDB conventions. (JW)
+   + Replace reference to '_array_intensities.undefined' by
+     '_array_intensities.undefined_value'.
+
+   + Replace references to '_array_intensity.scaling' with
+     '_array_intensities.scaling'.
+
+   + Add DIFFRN_SCAN... categories.
 ;
-         1.7.3                    2013-10-15
-;  Major cleanup of dictionary typos, misplaced loops, etc
-       by John Westbrook
-
-    +  Change _item.mandatory_code of all *.variant to implicit
-    +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
-    +  Correct many _item.name values that were wrong or missing
-       quote marks
-
+         0.5.1                    1999-01-03
 ;
-         1.7.2                    2013-10-07
-;  Add FEL detector positioning tags and change back to NXgoniometer
+       Cleanup of typos and syntax errors.  (HJB)
 
-    +  Add
-       _axis.rotation_axis and
-       _axis.rotation and
-    +  Change NXsample back to NXgoniometer
+       + Cleanup example details for DIFFRN_SCAN category.
 
+       + Add missing quote marks for '_diffrn_scan.id' definition.
 ;
-         1.7.1                    2013-08-10
-;  Minor cleanup (HJB)
-
-    +  Correction to description of
-         _diffrn_data_frame.array_section_id
-    +  Change NXgoniometer to NXsample
-    +  Fix typos in NeXus mappings
-
+         0.6.0                    1999-01-14
 ;
-         1.7.0                    2013-06-18
-;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+   Remove redundant information for ENC_NONE data.  (HJB)
 
-    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
-    +  Add new _category.NX_mapping_details DDL tag to carry
-       details on NeXus category mappings.
-    +  Define new tags _array_structure_list_section.array_id,
-       _array_structure_list_section.id,
-       _array_structure_list_section.index,
-       _array_structure_list_section.end,
-       _array_structure_list_section.start,
-       _array_structure_list_section.stride,
-       _array_structure_list_section.variant,
-       _diffrn_data_frame.array_section_id,
-       _diffrn_detector.layer_thickness,
-       _map_segment.array_section_id,
-       _map_segment.mask_array_section_id
+   + After the D5 remove binary section identifier, size and
+     compression type.
 
+   + Add Control-L to header.
 ;
-         1.6.4                    2011-07-02
-;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+         0.7.0                    2000-09-09
+;
+   Respond to comments by I. David Brown.  (HJB)
 
-    +  Define new tags _diffrn_scan.time_period,
-       _diffrn_scan.time_rstrt_incr,
-       _diffrn_scan_frame.time_period,
-       _diffrn_scan_frame.time_rstrt_incr 
-    +  fix bad category name in loop in _diffrn_detector.id
-    +  remove stray text field terminator at line 4642
-    +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
-    +  make formerly mandatory and implicit deprecated items non-mandatory
+   + Add further comments on '\n' and '\t'.
 
-;
-         1.6.3                    2010-08-26
-;
-       Cumulative corrections from 1.6.0, 1, 2 drafts (HJB)
+   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
+     and adding metres.  Change 'meter' to 'metre' throughout.
 
-         +  Move descriptive dictionary comments into
-         _datablock.description with category tree described
-         +  add default _array_data.array_id value of 1
-         +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
-         +  add VARIANT category and tags
-         +  add DIFFRN_SCAN_FRAME_MONITOR category
-;
-         1.5.4                    2007-07-28
-;  Typographics corrections (HJB)
+   + Add missing enumerations to '_array_structure.compression_type'
+     and make 'none' the default.
 
-     + Corrected embedded degree characters to \%
-     + Corrected embedded Aring to \%A
-     + Added trailing ^ for a power
-     + Removed 2 cases of a space after an underscore
-       in tag name.
-;
-         1.5.3                    2007-07-08
-;  Changes to support SLS miniCBF and suggestions
-   from the 24 May 07 BNL imgCIF workshop (HJB)
+   + Remove parent-child relationship between
+     '_array_structure_list.index' and '_array_structure_list.precedence'.
 
-     + Added new data items
-       '_array_data.header_contents',
-       '_array_data.header_convention',
-       '_diffrn_data_frame.center_fast',
-       '_diffrn_data_frame.center_slow',
-       '_diffrn_data_frame.center_units',
-       '_diffrn_measurement.sample_detector_distance',
-       '_diffrn_measurement.sample_detector_voffset
-     + Deprecated data items
-       '_diffrn_detector_element.center[1]',
-       '_diffrn_detector_element.center[2]'
-     + Added comments and example on miniCBF
-     + Changed all array_id data items to implicit
-;
-         1.5.2                    2007-05-06
-;
-       Further clarifications of the coordinate system. (HJB)
-;
-         1.5.1                    2007-04-26
-;
-       Improve definition of X-axis to cover the case of no goniometer
-        and clean up more line folds (HJB)
-;
-         1.5.0                    2007-07-25
-;  This is a cumulative list of the changes proposed since the
-   imgCIF workshop in Hawaii in July 2006.  It is the result
-   of contributions by H. J. Bernstein, A. Hammersley,
-   J. Wright and W. Kabsch.
+   + Improve alphabetization.
 
-   2007-02-19 Consolidated changes (edited by HJB)
-     + Added new data items
-       '_array_structure.compression_type_flag',
-       '_array_structure_list_axis.fract_displacement',
-       '_array_structure_list_axis.displacement_increment',
-       '_array_structure_list_axis.reference_angle',
-       '_array_structure_list_axis.reference_displacement',
-       '_axis.system',
-       '_diffrn_detector_element.reference_center_fast',
-       '_diffrn_detector_element.reference_center_slow',
-       '_diffrn_scan_axis.reference_angle',
-       '_diffrn_scan_axis.reference_displacement',
-       '_map.details', '_map.diffrn_id',
-       '_map.entry_id', '_map.id',
-       '_map_segment.array_id', '_map_segment.binary_id',
-       '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
-       '_map_segment.id', '_map_segment.map_id',
-       '_map_segment.details.
-     + Change type of 
-       '_array_structure.byte_order' and
-       '_array_structure.compression_type'
-       to ucode to make these values case-insensitive
-     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
-       '_array_structure.compression_type'
-     + Add to definitions for the binary data type to handle new compression
-       types, maps, and a variety of new axis types.
-    2007-07-25 Cleanup of typos for formal release (HJB)
-     + Corrected text fields for reference_ tag descriptions that
-       were off by one column
-     + Fix typos in comments listing fract_ tags
-     + Changed name of release from 1.5_DRAFT to 1.5
-     + Fix unclosed text fields in various map definitions
+   + Fix '_array_intensities.gain_esd' related function.
 
+   + Improve comments in AXIS.
+
+   + Fix DIFFRN_FRAME_DATA example.
+
+   + Remove erroneous DIFFRN_MEASUREMENT example.
+
+   + Add '_diffrn_measurement_axis.id' to the category key.
+;
+         0.7.1                    2000-09-29
+;
+       Cleanup fixes.  (JW)
+
+       + Correct spelling of DIFFRN_MEASUREMENT_AXIS in '_axis.id'
+
+       + Correct ordering of uses of '_item.mandatory_code' and
+       '_item_default.value'.
+;
+         1.0.0                    2000-12-21
+;
+       Release version - few typos and tidying up.  (BM & HJB)
+
+       + Move ITEM_TYPE_LIST, ITEM_UNITS_LIST and DICTIONARY_HISTORY to end
+       of dictionary.
+
+       + Alphabetize dictionary.
+;
+         1.1.0                    2001-02-06
+;
+   Draft resulting from discussions on header for use at NSLS.  (HJB)
+
+   + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
+
+   + Change '_diffrn_detector_axis.id' to '_diffrn_detector_axis.detector_id'.
+
+   + Add '_diffrn_measurement_axis.measurement_device' and change
+     '_diffrn_measurement_axis.id' to
+     '_diffrn_measurement_axis.measurement_id'.
+
+   + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
+    '_diffrn_radiation.div_x_y_source',
+    '_diffrn_radiation.polarizn_source_norm',
+   '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
+   '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
+   '_diffrn_scan_axis.displacement_rstrt_incr',
+   '_diffrn_scan_frame_axis.angle_increment',
+   '_diffrn_scan_frame_axis.angle_rstrt_incr',
+   '_diffrn_scan_frame_axis.displacement',
+   '_diffrn_scan_frame_axis.displacement_increment',and
+   '_diffrn_scan_frame_axis.displacement_rstrt_incr'.
+
+   + Add '_diffrn_measurement.device' to category key.
+
+   + Update yyyy-mm-dd to allow optional time with fractional seconds
+     for time stamps.
+
+   + Fix typos caught by RS.
+
+   + Add ARRAY_STRUCTURE_LIST_AXIS category, and use concept of axis sets to
+     allow for coupled axes, as in spiral scans.
+
+   + Add examples for fairly complete headers thanks to R. Sweet and P.
+     Ellis.
+;
+         1.1.1                    2001-02-16
+;
+       Several typo corrections by JW.
+;
+         1.1.2                    2001-03-06
+;
+       Several typo corrections by Wilfred Li.
+;
+         1.1.3                    2001-04-19
+;
+       Another typo corrections by Wilfred Li, and cleanup by HJB.
+;
+         1.2.0                    2003-02-07
+;
+       Corrections to encodings (remove extraneous hyphens) remove
+       extraneous underscore in '_array_structure.encoding_type'
+       enumeration.  Correct typos in items units list.  (HJB)
+;
+         1.2.1                    2003-02-22
+;
+       Correction of ATOM_ for ARRAY_ typos in various descriptions.
+       (HJB)
+;
+         1.2.2                    2003-03-10
+;
+       Correction of typos in various DIFFRN_SCAN_AXIS descriptions.
+       (HJB)
+;
+         1.2.3                    2003-07-03
+;
+       Cleanup to conform to ITVG.
+       + Correct sign error in ..._cubed units.
+       + Correct '_diffrn_radiation.polarisn_norm' range.
+       (HJB)
+;
+         1.2.4                    2003-07-14
+;
+   Changes as per I. David Brown.
+   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
+     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
+   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
+     category for completeness.
+   (HJB)
+;
+         1.3.0                    2003-07-24
+;
+   Changes as per Brian McMahon.
+   + Consistently quote tags embedded in text.
+   + Clean up introductory comments.
+   + Adjust line lengths to fit in 80 character window.
+   + Fix several descriptions in AXIS category which
+     referred to '_axis.type' instead of the current item.
+   + Fix erroneous use of deprecated item
+     '_diffrn_detector_axis.id' in examples for
+     DIFFRN_SCAN_AXIS.
+   + Add deprecated items '_diffrn_detector_axis.id'
+     and '_diffrn_measurement_axis.id'.
+   (HJB)
+;
+         1.3.1                    2003-08-13
+;
+       Changes as per Frances C. Bernstein.
+       + Identify initials.
+       + Adopt British spelling for centre in text.
+       + Set \p and \%Angstrom and powers.
+       + Clean up commas and unclear wordings.
+       + Clean up tenses in history.
+       Changes as per Gotzon Madariaga.
+       + Fix the ARRAY_DATA example to align '_array_data.binary_id'
+       and X-Binary-ID.
+       + Add a range to '_array_intensities.gain_esd'.
+       + In the example of DIFFRN_DETECTOR_ELEMENT,
+       '_diffrn_detector_element.id' and
+       '_diffrn_detector_element.detector_id' interchanged.
+       + Fix typos for direction, detector and axes.
+       + Clarify description of polarisation.
+       + Clarify axes in '_diffrn_detector_element.center[1]'
+        '_diffrn_detector_element.center[2]'.
+       + Add local item types for items that are pointers.
+       (HJB)
+;
+         1.3.2                    2005-06-25
+;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+              to those of current mmCIF; float modified by allowing integers
+              terminated by a point as valid. The 'time' part of
+              yyyy-mm-dd types made optional in the regexp. (BM)
+
+   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
+   (NJA)
+
+   2005-02-21  Minor corrections to spelling and punctuation
+   (NJA)
+
+   2005-01-08 Changes as per Nicola Ashcroft.
+   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
+   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
+   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
+     description.
+   + Removed unused 'byte-offsets' compressions and updated
+     cites to ITVG for '_array_structure.compression_type'.
+   (HJB)
 ;
          1.4.0                    2006-07-04
 ;  This is a change to reintegrate all changes made in the course of
@@ -13425,307 +13348,391 @@ save_
                _diffrn_measurement_axis.measurement_id
                added sub_category 'vector' (JDW)
 ;
-         1.3.2                    2005-06-25
-;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
-              to those of current mmCIF; float modified by allowing integers
-              terminated by a point as valid. The 'time' part of
-              yyyy-mm-dd types made optional in the regexp. (BM)
+         1.5.0                    2007-07-25
+;  This is a cumulative list of the changes proposed since the
+   imgCIF workshop in Hawaii in July 2006.  It is the result
+   of contributions by H. J. Bernstein, A. Hammersley,
+   J. Wright and W. Kabsch.
 
-   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
-   (NJA)
+   2007-02-19 Consolidated changes (edited by HJB)
+     + Added new data items
+       '_array_structure.compression_type_flag',
+       '_array_structure_list_axis.fract_displacement',
+       '_array_structure_list_axis.displacement_increment',
+       '_array_structure_list_axis.reference_angle',
+       '_array_structure_list_axis.reference_displacement',
+       '_axis.system',
+       '_diffrn_detector_element.reference_center_fast',
+       '_diffrn_detector_element.reference_center_slow',
+       '_diffrn_scan_axis.reference_angle',
+       '_diffrn_scan_axis.reference_displacement',
+       '_map.details', '_map.diffrn_id',
+       '_map.entry_id', '_map.id',
+       '_map_segment.array_id', '_map_segment.binary_id',
+       '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
+       '_map_segment.id', '_map_segment.map_id',
+       '_map_segment.details.
+     + Change type of 
+       '_array_structure.byte_order' and
+       '_array_structure.compression_type'
+       to ucode to make these values case-insensitive
+     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
+       '_array_structure.compression_type'
+     + Add to definitions for the binary data type to handle new compression
+       types, maps, and a variety of new axis types.
+    2007-07-25 Cleanup of typos for formal release (HJB)
+     + Corrected text fields for reference_ tag descriptions that
+       were off by one column
+     + Fix typos in comments listing fract_ tags
+     + Changed name of release from 1.5_DRAFT to 1.5
+     + Fix unclosed text fields in various map definitions
 
-   2005-02-21  Minor corrections to spelling and punctuation
-   (NJA)
-
-   2005-01-08 Changes as per Nicola Ashcroft.
-   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
-   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
-   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
-     description.
-   + Removed unused 'byte-offsets' compressions and updated
-     cites to ITVG for '_array_structure.compression_type'.
-   (HJB)
 ;
-         1.3.1                    2003-08-13
+         1.5.1                    2007-04-26
 ;
-       Changes as per Frances C. Bernstein.
-       + Identify initials.
-       + Adopt British spelling for centre in text.
-       + Set \p and \%Angstrom and powers.
-       + Clean up commas and unclear wordings.
-       + Clean up tenses in history.
-       Changes as per Gotzon Madariaga.
-       + Fix the ARRAY_DATA example to align '_array_data.binary_id'
-       and X-Binary-ID.
-       + Add a range to '_array_intensities.gain_esd'.
-       + In the example of DIFFRN_DETECTOR_ELEMENT,
-       '_diffrn_detector_element.id' and
-       '_diffrn_detector_element.detector_id' interchanged.
-       + Fix typos for direction, detector and axes.
-       + Clarify description of polarisation.
-       + Clarify axes in '_diffrn_detector_element.center[1]'
-        '_diffrn_detector_element.center[2]'.
-       + Add local item types for items that are pointers.
-       (HJB)
+       Improve definition of X-axis to cover the case of no goniometer
+        and clean up more line folds (HJB)
 ;
-         1.3.0                    2003-07-24
+         1.5.2                    2007-05-06
 ;
-   Changes as per Brian McMahon.
-   + Consistently quote tags embedded in text.
-   + Clean up introductory comments.
-   + Adjust line lengths to fit in 80 character window.
-   + Fix several descriptions in AXIS category which
-     referred to '_axis.type' instead of the current item.
-   + Fix erroneous use of deprecated item
-     '_diffrn_detector_axis.id' in examples for
-     DIFFRN_SCAN_AXIS.
-   + Add deprecated items '_diffrn_detector_axis.id'
-     and '_diffrn_measurement_axis.id'.
-   (HJB)
+       Further clarifications of the coordinate system. (HJB)
 ;
-         1.2.4                    2003-07-14
+         1.5.3                    2007-07-08
+;  Changes to support SLS miniCBF and suggestions
+   from the 24 May 07 BNL imgCIF workshop (HJB)
+
+     + Added new data items
+       '_array_data.header_contents',
+       '_array_data.header_convention',
+       '_diffrn_data_frame.center_fast',
+       '_diffrn_data_frame.center_slow',
+       '_diffrn_data_frame.center_units',
+       '_diffrn_measurement.sample_detector_distance',
+       '_diffrn_measurement.sample_detector_voffset
+     + Deprecated data items
+       '_diffrn_detector_element.center[1]',
+       '_diffrn_detector_element.center[2]'
+     + Added comments and example on miniCBF
+     + Changed all array_id data items to implicit
 ;
-   Changes as per I. David Brown.
-   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
-     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
-   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
-     category for completeness.
-   (HJB)
+         1.5.4                    2007-07-28
+;  Typographics corrections (HJB)
+
+     + Corrected embedded degree characters to \%
+     + Corrected embedded Aring to \%A
+     + Added trailing ^ for a power
+     + Removed 2 cases of a space after an underscore
+       in tag name.
 ;
-         1.2.3                    2003-07-03
+         1.6.3                    2010-08-26
 ;
-       Cleanup to conform to ITVG.
-       + Correct sign error in ..._cubed units.
-       + Correct '_diffrn_radiation.polarisn_norm' range.
-       (HJB)
+       Cumulative corrections from 1.6.0, 1, 2 drafts (HJB)
+
+         +  Move descriptive dictionary comments into
+         _datablock.description with category tree described
+         +  add default _array_data.array_id value of 1
+         +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
+         +  add VARIANT category and tags
+         +  add DIFFRN_SCAN_FRAME_MONITOR category
 ;
-         1.2.2                    2003-03-10
+         1.6.4                    2011-07-02
+;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+
+    +  Define new tags _diffrn_scan.time_period,
+       _diffrn_scan.time_rstrt_incr,
+       _diffrn_scan_frame.time_period,
+       _diffrn_scan_frame.time_rstrt_incr 
+    +  fix bad category name in loop in _diffrn_detector.id
+    +  remove stray text field terminator at line 4642
+    +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
+    +  make formerly mandatory and implicit deprecated items non-mandatory
+
 ;
-       Correction of typos in various DIFFRN_SCAN_AXIS descriptions.
-       (HJB)
+         1.7.0                    2013-06-18
+;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+
+    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
+    +  Add new _category.NX_mapping_details DDL tag to carry
+       details on NeXus category mappings.
+    +  Define new tags _array_structure_list_section.array_id,
+       _array_structure_list_section.id,
+       _array_structure_list_section.index,
+       _array_structure_list_section.end,
+       _array_structure_list_section.start,
+       _array_structure_list_section.stride,
+       _array_structure_list_section.variant,
+       _diffrn_data_frame.array_section_id,
+       _diffrn_detector.layer_thickness,
+       _map_segment.array_section_id,
+       _map_segment.mask_array_section_id
+
 ;
-         1.2.1                    2003-02-22
+         1.7.1                    2013-08-10
+;  Minor cleanup (HJB)
+
+    +  Correction to description of
+         _diffrn_data_frame.array_section_id
+    +  Change NXgoniometer to NXsample
+    +  Fix typos in NeXus mappings
+
 ;
-       Correction of ATOM_ for ARRAY_ typos in various descriptions.
-       (HJB)
+         1.7.10                   2014-04-25
 ;
-         1.2.0                    2003-02-07
+       Additions of esd's to polarization tags.  Change to NeXus mapping to use
+        NXtransformations instead of NXpoise (HJB)
+
+         + Add _diffrn_radiation.polarisn_norm_esd,
+         _diffrn_radiation.polarisn_ratio_esd,
+         _diffrn_radiation.polarizn_source_norm_esd,
+         _diffrn_radiation.polarizn_source_ratio_esd,
+         _diffrn_radiation.polarizn_Stokes_I_esd,
+         _diffrn_radiation.polarizn_Stokes_Q_esd,
+         _diffrn_radiation.polarizn_Stokes_U_esd,
+         _diffrn_radiation.polarizn_Stokes_V_esd,
+         _diffrn_scan_frame.polarizn_Stokes_I_esd,
+         _diffrn_scan_frame.polarizn_Stokes_Q_esd,
+         _diffrn_scan_frame.polarizn_Stokes_U_esd,
+         _diffrn_scan_frame.polarizn_Stokes_V_esd.
+         + Change NeXus mapping for ARRAY_STRUCTURE_LIST
+         ARRAY_STRUCTURE_LIST_AXIS, AXIS,
+         DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
+         DIFFRN_SCAN_FRAME_AXIS.
 ;
-       Corrections to encodings (remove extraneous hyphens) remove
-       extraneous underscore in '_array_structure.encoding_type'
-       enumeration.  Correct typos in items units list.  (HJB)
+         1.7.11                   2018-12-03
 ;
-         1.1.3                    2001-04-19
+       Changes for CBFlib 0.9.6 release (HJB)
+
+        + Remove _array_structure_list.array_section_id
+        + Revisions to _category.NX_mapping_details in most categories for
+        array sections.
+        + Change to uniform use of entry:NXentry
+        + Change to uniform use of identification of NXdetector by detector
+        element
+        + Change to uniform use of data_ARRAYID_BINARYID
+        + Add _array_structure_list.array_section_id
+        + Add _map_segment.mask_array_section_id
+        + Add _diffrn_scan_collection.scan_id
+        + Add _diffrn_scan_collection.type
+        + Add _diffrn_scan_collection.translation_width
+        + Add _diffrn_radiation.beam_width
+        + Add _diffrn_radiation.beam_height
+        + Add _diffrn_radiation.beam_flux
 ;
-       Another typo corrections by Wilfred Li, and cleanup by HJB.
+         1.7.2                    2013-10-07
+;  Add FEL detector positioning tags and change back to NXgoniometer
+
+    +  Add
+       _axis.rotation_axis and
+       _axis.rotation and
+    +  Change NXsample back to NXgoniometer
+
 ;
-         1.1.2                    2001-03-06
+         1.7.3                    2013-10-15
+;  Major cleanup of dictionary typos, misplaced loops, etc
+       by John Westbrook
+
+    +  Change _item.mandatory_code of all *.variant to implicit
+    +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
+    +  Correct many _item.name values that were wrong or missing
+       quote marks
+
 ;
-       Several typo corrections by Wilfred Li.
+         1.7.4                    2013-10-23
 ;
-         1.1.1                    2001-02-16
+       Minor cleanup and remove spurious tag
+
+         +  remove spurious _array_structure_list_section.array_set_id
+         references. (JS)
+         +  Change case of category names to conform to PDB conventions. (JW)
 ;
-       Several typo corrections by JW.
+         1.7.5                    2013-10-27
 ;
-         1.1.0                    2001-02-06
+       At request of JW for the PDB move _category.NX_mapping_details
+        to be adjacent to other category tags. (HJB)
 ;
-   Draft resulting from discussions on header for use at NSLS.  (HJB)
-
-   + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
-
-   + Change '_diffrn_detector_axis.id' to '_diffrn_detector_axis.detector_id'.
-
-   + Add '_diffrn_measurement_axis.measurement_device' and change
-     '_diffrn_measurement_axis.id' to
-     '_diffrn_measurement_axis.measurement_id'.
-
-   + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
-    '_diffrn_radiation.div_x_y_source',
-    '_diffrn_radiation.polarizn_source_norm',
-   '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
-   '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
-   '_diffrn_scan_axis.displacement_rstrt_incr',
-   '_diffrn_scan_frame_axis.angle_increment',
-   '_diffrn_scan_frame_axis.angle_rstrt_incr',
-   '_diffrn_scan_frame_axis.displacement',
-   '_diffrn_scan_frame_axis.displacement_increment',and
-   '_diffrn_scan_frame_axis.displacement_rstrt_incr'.
-
-   + Add '_diffrn_measurement.device' to category key.
-
-   + Update yyyy-mm-dd to allow optional time with fractional seconds
-     for time stamps.
-
-   + Fix typos caught by RS.
-
-   + Add ARRAY_STRUCTURE_LIST_AXIS category, and use concept of axis sets to
-     allow for coupled axes, as in spiral scans.
-
-   + Add examples for fairly complete headers thanks to R. Sweet and P.
-     Ellis.
+         1.7.6                    2013-10-29
 ;
-         1.0.0                    2000-12-21
+       To avoid a conflict with PDB software, remove the null value
+         enumeration for _variant.role (HJB)
 ;
-       Release version - few typos and tidying up.  (BM & HJB)
+         1.7.7                    2014-02-22
+;  Major changes to NeXus mapping to conform to JS functional
+    mapping prototype, add Stoke parameter tags for polarization
+    and beam intensity, and add an new tag for FEL axes (HJB)
 
-       + Move ITEM_TYPE_LIST, ITEM_UNITS_LIST and DICTIONARY_HISTORY to end
-       of dictionary.
-
-       + Alphabetize dictionary.
+       + Add
+       _axis.equipment_component,
+       _diffrn_radiation.polarizn_Stokes_I,
+       _diffrn_radiation.polarizn_Stokes_Q,
+       _diffrn_radiation.polarizn_Stokes_U,
+       _diffrn_radiation.polarizn_Stokes_V,
+       _diffrn_scan_frame.polarizn_Stokes_I,
+       _diffrn_scan_frame.polarizn_Stokes_Q,
+       _diffrn_scan_frame.polarizn_Stokes_U,
+       _diffrn_scan_frame.polarizn_Stokes_V.
+       + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
+       + Update dictionary version
 ;
-         0.7.1                    2000-09-29
+         1.7.8                    2014-02-22
+;  Minor changes to NeXus mapping. (HJB)
+
+       + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
+       NXdetector base class terminology
+
+       + Add _diffrn_detector.gain_setting to handle
+       the reverse mapping from NeXus of the equivalent field in NXdetector.
 ;
-       Cleanup fixes.  (JW)
+         1.7.9                    2014-04-05
+;  Corrections to Stokes parameter description. (HJB)
 
-       + Correct spelling of DIFFRN_MEASUREMENT_AXIS in '_axis.id'
+    + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
+    and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
+        component.
 
-       + Correct ordering of uses of '_item.mandatory_code' and
-       '_item_default.value'.
+    + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
+    description and _diffrn_scan_frame.polarizn_Stokes_V description.
+
 ;
-         0.7.0                    2000-09-09
+         1.8.0                    2021-01-24
+;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+
+    + Add _diffrn_data_frame.center_derived as optional
+    + Add _diffrn_measurement.sample_detector_distance_derived as optional
+    + Change _diffrn_scan.date_start to mandatory
+    + Add _diffrn_scan.date_end_estimated as mandatory
+    + Fix .array_id and .binary_id columns to be implicit in all cases to
+      facilitate mini_cbfs
+
 ;
-   Respond to comments by I. David Brown.  (HJB)
-
-   + Add further comments on '\n' and '\t'.
-
-   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
-     and adding metres.  Change 'meter' to 'metre' throughout.
-
-   + Add missing enumerations to '_array_structure.compression_type'
-     and make 'none' the default.
-
-   + Remove parent-child relationship between
-     '_array_structure_list.index' and '_array_structure_list.precedence'.
-
-   + Improve alphabetization.
-
-   + Fix '_array_intensities.gain_esd' related function.
-
-   + Improve comments in AXIS.
-
-   + Fix DIFFRN_FRAME_DATA example.
-
-   + Remove erroneous DIFFRN_MEASUREMENT example.
-
-   + Add '_diffrn_measurement_axis.id' to the category key.
+         1.8.1                    2021-01-30
 ;
-         0.6.0                    1999-01-14
+       Copy-paste error corrections (JRH)
+
+        + Fix double underscore in _diffrn_data_frame.center_derived
+        + Fix wrong _item.name in _diffrn_scan.date_end_estimated
+        + Fix wrong _item.mandatory_code in _diffrn_scan_frame_monitor.frame_id
+        + Fix wrong _item.mandatory_code in _variant.variant_of
 ;
-   Remove redundant information for ENC_NONE data.  (HJB)
-
-   + After the D5 remove binary section identifier, size and
-     compression type.
-
-   + Add Control-L to header.
+         1.8.2                    2021-02-21
 ;
-         0.5.1                    1999-01-03
+       Corrections and additions for ITVG 2021
+
+        + Add McStas as an axis coordinate system
+        + Add _array_intensities.underload as optional
+        + Add _diffrn_scan_collection.details as optional
+        + Add _diffrn_scan_collection.variant as optional
 ;
-       Cleanup of typos and syntax errors.  (HJB)
+         1.8.3                    2021-02-28
+;   Correction as per Brian McMahon
 
-       + Cleanup example details for DIFFRN_SCAN category.
-
-       + Add missing quote marks for '_diffrn_scan.id' definition.
+    + Fix _item.name for _array_structure_list.array_section_id
+    + Remove spurious _item_aliases.alias_name from
+      _diffrn_radiation.polarisn_ratio_esd
+    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
+    + Provide missing _diffrn_scan_frame_monitor.monitor_value definition
+    + Deprecate _diffrn_scan_frame_monitor.value
 ;
-         0.5.0                    1999-01-01
+         1.8.4                    2021-04-15
+;   Copy-editing refinements (bm)
+
+    + Add _item_related.related_name and
+      "_item_related.function_code replacedby" to deprecated items.
+    + Add "_item_default.value  ." to *_variant items
+    + Change uses of \%Angstroms to \%angstr\"oms
+    + Change category save frames to upper case names
+    + Fix misssing superscript terminating ^
+
+    Preliminary version of external data tags (jrh)
+
+    + Add _array_data.external_format
+    + Add _array_data.external_version
+    + Add _array_data.external_location_uri
+    + Add _array_data.external_path
+    + Add _array_data.external_frame
+    + Add _array_data.external_archive_path
+    + Add _array_data.external_archive_format
+
+    Note the second block of mads is a preliminary version.  When they are
+    done they may well be removed from here and reappear in a 1.8.5
+    dictionary.
+
 ;
-   Modifications for axis definitions and reduction of binary header.  (HJB)
-
-   + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
-
-   + Add AXIS category.
-
-   + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
-     from cif_mm.dic for clarity.
-
-   + Change '_array_structure.encoding_type' from type code to uline and
-     added X-Binary-Element-Type to MIME header.
-
-   + Add detector beam centre '_diffrn_detector_element.center[1]' and
-     '_diffrn_detector_element.center[2]'.
-
-   + Correct item name of '_diffrn_refln.frame_id'.
-
-   + Replace reference to '_array_intensities.undefined' by
-     '_array_intensities.undefined_value'.
-
-   + Replace references to '_array_intensity.scaling' with
-     '_array_intensities.scaling'.
-
-   + Add DIFFRN_SCAN... categories.
+         1.8.5                    2021-07-09
 ;
-         0.4.0                    1998-08-11
+       Handling of external data (jrh, ab, hjb)
+
+        + Remove preliminary versions of external data tags in ARRAY_DATA
+        + Add ARRAY_DATA_EXTERNAL_DATA
+        + Add _array_data.external_data_id
+        + Add _array_data_external_data.format
+        + Add _array_data_external_data.frame
+        + Add _array_data_external_data.id
+        + Add _array_data_external_data.path
+        + Add _array_data_external_data.uri
+        + Add _array_data_external_data.variant
+        + Add _array_data_external_data.version
 ;
-       Modifications to the 0.3 imgCIF draft.  (HJB)
-
-       + Reflow comment lines over 80 characters and corrected typos.
-
-       + Update examples and descriptions of MIME encoded data.
-
-       + Change name to cbfext98.dic.
+         1.8.6                    2022-05-11
 ;
-         0.3.0                    1998-07-04
+       Add missing archive tags to external data tags, clarify use of
+        those tags and correct typos (jrh, hjb)
+
+        + Add _array_data_external_data.archive_format
+        + Add _array_data_external_data.archive_path
 ;
-   Modifications for imgCIF.  (HJB)
+         1.8.7                    2023-01-26
+;   Various additions
 
-   + Add binary type, which is a text field containing a variant on
-     MIME encoded data.
-
-   + Change type of '_array_data.data' to binary and specify internal
-     structure of raw binary data.
-
-   + Add '_array_data.binary_id', and make
-     '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
-     into pointers to this item.
+    + Add _array_data_external_data.file_compression
+      2022-06-09 (jrh).
+    + Fix incorrect _diffrn_scan_axis.angle_range
+      example and clarify definition 2022-06-09 (jrh)
+    + Clarify wording describing _array_intensities.overload 
+      2022-12-31 (ab) 
 ;
-         0.2.0                    1997-12-02
+         1.8.8                    2024-01-20
+;   Additional flux tags and change to ddl2 version being the master
+    instead of the html version being the master.  Make changes to
+    support conversions to DDLm and back to DDL2.  Mark tags aliased
+    from mmCIF_PDBx dictionary.
+
+    + Change from use of _item.type_code to _item_type.code
+    + Fix extraneous single quote after _array_data_external_data.file_compression
+    + Change 'photons per second' to photons_per_second in units
+    + Add micrometres, photons, photons_per_second, and 
+      photons_per_seconf_per_micrometre_squared to units
+    + Add stub DIFFRN category
+    + Add _diffrn.id
+    + Add  _diffrn_radiation.beam_flux_density
+    + Add _diffrn_radiation.beam_flux_density_integrated
+    + Add  _diffrn_radiation.beam_flux_integrated
+    + Add _diffrn_radiation.beam_flux_integration_time
+    + Add _diffrn_radiation.beam_incident_flux
+    + Add _diffrn_radiation.beam_incident_flux_integrated
+    + Add stub DIFFRN_SOURCE category
+    + Add _diffrn_source.diffrn_id
+    + Add _diffrn_source.source
+    + Add _diffrn_source.type
 ;
-   Modifications to the CBF draft.  (JW)
-
-   + Add category hierarchy for describing frame data developed from
-     discussions at the BNL imgCIF Workshop Oct 1997.   The following
-     changes are made in implementing the workshop draft.  Category
-     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
-     DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT.   The
-     parent item for '_diffrn_frame_data.array_id' is changed from
-     '_array_structure_list.array_id' to '_array_structure.id'. Item
-     '_diffrn_detector.array_id' is deleted.
-   + Add data item '_diffrn_frame_data.binary_id' to identify data
-     groups within a binary section.  The formal identification of the
-     binary section is still fuzzy.
+         1.8.8-dev1               2025-05-25
 ;
-         0.1.0                    1997-01-24
+       Minor corrections to 1.8.8 found while working on 1.8.9
 ;
-   First draft of this dictionary in DDL 2.1 compliant format by John
-   Westbrook (JW).  This version is adapted from the Crystallographic
-   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
-   (AH).
+         1.8.8-dev2               2025-06-10
+;
+       Pick up minor type corrections from 1.8.9 dcitionary
+;
+         1.8.9                    2025-06-10
+;
+       Addition of missing diffrn.id pointers
 
-   Modifications to the CBF draft.  (JW)
-
-   + In this version the array description has been cast in the categories
-     ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
-     have been generalized to describe array data  of arbitrary dimension.
-
-   + Array data in this description are contained in the category
-     ARRAY_DATA.  This departs from the CBF notion of data existing
-     in some special comment. In this description, data are handled as an
-     ordinary data item encapsulated in a character data type.   Although
-     data this manner deviates from CIF conventions, it does not violate
-     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
-     the binary representation which will permit some level of data
-     validation.  In this version, the placeholder type code "any" has
-     been used. This translates to a regular expression which will match
-     any pattern.
-
-     It should be noted that DDL 2.1 already supports array data objects
-     although these have not been used in the current mmCIF dictionary.
-     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
-     ITEM_STRUCTURE_LIST categories to provide the information that is
-     carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
-     moving the array structure to the DDL level it would be possible to
-     define an array type as well as a regular expression defining the
-     data format.
-
-   + Multiple array sections can be properly handled within a single
-     datablock.
+        + Add _diffrn_detector_element.diffrn_id
+        + Add _diffrn_measurement_axis.diffrn_id
+        + Add _diffrn_scan.diffrn_id
+        + Add _diffrn_scan_axis.diffrn_id
+        + Add _diffrn_scan_collection.diffrn_id
+        + Add _diffrn_scan_frame.diffrn_id
+        + Add _diffrn_scan_frame_axis.diffrn_id
+        + Add _diffrn_scan_frame_axis.diffrn_id
+        + Add _diffrn_scan_frame_monitor.diffrn_id
 ;

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -781,7 +781,7 @@ save_
 
 save_ARRAY_DATA
 
-    _definition.id                array_data
+    _definition.id                ARRAY_DATA
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -805,7 +805,7 @@ save_ARRAY_DATA
      dictionary will need to be populated.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_data
+    _name.object_id               ARRAY_DATA
     _name.ddl2_mandatory          no
 
     loop_
@@ -985,8 +985,8 @@ save_array_data.array_id
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1016,8 +1016,8 @@ save_array_data.binary_id
     _name.category_id             array_data
     _name.object_id               binary_id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
@@ -1298,8 +1298,8 @@ save_array_data.external_data_id
     _name.object_id               external_data_id
     _name.linked_item_id          '_array_data_external_data.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1373,8 +1373,8 @@ save_array_data.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1384,7 +1384,7 @@ save_
 
 save_ARRAY_DATA_EXTERNAL_DATA
 
-    _definition.id                array_data_external_data
+    _definition.id                ARRAY_DATA_EXTERNAL_DATA
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -1394,7 +1394,7 @@ save_ARRAY_DATA_EXTERNAL_DATA
     use in  ARRAY_DATA that are found external to the cif_img file.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_data_external_data
+    _name.object_id               ARRAY_DATA_EXTERNAL_DATA
     _name.ddl2_mandatory          no
     _category_key.name            '_array_data_external_data.id'
     _nx_mapping.details
@@ -1724,8 +1724,8 @@ save_array_data_external_data.id
     _name.category_id             array_data_external_data
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1823,7 +1823,7 @@ save_
 
 save_ARRAY_ELEMENT_SIZE
 
-    _definition.id                array_element_size
+    _definition.id                ARRAY_ELEMENT_SIZE
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -1832,7 +1832,7 @@ save_ARRAY_ELEMENT_SIZE
      size of array elements along each array dimension.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_element_size
+    _name.object_id               ARRAY_ELEMENT_SIZE
     _name.ddl2_mandatory          no
 
     loop_
@@ -1908,8 +1908,8 @@ save_array_element_size.index
     _name.object_id               index
     _name.linked_item_id          '_array_structure_list.index'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
@@ -1956,8 +1956,8 @@ save_array_element_size.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1967,7 +1967,7 @@ save_
 
 save_ARRAY_INTENSITIES
 
-    _definition.id                array_intensities
+    _definition.id                ARRAY_INTENSITIES
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -1987,7 +1987,7 @@ save_ARRAY_INTENSITIES
      and _array_intensities.gain will not be used.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_intensities
+    _name.object_id               ARRAY_INTENSITIES
     _name.ddl2_mandatory          no
 
     loop_
@@ -2086,8 +2086,8 @@ save_array_intensities.array_id
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -2105,8 +2105,8 @@ save_array_intensities.binary_id
     _name.object_id               binary_id
     _name.linked_item_id          '_array_data.binary_id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
@@ -2515,8 +2515,8 @@ save_array_intensities.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -2526,7 +2526,7 @@ save_
 
 save_ARRAY_STRUCTURE
 
-    _definition.id                array_structure
+    _definition.id                ARRAY_STRUCTURE
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -2535,7 +2535,7 @@ save_ARRAY_STRUCTURE
      encoding of array data that may be stored in the ARRAY_DATA category.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_structure
+    _name.object_id               ARRAY_STRUCTURE
     _name.ddl2_mandatory          no
 
     loop_
@@ -2751,8 +2751,8 @@ save_array_structure.id
     _name.category_id             array_structure
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -2777,8 +2777,8 @@ save_array_structure.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -2788,7 +2788,7 @@ save_
 
 save_ARRAY_STRUCTURE_LIST
 
-    _definition.id                array_structure_list
+    _definition.id                ARRAY_STRUCTURE_LIST
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -2798,7 +2798,7 @@ save_ARRAY_STRUCTURE_LIST
      The relationship to physical axes may be given.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_structure_list
+    _name.object_id               ARRAY_STRUCTURE_LIST
     _name.ddl2_mandatory          no
 
     loop_
@@ -3009,8 +3009,8 @@ save_array_structure_list.array_id
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3056,8 +3056,8 @@ save_array_structure_list.axis_set_id
     _name.category_id             array_structure_list
     _name.object_id               axis_set_id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3127,8 +3127,8 @@ save_array_structure_list.index
     _name.category_id             array_structure_list
     _name.object_id               index
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
@@ -3186,8 +3186,8 @@ save_array_structure_list.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3197,7 +3197,7 @@ save_
 
 save_ARRAY_STRUCTURE_LIST_AXIS
 
-    _definition.id                array_structure_list_axis
+    _definition.id                ARRAY_STRUCTURE_LIST_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -3220,7 +3220,7 @@ save_ARRAY_STRUCTURE_LIST_AXIS
      of an array.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_structure_list_axis
+    _name.object_id               ARRAY_STRUCTURE_LIST_AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -3495,8 +3495,8 @@ save_array_structure_list_axis.axis_id
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3524,8 +3524,8 @@ save_array_structure_list_axis.axis_set_id
     _name.object_id               axis_set_id
     _name.linked_item_id          '_array_structure_list.axis_set_id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3721,8 +3721,8 @@ save_array_structure_list_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3732,7 +3732,7 @@ save_
 
 save_ARRAY_STRUCTURE_LIST_SECTION
 
-    _definition.id                array_structure_list_section
+    _definition.id                ARRAY_STRUCTURE_LIST_SECTION
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -3759,7 +3759,7 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     by the stride.
 ;
     _name.category_id             HEAD
-    _name.object_id               array_structure_list_section
+    _name.object_id               ARRAY_STRUCTURE_LIST_SECTION
     _name.ddl2_mandatory          no
 
     loop_
@@ -3846,8 +3846,8 @@ save_array_structure_list_section.array_id
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3904,8 +3904,8 @@ save_array_structure_list_section.id
     _name.category_id             array_structure_list_section
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3931,8 +3931,8 @@ save_array_structure_list_section.index
     _name.object_id               index
     _name.linked_item_id          '_array_structure_list.index'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
@@ -4043,7 +4043,7 @@ save_
 
 save_AXIS
 
-    _definition.id                axis
+    _definition.id                AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -4384,7 +4384,7 @@ save_AXIS
      Brookhaven National Laboratory.
 ;
     _name.category_id             HEAD
-    _name.object_id               axis
+    _name.object_id               AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -5937,8 +5937,8 @@ save_axis.id
     _name.category_id             axis
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6157,8 +6157,8 @@ save_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6237,7 +6237,7 @@ save_
 
 save_DIFFRN
 
-    _definition.id                diffrn
+    _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2025-09-04
@@ -6251,7 +6251,7 @@ save_DIFFRN
                dictionary
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn
+    _name.object_id               DIFFRN
     _name.ddl2_mandatory          no
     _category_key.name            '_diffrn.id'
 
@@ -6276,8 +6276,8 @@ save_diffrn.id
     _name.category_id             diffrn
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6286,7 +6286,7 @@ save_
 
 save_DIFFRN_DATA_FRAME
 
-    _definition.id                diffrn_data_frame
+    _definition.id                DIFFRN_DATA_FRAME
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -6299,7 +6299,7 @@ save_DIFFRN_DATA_FRAME
               as aliases but should not be used for new work.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_data_frame
+    _name.object_id               DIFFRN_DATA_FRAME
     _name.ddl2_mandatory          no
 
     loop_
@@ -6412,8 +6412,8 @@ save_diffrn_data_frame.array_id
     _name.object_id               array_id
     _name.linked_item_id          '_array_structure.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6431,8 +6431,8 @@ save_diffrn_data_frame.array_section_id
     _name.object_id               array_section_id
     _name.linked_item_id          '_array_structure_list_section.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6454,12 +6454,11 @@ save_diffrn_data_frame.binary_id
     _name.object_id               binary_id
     _name.linked_item_id          '_array_data.binary_id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Number
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
-    _units.code                   none
 
 save_
 
@@ -6663,8 +6662,8 @@ save_diffrn_data_frame.detector_element_id
     _name.object_id               detector_element_id
     _name.linked_item_id          '_diffrn_detector_element.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6682,8 +6681,8 @@ save_diffrn_data_frame.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6704,8 +6703,8 @@ save_diffrn_data_frame.id
     _name.category_id             diffrn_data_frame
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6729,8 +6728,8 @@ save_diffrn_data_frame.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6740,7 +6739,7 @@ save_
 
 save_DIFFRN_DETECTOR
 
-    _definition.id                diffrn_detector
+    _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2025-09-04
@@ -6751,7 +6750,7 @@ save_DIFFRN_DETECTOR
      any analyser and post-sample collimation.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_detector
+    _name.object_id               DIFFRN_DETECTOR
     _name.ddl2_mandatory          no
 
     loop_
@@ -6871,8 +6870,8 @@ save_diffrn_detector.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6955,8 +6954,8 @@ save_diffrn_detector.id
     _name.category_id             diffrn_detector
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7067,8 +7066,8 @@ save_diffrn_detector.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7078,7 +7077,7 @@ save_
 
 save_DIFFRN_DETECTOR_AXIS
 
-    _definition.id                diffrn_detector_axis
+    _definition.id                DIFFRN_DETECTOR_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -7087,7 +7086,7 @@ save_DIFFRN_DETECTOR_AXIS
      axes with detectors.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_detector_axis
+    _name.object_id               DIFFRN_DETECTOR_AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -7127,8 +7126,8 @@ save_diffrn_detector_axis.axis_id
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7154,8 +7153,8 @@ save_diffrn_detector_axis.detector_id
     _name.object_id               detector_id
     _name.linked_item_id          '_diffrn_detector.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7173,8 +7172,8 @@ save_diffrn_detector_axis.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7218,8 +7217,8 @@ save_diffrn_detector_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7229,7 +7228,7 @@ save_
 
 save_DIFFRN_DETECTOR_ELEMENT
 
-    _definition.id                diffrn_detector_element
+    _definition.id                DIFFRN_DETECTOR_ELEMENT
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -7244,7 +7243,7 @@ save_DIFFRN_DETECTOR_ELEMENT
      detector element.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_detector_element
+    _name.object_id               DIFFRN_DETECTOR_ELEMENT
     _name.ddl2_mandatory          no
 
     loop_
@@ -7427,8 +7426,8 @@ save_diffrn_detector_element.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7445,8 +7444,8 @@ save_diffrn_detector_element.id
     _name.category_id             diffrn_detector_element
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7578,8 +7577,8 @@ save_diffrn_detector_element.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7589,7 +7588,7 @@ save_
 
 save_DIFFRN_FRAME_DATA
 
-    _definition.id                diffrn_frame_data
+    _definition.id                DIFFRN_FRAME_DATA
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2025-09-04
@@ -7618,7 +7617,7 @@ save_DIFFRN_FRAME_DATA
      All _item.mandatory_code values have been changed to 'no'.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_frame_data
+    _name.object_id               DIFFRN_FRAME_DATA
     _name.ddl2_mandatory          no
 
     loop_
@@ -7775,7 +7774,7 @@ save_
 
 save_DIFFRN_MEASUREMENT
 
-    _definition.id                diffrn_measurement
+    _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2025-09-04
@@ -7787,7 +7786,7 @@ save_DIFFRN_MEASUREMENT
      diffraction data were measured.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_measurement
+    _name.object_id               DIFFRN_MEASUREMENT
     _name.ddl2_mandatory          no
 
     loop_
@@ -7916,8 +7915,8 @@ save_diffrn_measurement.device
     _name.category_id             diffrn_measurement
     _name.object_id               device
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
@@ -7998,8 +7997,8 @@ save_diffrn_measurement.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8028,8 +8027,8 @@ save_diffrn_measurement.id
     _name.category_id             diffrn_measurement
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8207,8 +8206,8 @@ save_diffrn_measurement.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8218,7 +8217,7 @@ save_
 
 save_DIFFRN_MEASUREMENT_AXIS
 
-    _definition.id                diffrn_measurement_axis
+    _definition.id                DIFFRN_MEASUREMENT_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -8227,7 +8226,7 @@ save_DIFFRN_MEASUREMENT_AXIS
      axes with goniometers.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_measurement_axis
+    _name.object_id               DIFFRN_MEASUREMENT_AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -8273,8 +8272,8 @@ save_diffrn_measurement_axis.axis_id
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8324,8 +8323,8 @@ save_diffrn_measurement_axis.measurement_device
     _name.object_id               measurement_device
     _name.linked_item_id          '_diffrn_measurement.device'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
@@ -8351,8 +8350,8 @@ save_diffrn_measurement_axis.measurement_id
     _name.object_id               measurement_id
     _name.linked_item_id          '_diffrn_measurement.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8376,8 +8375,8 @@ save_diffrn_measurement_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -8387,7 +8386,7 @@ save_
 
 save_DIFFRN_RADIATION
 
-    _definition.id                diffrn_radiation
+    _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2025-09-04
@@ -8400,7 +8399,7 @@ save_DIFFRN_RADIATION
               items in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_radiation
+    _name.object_id               DIFFRN_RADIATION
     _name.ddl2_mandatory          no
 
     loop_
@@ -8739,8 +8738,8 @@ save_diffrn_radiation.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9651,8 +9650,8 @@ save_diffrn_radiation.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9711,7 +9710,7 @@ save_
 
 save_DIFFRN_REFLN
 
-    _definition.id                diffrn_refln
+    _definition.id                DIFFRN_REFLN
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -9732,7 +9731,7 @@ save_DIFFRN_REFLN
      _diffrn_refln.frame_id
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_refln
+    _name.object_id               DIFFRN_REFLN
     _name.ddl2_mandatory          no
 
     loop_
@@ -9765,8 +9764,8 @@ save_diffrn_refln.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9784,8 +9783,8 @@ save_diffrn_refln.frame_id
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9827,8 +9826,8 @@ save_diffrn_refln.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9848,7 +9847,7 @@ save_
 
 save_DIFFRN_SCAN
 
-    _definition.id                diffrn_scan
+    _definition.id                DIFFRN_SCAN
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -9857,7 +9856,7 @@ save_DIFFRN_SCAN
      or more scans, relating axis positions to frames.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan
+    _name.object_id               DIFFRN_SCAN
     _name.ddl2_mandatory          no
 
     loop_
@@ -10574,8 +10573,8 @@ save_diffrn_scan.frame_id_end
     _name.object_id               frame_id_end
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -10596,8 +10595,8 @@ save_diffrn_scan.frame_id_start
     _name.object_id               frame_id_start
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -10641,8 +10640,8 @@ save_diffrn_scan.id
     _name.category_id             diffrn_scan
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -10751,8 +10750,8 @@ save_diffrn_scan.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -10762,7 +10761,7 @@ save_
 
 save_DIFFRN_SCAN_AXIS
 
-    _definition.id                diffrn_scan_axis
+    _definition.id                DIFFRN_SCAN_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -10772,7 +10771,7 @@ save_DIFFRN_SCAN_AXIS
      their zero points.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan_axis
+    _name.object_id               DIFFRN_SCAN_AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -10955,8 +10954,8 @@ save_diffrn_scan_axis.axis_id
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11170,8 +11169,8 @@ save_diffrn_scan_axis.scan_id
     _name.object_id               scan_id
     _name.linked_item_id          '_diffrn_scan.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11195,8 +11194,8 @@ save_diffrn_scan_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11206,7 +11205,7 @@ save_
 
 save_DIFFRN_SCAN_COLLECTION
 
-    _definition.id                diffrn_scan_collection
+    _definition.id                DIFFRN_SCAN_COLLECTION
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -11218,7 +11217,7 @@ save_DIFFRN_SCAN_COLLECTION
      synchrotron and XFEL collection strategies evolve.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan_collection
+    _name.object_id               DIFFRN_SCAN_COLLECTION
     _name.ddl2_mandatory          no
 
     loop_
@@ -11290,8 +11289,8 @@ save_diffrn_scan_collection.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11383,8 +11382,8 @@ save_diffrn_scan_collection.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11394,7 +11393,7 @@ save_
 
 save_DIFFRN_SCAN_FRAME
 
-    _definition.id                diffrn_scan_frame
+    _definition.id                DIFFRN_SCAN_FRAME
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -11403,7 +11402,7 @@ save_DIFFRN_SCAN_FRAME
      the relationships of particular frames to scans.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan_frame
+    _name.object_id               DIFFRN_SCAN_FRAME
     _name.ddl2_mandatory          no
 
     loop_
@@ -11479,8 +11478,8 @@ save_diffrn_scan_frame.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11501,8 +11500,8 @@ save_diffrn_scan_frame.frame_id
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11902,8 +11901,8 @@ save_diffrn_scan_frame.scan_id
     _name.object_id               scan_id
     _name.linked_item_id          '_diffrn_scan.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11984,8 +11983,8 @@ save_diffrn_scan_frame.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11995,7 +11994,7 @@ save_
 
 save_DIFFRN_SCAN_FRAME_AXIS
 
-    _definition.id                diffrn_scan_frame_axis
+    _definition.id                DIFFRN_SCAN_FRAME_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -12008,7 +12007,7 @@ save_DIFFRN_SCAN_FRAME_AXIS
      simply inferred from values in DIFFRN_SCAN_AXIS.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan_frame_axis
+    _name.object_id               DIFFRN_SCAN_FRAME_AXIS
     _name.ddl2_mandatory          no
 
     loop_
@@ -12161,8 +12160,8 @@ save_diffrn_scan_frame_axis.axis_id
     _name.object_id               axis_id
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12180,8 +12179,8 @@ save_diffrn_scan_frame_axis.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12281,8 +12280,8 @@ save_diffrn_scan_frame_axis.frame_id
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12363,8 +12362,8 @@ save_diffrn_scan_frame_axis.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12374,7 +12373,7 @@ save_
 
 save_DIFFRN_SCAN_FRAME_MONITOR
 
-    _definition.id                diffrn_scan_frame_monitor
+    _definition.id                DIFFRN_SCAN_FRAME_MONITOR
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -12405,7 +12404,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      omitted.
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_scan_frame_monitor
+    _name.object_id               DIFFRN_SCAN_FRAME_MONITOR
     _name.ddl2_mandatory          no
 
     loop_
@@ -12538,8 +12537,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
       MONITOR_Z        translation detector . 0 0 1 0 0 0
 ;
     _description_example.detail
-;
-    Example 1. The beam intensity for frame FRAME1 is being tracked
+;    Example 1. The beam intensity for frame FRAME1 is being tracked
      by a beamstop monitor detector BSM01, made from metal foil and
      a PIN diode, located 20 mm in front of a MAR345 detector and being
      sampled every 2 seconds in a 20 second scan.
@@ -12583,8 +12581,8 @@ save_diffrn_scan_frame_monitor.detector_id
     _name.object_id               detector_id
     _name.linked_item_id          '_diffrn_detector.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12602,8 +12600,8 @@ save_diffrn_scan_frame_monitor.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12621,8 +12619,8 @@ save_diffrn_scan_frame_monitor.frame_id
     _name.object_id               frame_id
     _name.linked_item_id          '_diffrn_data_frame.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12781,8 +12779,8 @@ save_diffrn_scan_frame_monitor.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12792,7 +12790,7 @@ save_
 
 save_DIFFRN_SOURCE
 
-    _definition.id                diffrn_source
+    _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2025-09-04
@@ -12804,7 +12802,7 @@ save_DIFFRN_SOURCE
                specified in the mmCIF_PDBx dictionary
 ;
     _name.category_id             HEAD
-    _name.object_id               diffrn_source
+    _name.object_id               DIFFRN_SOURCE
     _name.ddl2_mandatory          no
     _category_key.name            '_diffrn_source.diffrn_id'
 
@@ -12902,7 +12900,7 @@ save_
 
 save_MAP
 
-    _definition.id                map
+    _definition.id                MAP
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -12919,7 +12917,7 @@ save_MAP
      Examples are given in the MAP_SEGMENT category.
 ;
     _name.category_id             HEAD
-    _name.object_id               map
+    _name.object_id               MAP
     _name.ddl2_mandatory          no
 
     loop_
@@ -13007,8 +13005,8 @@ save_map.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13043,8 +13041,8 @@ save_map.id
     _name.category_id             map
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13068,8 +13066,8 @@ save_map.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13079,7 +13077,7 @@ save_
 
 save_MAP_SEGMENT
 
-    _definition.id                map_segment
+    _definition.id                MAP_SEGMENT
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -13088,7 +13086,7 @@ save_MAP_SEGMENT
      the details about each segment (section or brick) of a map.
 ;
     _name.category_id             HEAD
-    _name.object_id               map_segment
+    _name.object_id               MAP_SEGMENT
     _name.ddl2_mandatory          no
 
     loop_
@@ -13169,8 +13167,8 @@ save_map_segment.array_section_id
     _name.object_id               array_section_id
     _name.linked_item_id          '_array_structure_list_section.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13234,8 +13232,8 @@ save_map_segment.id
     _name.object_id               id
     _name.linked_item_id          '_map.id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13350,8 +13348,8 @@ save_map_segment.variant
     _name.object_id               variant
     _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13361,7 +13359,7 @@ save_
 
 save_VARIANT
 
-    _definition.id                variant
+    _definition.id                VARIANT
     _definition.scope             Category
     _definition.class             Loop
     _description.text
@@ -13406,7 +13404,7 @@ save_VARIANT
      be used.
 ;
     _name.category_id             HEAD
-    _name.object_id               variant
+    _name.object_id               VARIANT
     _name.ddl2_mandatory          no
 
     loop_
@@ -13485,8 +13483,7 @@ save_variant.details
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
-    _description_example.case
-        'indexed cell and refined beam centre'
+    _description_example.case     'indexed cell and refined beam centre'
 
 save_
 
@@ -13501,8 +13498,8 @@ save_variant.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -13606,8 +13603,8 @@ save_variant.variant
     _name.category_id             variant
     _name.object_id               variant
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -5,7 +5,7 @@ data_CIF_IMG
     _dictionary.title             CIF_IMG
     _dictionary.class             Instance
     _dictionary.version           1.8.9
-    _dictionary.date              2025-09-15
+    _dictionary.date              2025-09-16
     _dictionary.ddl_conformance   3.14.0
     _dictionary.namespace         Ddlm
     _description.text
@@ -6148,7 +6148,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-15
+    _definition.update            2025-09-16
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6639,7 +6639,7 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-15
+    _definition.update            2025-09-16
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -7369,61 +7369,12 @@ save_diffrn_detector_element.variant
 
 save_
 
-save_DIFFRN_FRAME_DATA
-
-    _definition.id                DIFFRN_FRAME_DATA
-    _definition.scope             Category
-    _definition.class             Loop
-    _description.text
-;
-    Data items in the DIFFRN_FRAME_DATA category record
-     the details about each frame of data.
-
-     The items in this category are now in the
-     DIFFRN_DATA_FRAME category.
-
-     The items in the DIFFRN_FRAME_DATA category
-     are now deprecated.  The items from this category
-     are provided as aliases in the 1.0 dictionary
-     or, in the case of _diffrn_frame_data.details,
-     in the 1.4 dictionary.  THESE ITEMS SHOULD NOT
-     BE USED FOR NEW WORK.
-
-     The items from the old category are provided
-     in this dictionary for completeness
-     but should not be used or cited.  To avoid
-     confusion, the example has been removed
-     and the redundant parent-child links to other
-     categories have been removed.
-
-     All _item.mandatory_code values have been changed to 'no'.
-;
-    _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_FRAME_DATA
-    _name.ddl2_mandatory          No
-
-    loop_
-      _category_key.name
-         '_diffrn_frame_data.id'
-         '_diffrn_frame_data.detector_element_id'
-
-    _description_example.case
-;
-    # EXAMPLE REMOVED #
-;
-    _description_example.detail
-;
-    THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
-;
-
-save_
-
 save_DIFFRN_MEASUREMENT
 
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-15
+    _definition.update            2025-09-16
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -7928,7 +7879,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-15
+    _definition.update            2025-09-16
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -12079,7 +12030,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-15
+    _definition.update            2025-09-16
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -13554,7 +13505,7 @@ save_
 ;
        Pick up minor type corrections from 1.8.9 dcitionary
 ;
-         1.8.9                    2025-09-15
+         1.8.9                    2025-09-16
 ;   Addition of missing diffrn.id pointers
 
     + Add _diffrn_detector_element.diffrn_id

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -5,7 +5,7 @@ data_CIF_IMG
     _dictionary.title             CIF_IMG
     _dictionary.class             Instance
     _dictionary.version           1.8.9
-    _dictionary.date              2025-06-10
+    _dictionary.date              2025-09-12
     _dictionary.ddl_conformance   3.14.0
     _dictionary.namespace         Ddlm
     _description.text
@@ -1265,6 +1265,7 @@ save_array_data.data
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Array
+    _type.dimension               '[]'
     _type.contents                Complex
     _type.ddl2_code               Binary
     _units.code                   none
@@ -1893,6 +1894,7 @@ save_array_element_size.index
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               Int
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -2065,6 +2067,7 @@ save_array_intensities.array_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               Code
+    _enumeration.default          1
 
 save_
 
@@ -2084,6 +2087,8 @@ save_array_intensities.binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               Int
+    _enumeration.range            1:
+    _enumeration.default          1
     _units.code                   none
 
 save_
@@ -2967,6 +2972,7 @@ save_array_structure_list.array_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               Code
+    _enumeration.default          1
 
 save_
 
@@ -3777,6 +3783,7 @@ save_array_structure_list_section.array_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               Code
+    _enumeration.default          1
 
 save_
 
@@ -3856,6 +3863,7 @@ save_array_structure_list_section.index
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               Int
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -6141,7 +6149,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-11
+    _definition.update            2025-09-12
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6303,6 +6311,7 @@ save_diffrn_data_frame.array_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               Code
+    _enumeration.default          1
 
 save_
 
@@ -6345,6 +6354,8 @@ save_diffrn_data_frame.binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               Int
+    _enumeration.range            1:
+    _enumeration.default          1
     _units.code                   none
 
 save_
@@ -6629,7 +6640,7 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-11
+    _definition.update            2025-09-12
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -7467,7 +7478,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-11
+    _definition.update            2025-09-12
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -8041,7 +8052,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-11
+    _definition.update            2025-09-12
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -12192,7 +12203,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-11
+    _definition.update            2025-09-12
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -13728,17 +13739,22 @@ save_
 ;
        Pick up minor type corrections from 1.8.9 dcitionary
 ;
-         1.8.9                    2025-06-10
-;
-       Addition of missing diffrn.id pointers
+         1.8.9                    2025-09-12
+;   Addition of missing diffrn.id pointers
 
-        + Add _diffrn_detector_element.diffrn_id
-        + Add _diffrn_measurement_axis.diffrn_id
-        + Add _diffrn_scan.diffrn_id
-        + Add _diffrn_scan_axis.diffrn_id
-        + Add _diffrn_scan_collection.diffrn_id
-        + Add _diffrn_scan_frame.diffrn_id
-        + Add _diffrn_scan_frame_axis.diffrn_id
-        + Add _diffrn_scan_frame_axis.diffrn_id
-        + Add _diffrn_scan_frame_monitor.diffrn_id
+    + Add _diffrn_detector_element.diffrn_id
+    + Add _diffrn_measurement_axis.diffrn_id
+    + Add _diffrn_scan.diffrn_id
+    + Add _diffrn_scan_axis.diffrn_id
+    + Add _diffrn_scan_collection.diffrn_id
+    + Add _diffrn_scan_frame.diffrn_id
+    + Add _diffrn_scan_frame_axis.diffrn_id
+    + Add _diffrn_scan_frame_axis.diffrn_id
+    + Add _diffrn_scan_frame_monitor.diffrn_id
+     (DDLm conversion) Specified Set categories ["diffrn_radiation", "diffrn_measurement", "diffrn_detector", "diffrn", "diffrn_source"]
+
+     (DDLm conversion) Removed redundant aliases and definitions for aliased data names ["_diffrn_frame_data.binary_id", "_diffrn_frame_data.id", "_diffrn_scan_frame_monitor.value", "_diffrn_frame_data.details", "_diffrn_measurement_axis.id", "_diffrn_frame_data.array_id", "_diffrn_frame_data.detector_element_id", "_diffrn_detector_axis.id"]
+
+     (DDLm conversion) Removed DDL2-only categories
+
 ;

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -964,11 +964,6 @@ save_ARRAY_DATA
             @CBF_header_convention="HEADERCONVENTION"
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
 save_
 
 save_array_data.array_id
@@ -1023,12 +1018,6 @@ save_array_data.binary_id
     _type.ddl2_code               int
     _enumeration.range            1:
     _enumeration.default          1
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
 
 save_
 
@@ -1431,11 +1420,6 @@ save_ARRAY_DATA_EXTERNAL_DATA
             @CBF_external_data_path="DATAPATH"
             @CBF_external_data_frame="DATAFRAME"
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
 
 save_
 
@@ -1872,11 +1856,6 @@ save_ARRAY_ELEMENT_SIZE
     _array_element_size.index == 1,2, or 3 respectively
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
 save_
 
 save_array_element_size.array_id
@@ -1934,8 +1913,6 @@ save_array_element_size.size
     _type.ddl2_code               float
     _type.ddl2_units              metres
     _units.code                   metres
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -2068,11 +2045,6 @@ save_ARRAY_INTENSITIES
     both uses.
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
 save_
 
 save_array_intensities.array_id
@@ -2150,10 +2122,6 @@ save_array_intensities.gain
     _type.ddl2_code               float
     _type.ddl2_units              counts_per_photon
     _units.code                   counts_per_photon
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
-    _ddl2_item_related.related_name '_array_intensities.gain_esd'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -2175,10 +2143,6 @@ save_array_intensities.gain_esd
     _type.ddl2_code               float
     _type.ddl2_units              counts_per_photon
     _units.code                   counts_per_photon
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
-    _ddl2_item_related.related_name '_array_intensities.gain'
-    _ddl2_item_related.function_code associated_esd
 
 save_
 
@@ -2396,8 +2360,6 @@ save_array_intensities.pixel_fast_bin_size
     _type.ddl2_units              pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -2429,8 +2391,6 @@ save_array_intensities.pixel_slow_bin_size
     _type.ddl2_units              pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -2566,11 +2526,6 @@ save_ARRAY_STRUCTURE
     At present NeXus does not expose this information.  This should be
     discussed.
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
 
 save_
 
@@ -2991,11 +2946,6 @@ save_ARRAY_STRUCTURE_LIST
            same ordering.
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
 save_
 
 save_array_structure_list.array_id
@@ -3082,12 +3032,6 @@ save_array_structure_list.dimension
     _enumeration.range            1:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
-
 save_
 
 save_array_structure_list.direction
@@ -3134,12 +3078,6 @@ save_array_structure_list.index
     _type.ddl2_code               int
     _enumeration.range            1:
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
-
 save_
 
 save_array_structure_list.precedence
@@ -3160,12 +3098,6 @@ save_array_structure_list.precedence
     _type.ddl2_code               int
     _enumeration.range            1:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
 
 save_
 
@@ -3388,11 +3320,6 @@ save_ARRAY_STRUCTURE_LIST_AXIS
            and the array section information will be organized by the
            same ordering.
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
 
 save_
 
@@ -3828,11 +3755,6 @@ save_ARRAY_STRUCTURE_LIST_SECTION
              /data_stride[...] the strides of ARRAYSECTIONID
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
 save_
 
 save_array_structure_list_section.array_id
@@ -3881,12 +3803,6 @@ save_array_structure_list_section.end
     _type.ddl2_code               int
     _enumeration.range            1:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
 
 save_
 
@@ -3977,12 +3893,6 @@ save_array_structure_list_section.start
     _enumeration.range            1:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
-
 save_
 
 save_array_structure_list_section.stride
@@ -4006,12 +3916,6 @@ save_array_structure_list_section.stride
     _enumeration.range            1:
     _enumeration.default          1
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
 
 save_
 
@@ -5847,12 +5751,6 @@ for AXISEQUIPMENT=="general"}
               @vector=coordxform([V1,V2,V3])
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         axis_group
-         diffrn_group
-
 save_
 
 save_axis.depends_on
@@ -5965,7 +5863,6 @@ save_axis.offset[1]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5989,7 +5886,6 @@ save_axis.offset[2]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -6013,7 +5909,6 @@ save_axis.offset[3]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -6185,7 +6080,6 @@ save_axis.vector[1]
     _type.ddl2_code               float
     _enumeration.default          0.0
     _units.code                   none
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -6208,7 +6102,6 @@ save_axis.vector[2]
     _type.ddl2_code               float
     _enumeration.default          0.0
     _units.code                   none
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -6231,7 +6124,6 @@ save_axis.vector[3]
     _type.ddl2_code               float
     _enumeration.default          0.0
     _units.code                   none
-    _ddl2_sub_category.id         vector
 
 save_
 
@@ -6240,7 +6132,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-04
+    _definition.update            2025-09-05
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6254,11 +6146,6 @@ save_DIFFRN
     _name.object_id               DIFFRN
     _name.ddl2_mandatory          no
     _category_key.name            '_diffrn.id'
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -6388,12 +6275,6 @@ save_DIFFRN_DATA_FRAME
     and a fast index of the number of detector elements.  There is a middle
     index for CENTERARRAY in the order fast and then slow.
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-         diffrn_group
 
 save_
 
@@ -6742,7 +6623,7 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-04
+    _definition.update            2025-09-05
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -6793,11 +6674,6 @@ save_DIFFRN_DETECTOR
               /description="DETTYPE"
               /gain_setting="GAINSETTING"
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -6906,12 +6782,6 @@ save_diffrn_detector.dtime
     _enumeration.range            0.0:
     _units.code                   microseconds
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_detector.gain_setting
@@ -6981,12 +6851,6 @@ save_diffrn_detector.layer_thickness
     _enumeration.range            0.0:
     _units.code                   millimetres
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_detector.number_of_axes
@@ -7019,12 +6883,6 @@ save_diffrn_detector.number_of_axes
     _type.ddl2_code               int
     _enumeration.range            1:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        .
-         1                        1
 
 save_
 
@@ -7108,11 +6966,6 @@ This information normally will duplicate information obtained from
 the ARRAY_STRUCTURE_LIST_AXIS.
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_detector_axis.axis_id
@@ -7174,26 +7027,6 @@ save_diffrn_detector_axis.diffrn_id
     _name.ddl2_mandatory          implicit
     _type.purpose                 Link
     _type.source                  Related
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               code
-
-save_
-
-save_diffrn_detector_axis.id
-
-    _definition.id                '_diffrn_detector_axis.id'
-    _description.text
-;             This data item is a pointer to _diffrn_detector.id in
-              the DIFFRN_DETECTOR category.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_detector_axis
-    _name.object_id               id
-    _name.ddl2_mandatory          no
-    _type.purpose                 Describe
-    _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7309,12 +7142,6 @@ save_DIFFRN_DETECTOR_ELEMENT
      inserts ELEMENTID into the colon-separated list of units
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-         diffrn_group
-
 save_
 
 save_diffrn_detector_element.center[1]
@@ -7351,9 +7178,6 @@ save_diffrn_detector_element.center[1]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
-    _ddl2_sub_category.id         vector
-    _ddl2_item_related.related_name '_diffrn_data_frame.center_fast'
-    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -7391,9 +7215,6 @@ save_diffrn_detector_element.center[2]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
-    _ddl2_sub_category.id         vector
-    _ddl2_item_related.related_name '_diffrn_data_frame.center_slow'
-    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -7591,7 +7412,6 @@ save_DIFFRN_FRAME_DATA
     _definition.id                DIFFRN_FRAME_DATA
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-04
     _description.text
 ;
     Data items in the DIFFRN_FRAME_DATA category record
@@ -7624,7 +7444,6 @@ save_DIFFRN_FRAME_DATA
       _category_key.name
          '_diffrn_frame_data.id'
          '_diffrn_frame_data.detector_element_id'
-         '_diffrn_frame_data.diffrn_id'
 
     _description_example.case
 ;
@@ -7635,141 +7454,6 @@ save_DIFFRN_FRAME_DATA
     THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-
-save_
-
-save_diffrn_frame_data.array_id
-
-    _definition.id                '_diffrn_frame_data.array_id'
-    _description.text
-;             This item is a pointer to _array_structure.id in the
-              ARRAY_STRUCTURE category.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               array_id
-    _name.ddl2_mandatory          no
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               code
-    _ddl2_item_related.related_name '_diffrn_data_frame.array_id'
-    _ddl2_item_related.function_code replacedby
-
-save_
-
-save_diffrn_frame_data.binary_id
-
-    _definition.id                '_diffrn_frame_data.binary_id'
-    _description.text
-;             This item is a pointer to _array_data.binary_id in the
-              ARRAY_STRUCTURE category.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               binary_id
-    _name.ddl2_mandatory          implicit
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _type.ddl2_code               int
-    _units.code                   none
-    _ddl2_item_related.related_name '_diffrn_data_frame.binary_id'
-    _ddl2_item_related.function_code replacedby
-
-save_
-
-save_diffrn_frame_data.details
-
-    _definition.id                '_diffrn_frame_data.details'
-    _description.text
-;             The value of _diffrn_frame_data.details should give a
-              description of special aspects of each frame of data.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               details
-    _name.ddl2_mandatory          no
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               text
-    _ddl2_item_related.related_name '_diffrn_data_frame.details'
-    _ddl2_item_related.function_code replacedby
-
-save_
-
-save_diffrn_frame_data.detector_element_id
-
-    _definition.id                '_diffrn_frame_data.detector_element_id'
-    _description.text
-;             This item is a pointer to _diffrn_detector_element.id
-              in the DIFFRN_DETECTOR_ELEMENT category.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               detector_element_id
-    _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               code
-    _ddl2_item_related.related_name '_diffrn_data_frame.detector_element_id'
-    _ddl2_item_related.function_code replacedby
-
-save_
-
-save_diffrn_frame_data.diffrn_id
-
-    _definition.id                '_diffrn_frame_data.diffrn_id'
-    _definition.update            2025-09-04
-    _description.text
-;
-    Identifier for data collection conditions. Values of this item are drawn
-    from values of _diffrn.id.
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_diffrn_frame_data.id
-
-    _definition.id                '_diffrn_frame_data.id'
-    _description.text
-;             The value of _diffrn_frame_data.id must uniquely identify
-              each complete frame of data.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_frame_data
-    _name.object_id               id
-    _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               code
-    _ddl2_item_related.related_name '_diffrn_data_frame.id'
-    _ddl2_item_related.function_code replacedby
-
 save_
 
 save_DIFFRN_MEASUREMENT
@@ -7777,7 +7461,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-04
+    _definition.update            2025-09-05
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -7857,11 +7541,6 @@ save_DIFFRN_MEASUREMENT
         /CBF_diffrn_measurement__sample_detector_voffset=VOFST
           @units="mm"    
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -8081,12 +7760,6 @@ save_diffrn_measurement.number_of_axes
     _enumeration.range            1:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        .
-         1                        1
-
 save_
 
 save_diffrn_measurement.sample_detector_distance
@@ -8108,8 +7781,6 @@ save_diffrn_measurement.sample_detector_distance
     _type.ddl2_code               float
     _type.ddl2_units              millimetres
     _units.code                   millimetres
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -8155,8 +7826,6 @@ save_diffrn_measurement.sample_detector_voffset
     _type.ddl2_units              millimetres
     _enumeration.range            :
     _units.code                   millimetres
-    _ddl2_enumeration_range.minimum .
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -8254,11 +7923,6 @@ save_DIFFRN_MEASUREMENT_AXIS
           /CBF_diffrn_measurement__device="DEVICE"
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_measurement_axis.axis_id
@@ -8287,28 +7951,6 @@ save_diffrn_measurement_axis.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
-
-save_
-
-save_diffrn_measurement_axis.id
-
-    _definition.id                '_diffrn_measurement_axis.id'
-    _description.text
-;             This data item is a pointer to _diffrn_measurement.id in
-              the DIFFRN_MEASUREMENT category.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_measurement_axis
-    _name.object_id               id
-    _name.ddl2_mandatory          no
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _type.ddl2_code               code
-    _ddl2_item_related.related_name '_diffrn_measurement_axis.measurement_id'
-    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -8389,7 +8031,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-04
+    _definition.update            2025-09-05
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -8519,11 +8161,6 @@ save_DIFFRN_RADIATION
 
          With the incident_polarisation_stokes array indexed by FRAMENO
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -8872,12 +8509,6 @@ save_diffrn_radiation.filter_edge
     _enumeration.range            0.0:
     _units.code                   angstroms
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_radiation.inhomogeneity
@@ -8902,12 +8533,6 @@ save_diffrn_radiation.inhomogeneity
     _type.ddl2_units              millimetres
     _enumeration.range            0.0:
     _units.code                   millimetres
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
 
 save_
 
@@ -8965,13 +8590,6 @@ save_diffrn_radiation.polarisn_norm
     _enumeration.range            -90.0:90.0
     _units.code                   degrees
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         90.0                     90.0
-         -90.0                    90.0
-         -90.0                    -90.0
-
 save_
 
 save_diffrn_radiation.polarisn_norm_esd
@@ -8995,15 +8613,6 @@ save_diffrn_radiation.polarisn_norm_esd
     _type.ddl2_units              degrees
     _enumeration.range            0.0:
     _units.code                   degrees
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_norm'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9034,12 +8643,6 @@ save_diffrn_radiation.polarisn_ratio
     _enumeration.range            0.0:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_radiation.polarisn_ratio_esd
@@ -9061,15 +8664,6 @@ save_diffrn_radiation.polarisn_ratio_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_ratio'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9111,13 +8705,6 @@ save_diffrn_radiation.polarizn_source_norm
     _enumeration.default          0.0
     _units.code                   degrees
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         90.0                     90.0
-         -90.0                    90.0
-         -90.0                    -90.0
-
 save_
 
 save_diffrn_radiation.polarizn_source_norm_esd
@@ -9141,15 +8728,6 @@ save_diffrn_radiation.polarizn_source_norm_esd
     _type.ddl2_units              degrees
     _enumeration.range            0.0:
     _units.code                   degrees
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_norm'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9206,13 +8784,6 @@ save_diffrn_radiation.polarizn_source_ratio
     _enumeration.range            -1.0:1.0
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1.0                      1.0
-         -1.0                     1.0
-         -1.0                     -1.0
-
 save_
 
 save_diffrn_radiation.polarizn_source_ratio_esd
@@ -9237,15 +8808,6 @@ save_diffrn_radiation.polarizn_source_ratio_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_ratio'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9292,12 +8854,6 @@ save_diffrn_radiation.polarizn_stokes_i
     _enumeration.default          1.0
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_radiation.polarizn_stokes_i_esd
@@ -9323,15 +8879,6 @@ save_diffrn_radiation.polarizn_stokes_i_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_I'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9403,15 +8950,6 @@ save_diffrn_radiation.polarizn_stokes_q_esd
     _enumeration.range            0.0:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_Q'
-    _ddl2_item_related.function_code associated_value
-
 save_
 
 save_diffrn_radiation.polarizn_stokes_u
@@ -9481,15 +9019,6 @@ save_diffrn_radiation.polarizn_stokes_u_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_U'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9562,15 +9091,6 @@ save_diffrn_radiation.polarizn_stokes_v_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_V'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -9745,11 +9265,6 @@ save_DIFFRN_REFLN
 ;
     This category will be addressed at a future date.
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -10486,11 +10001,6 @@ save_DIFFRN_SCAN
     for which the value of _diffrn_scan_frame.frame_id equals FRAMEENDID   
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_scan.date_end
@@ -10621,12 +10131,6 @@ save_diffrn_scan.frames
     _enumeration.range            1:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        .
-         1                        1
-
 save_
 
 save_diffrn_scan.id
@@ -10668,8 +10172,6 @@ save_diffrn_scan.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10692,8 +10194,6 @@ save_diffrn_scan.time_period
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10728,8 +10228,6 @@ save_diffrn_scan.time_rstrt_incr
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10821,11 +10319,6 @@ save_DIFFRN_SCAN_AXIS
              @diffrn_scan_axis__reference_angle=ANG
              @diffrn_scan_axis__reference_displacement=DISP
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -11253,11 +10746,6 @@ save_DIFFRN_SCAN_COLLECTION
               /translation_width=["TRANSLATION_WIDTH"]
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_scan_collection.details
@@ -11443,11 +10931,6 @@ save_DIFFRN_SCAN_FRAME
      where each array element is inserted at index FRAMENUMBER          
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_scan_frame.date
@@ -11529,12 +11012,6 @@ save_diffrn_scan_frame.frame_number
     _enumeration.range            0:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0                        .
-         0                        0
-
 save_
 
 save_diffrn_scan_frame.integration_time
@@ -11557,8 +11034,6 @@ save_diffrn_scan_frame.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -11605,12 +11080,6 @@ save_diffrn_scan_frame.polarizn_stokes_i
     _enumeration.default          1.0
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
 save_
 
 save_diffrn_scan_frame.polarizn_stokes_i_esd
@@ -11636,15 +11105,6 @@ save_diffrn_scan_frame.polarizn_stokes_i_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_I'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -11716,15 +11176,6 @@ save_diffrn_scan_frame.polarizn_stokes_q_esd
     _enumeration.range            0.0:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_Q'
-    _ddl2_item_related.function_code associated_value
-
 save_
 
 save_diffrn_scan_frame.polarizn_stokes_u
@@ -11794,15 +11245,6 @@ save_diffrn_scan_frame.polarizn_stokes_u_esd
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _units.code                   none
-
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_U'
-    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -11876,15 +11318,6 @@ save_diffrn_scan_frame.polarizn_stokes_v_esd
     _enumeration.range            0.0:
     _units.code                   none
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         0.0                      .
-         0.0                      0.0
-
-    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_V'
-    _ddl2_item_related.function_code associated_value
-
 save_
 
 save_diffrn_scan_frame.scan_id
@@ -11927,8 +11360,6 @@ save_diffrn_scan_frame.time_period
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -11961,8 +11392,6 @@ save_diffrn_scan_frame.time_rstrt_incr
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -12062,11 +11491,6 @@ save_DIFFRN_SCAN_FRAME_AXIS
 
     The remaining tags similarly populate the attribute arrays
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -12562,11 +11986,6 @@ save_DIFFRN_SCAN_FRAME_MONITOR
             /count_time=[INTEGRATIONTIME] 
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
-
 save_
 
 save_diffrn_scan_frame_monitor.detector_id
@@ -12651,12 +12070,6 @@ save_diffrn_scan_frame_monitor.id
     _enumeration.range            1:
     _enumeration.default          1
 
-    loop_
-      _ddl2_enumeration_range.minimum
-      _ddl2_enumeration_range.maximum
-         1                        1
-         1                        .
-
 save_
 
 save_diffrn_scan_frame_monitor.integration_time
@@ -12677,8 +12090,6 @@ save_diffrn_scan_frame_monitor.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -12710,8 +12121,6 @@ save_diffrn_scan_frame_monitor.monitor_value
     _type.contents                Real
     _type.ddl2_code               float
     _units.code                   none
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -12730,35 +12139,6 @@ save_diffrn_scan_frame_monitor.scan_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
-
-save_
-
-save_diffrn_scan_frame_monitor.value
-
-    _definition.id                '_diffrn_scan_frame_monitor.value'
-    _description.text
-;             This is a deprecated version of
-              _diffrn_scan_frame_monitor.monitor_value.
-
-              The value is typed as float to allow of monitors for very
-              intense beams that cannot report all digits, but when available,
-              all digits of the monitor should be recorded.
-
-              DEPRECATED -- DO NOT USE
-;
-    _name.category_id             diffrn_scan_frame_monitor
-    _name.object_id               value
-    _name.ddl2_mandatory          no
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _type.ddl2_code               float
-    _units.code                   none
-    _ddl2_enumeration_range.minimum 0.0
-    _ddl2_enumeration_range.maximum .
-    _ddl2_item_related.related_name '_diffrn_scan_frame_monitor.monitor_value'
-    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -12793,7 +12173,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-04
+    _definition.update            2025-09-05
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -12805,11 +12185,6 @@ save_DIFFRN_SOURCE
     _name.object_id               DIFFRN_SOURCE
     _name.ddl2_mandatory          no
     _category_key.name            '_diffrn_source.diffrn_id'
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         diffrn_group
 
 save_
 
@@ -12947,12 +12322,6 @@ save_MAP
 ;   Example 1. Identifying an observed density map
                 and a calculated density map
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-         map_group
 
 save_
 
@@ -13126,12 +12495,6 @@ save_MAP_SEGMENT
                 segment, both using the same array structure
                 and mask.
 ;
-
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         array_data_group
-         map_group
 
 save_
 
@@ -13462,11 +12825,6 @@ save_VARIANT
        left and 0.1 mm down.
 ;
 
-    loop_
-      _ddl2_category_group.id
-         inclusive_group
-         variant_group
-
 save_
 
 save_variant.details
@@ -13653,11 +13011,11 @@ save_
         + Add _diffrn_scan_frame_axis.diffrn_id
         + Add _diffrn_scan_frame_monitor.diffrn_id
 ;
-         1.8.8.2                  2025-06-10
+         1.8.8-dev2               2025-06-10
 ;
        Pick up minor type corrections from 1.8.9 dcitionary
 ;
-         1.8.8.1                  2025-05-25
+         1.8.8-dev1               2025-05-25
 ;
        Minor corrections to 1.8.8 found while working on 1.8.9
 ;
@@ -13908,7 +13266,7 @@ save_
     +  Fix typos in NeXus mappings
 
 ;
-         1.7                      2013-06-18
+         1.7.0                    2013-06-18
 ;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
 
     +  Define new ARRAY_STRUCTURE_LIST_SECTION category
@@ -13987,7 +13345,7 @@ save_
        Improve definition of X-axis to cover the case of no goniometer
         and clean up more line folds (HJB)
 ;
-         1.5                      2007-07-25
+         1.5.0                    2007-07-25
 ;  This is a cumulative list of the changes proposed since the
    imgCIF workshop in Hawaii in July 2006.  It is the result
    of contributions by H. J. Bernstein, A. Hammersley,
@@ -14027,7 +13385,7 @@ save_
      + Fix unclosed text fields in various map definitions
 
 ;
-         1.4                      2006-07-04
+         1.4.0                    2006-07-04
 ;  This is a change to reintegrate all changes made in the course of
    publication of ITVG, by the RCSB from April 2005 through
    August 2008 and changes for the 2006 imgCIF workshop in
@@ -14151,7 +13509,7 @@ save_
        Correction of ATOM_ for ARRAY_ typos in various descriptions.
        (HJB)
 ;
-         1.2                      2003-02-07
+         1.2.0                    2003-02-07
 ;
        Corrections to encodings (remove extraneous hyphens) remove
        extraneous underscore in '_array_structure.encoding_type'
@@ -14169,7 +13527,7 @@ save_
 ;
        Several typo corrections by JW.
 ;
-         1.1                      2001-02-06
+         1.1.0                    2001-02-06
 ;
    Draft resulting from discussions on header for use at NSLS.  (HJB)
 
@@ -14206,7 +13564,7 @@ save_
    + Add examples for fairly complete headers thanks to R. Sweet and P.
      Ellis.
 ;
-         1.0                      2000-12-21
+         1.0.0                    2000-12-21
 ;
        Release version - few typos and tidying up.  (BM & HJB)
 
@@ -14268,7 +13626,7 @@ save_
 
        + Add missing quote marks for '_diffrn_scan.id' definition.
 ;
-         0.5                      1999-01-01
+         0.5.0                    1999-01-01
 ;
    Modifications for axis definitions and reduction of binary header.  (HJB)
 
@@ -14295,7 +13653,7 @@ save_
 
    + Add DIFFRN_SCAN... categories.
 ;
-         0.4                      1998-08-11
+         0.4.0                    1998-08-11
 ;
        Modifications to the 0.3 imgCIF draft.  (HJB)
 
@@ -14305,7 +13663,7 @@ save_
 
        + Change name to cbfext98.dic.
 ;
-         0.3                      1998-07-04
+         0.3.0                    1998-07-04
 ;
    Modifications for imgCIF.  (HJB)
 
@@ -14319,7 +13677,7 @@ save_
      '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
      into pointers to this item.
 ;
-         0.2                      1997-12-02
+         0.2.0                    1997-12-02
 ;
    Modifications to the CBF draft.  (JW)
 
@@ -14335,7 +13693,7 @@ save_
      groups within a binary section.  The formal identification of the
      binary section is still fuzzy.
 ;
-         0.1                      1997-01-24
+         0.1.0                    1997-01-24
 ;
    First draft of this dictionary in DDL 2.1 compliant format by John
    Westbrook (JW).  This version is adapted from the Crystallographic

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -2,12 +2,12 @@
 
 data_CIF_IMG.DIC
 
-    _dictionary.title             Cif_img.dic
+    _dictionary.title             cif_img.dic
     _dictionary.class             Instance
-    _dictionary.version           1.8.6
-    _dictionary.date              2022-05-11
+    _dictionary.version           1.8.9
+    _dictionary.date              2025-06-10
     _dictionary.ddl_conformance   3.14.0
-    _dictionary.namespace         CifCore
+    _dictionary.namespace         ddlm
     _description.text
 ;##############################################################################
 #                                                                            #
@@ -15,28 +15,28 @@ data_CIF_IMG.DIC
 #             and Crystallographic Binary File Dictionary (CBF)              #
 #            Extending the Macromolecular CIF Dictionary (mmCIF)             #
 #                                                                            #
-#                              Version 1.8.6                                 #
-#                              of 2022-05-11                                 #
-#                                                                            #
-#                                                                            #
+#                              Version 1.8.9                                 #
+#                              of 2025-06-10                                 #
+#++/--                                                                       #
+#+/-                                                                         #
 #    ###################################################################     #
 #    # *** WARNING *** THIS IS A DRAFT FOR DISCUSSION *** WARNING ***  #     #
 #    #                 SUBJECT TO CHANGE WITHOUT NOTICE                #     #
 #    #       SEND COMMENTS TO imgcif-l@iucr.org CITING THE VERSION     #     #
 #    ###################################################################     #
-#            This draft edited by B. McMahon and H. J. Bernstein             #
+#                  This draft edited by Herbert J. Bernstein                 #
 #                                                                            #
 #     by Andrew P. Hammersley, Herbert J. Bernstein and John D. Westbrook    #
 #                                                                            #
 # This dictionary was adapted from a format discussed at the imgCIF Workshop #
 # held at BNL Oct 1997 and the Crystallographic Binary File Format Draft     #
 # Proposal by Andrew Hammersley.  The first DDL 2.1 Version was created by   #
-# John Westbrook.  This version is being prepared in support of the 2021     #
+# John Westbrook.  This version is being prepared in support of the 2024     #
 # revisions to ITVG, and was drafted by Herbert J. Bernstein and             #
 # incorporates comments by James Hester, I. David Brown, John Westbrook,     #
 # Brian McMahon, Bob Sweet, Paul Ellis, Harry Powell, Wilfred Li,            #
-# Gotzon Madariaga, Frances C. Bernstein, Chris Nielsen, Nicola Ashcroft and #
-# others and reflects comments in                                            #
+# Gotzon Madariaga, Frances C. Bernstein, Chris Nielsen, Nicola Ashcroft,    #
+# Aaron Brewster, James Hester and others and reflects comments in           #
 # Bernstein, H. J., Foerster, A., Bhowmick, A., Brewster, A. S.,             #
 # Brockhauser, S., Gelisio, L., Hall, D. R., Leonarski, F., Mariani, V.,     #
 # Santoni, G., Vonrhein, C. & Winter, G. (2020). "Gold Standard for          #
@@ -44,13 +44,14 @@ data_CIF_IMG.DIC
 # https://doi.org/10.1107/S2052252520008672,                                 #
 # https://doi.org//10.1107/S2052252520008672/ti5018sup1.pdf,                 #
 # https://doi.org//10.1107/S2052252520008672/ti5018sup2.pdf                  #
+
 ##############################################################################
 #    CONTENTS
 #
 #        CATEGORY_GROUP_LIST
 #        SUB_CATEGORY
 #
-#        category  ARRAY_DATA
+#        category  ARRAY_DATA 
 #
 #                  _array_data.array_id
 #                  _array_data.binary_id
@@ -60,10 +61,12 @@ data_CIF_IMG.DIC
 #                  _array_data.header_convention
 #                  _array_data.variant
 #
-#        category  ARRAY_DATA_EXTERNAL_DATA
+
+#        category  ARRAY_DATA_EXTERNAL_DATA 
 #
 #                  _array_data_external_data.archive_format
 #                  _array_data_external_data.archive_path
+#                  _array_data_external_data.file_compression
 #                  _array_data_external_data.format
 #                  _array_data_external_data.frame
 #                  _array_data_external_data.id
@@ -72,14 +75,16 @@ data_CIF_IMG.DIC
 #                  _array_data_external_data.variant
 #                  _array_data_external_data.version
 #
-#        category  ARRAY_ELEMENT_SIZE
+
+#        category  ARRAY_ELEMENT_SIZE 
 #
 #                  _array_element_size.array_id
 #                  _array_element_size.index
 #                  _array_element_size.size
 #                  _array_element_size.variant
 #
-#        category  ARRAY_INTENSITIES
+
+#        category  ARRAY_INTENSITIES 
 #
 #                  _array_intensities.array_id
 #                  _array_intensities.binary_id
@@ -97,7 +102,8 @@ data_CIF_IMG.DIC
 #                  _array_intensities.underload
 #                  _array_intensities.variant
 #
-#        category  ARRAY_STRUCTURE
+
+#        category  ARRAY_STRUCTURE 
 #
 #                  _array_structure.byte_order
 #                  _array_structure.compression_type
@@ -106,7 +112,8 @@ data_CIF_IMG.DIC
 #                  _array_structure.id
 #                  _array_structure.variant
 #
-#        category  ARRAY_STRUCTURE_LIST
+
+#        category  ARRAY_STRUCTURE_LIST 
 #
 #                  _array_structure_list.axis_set_id
 #                  _array_structure_list.array_id
@@ -117,7 +124,8 @@ data_CIF_IMG.DIC
 #                  _array_structure_list.precedence
 #                  _array_structure_list.variant
 #
-#        category  ARRAY_STRUCTURE_LIST_SECTION
+
+#        category  ARRAY_STRUCTURE_LIST_SECTION 
 #
 #                  _array_structure_list_section.array_id
 #                  _array_structure_list_section.end
@@ -127,7 +135,8 @@ data_CIF_IMG.DIC
 #                  _array_structure_list_section.stride
 #                  _array_structure_list_section.variant
 #
-#        category  ARRAY_STRUCTURE_LIST_AXIS
+
+#        category  ARRAY_STRUCTURE_LIST_AXIS 
 #
 #                  _array_structure_list_axis.axis_id
 #                  _array_structure_list_axis.axis_set_id
@@ -143,7 +152,8 @@ data_CIF_IMG.DIC
 #                  _array_structure_list_axis.reference_displacement
 #                  _array_structure_list_axis.variant
 #
-#        category  AXIS
+
+#        category  AXIS 
 #
 #                  _axis.depends_on
 #                  _axis.equipment
@@ -161,20 +171,29 @@ data_CIF_IMG.DIC
 #                  _axis.vector[3]
 #                  _axis.variant
 #
-#        category  DIFFRN_DATA_FRAME
+
+#        category  DIFFRN 
+#
+#                  _diffrn.id
+#
+
+#        category  DIFFRN_DATA_FRAME 
 #
 #                  _diffrn_data_frame.array_id
 #                  _diffrn_data_frame.array_section_id
 #                  _diffrn_data_frame.binary_id
+#                  _diffrn_data_frame.center_derived
 #                  _diffrn_data_frame.center_fast
 #                  _diffrn_data_frame.center_slow
 #                  _diffrn_data_frame.center_units
 #                  _diffrn_data_frame.detector_element_id
+#                  _diffrn_data_frame.diffrn_id
 #                  _diffrn_data_frame.id
 #                  _diffrn_data_frame.details
 #                  _diffrn_data_frame.variant
 #
-#        category  DIFFRN_DETECTOR
+
+#        category  DIFFRN_DETECTOR 
 #
 #                  _diffrn_detector.details
 #                  _diffrn_detector.detector
@@ -187,28 +206,34 @@ data_CIF_IMG.DIC
 #                  _diffrn_detector.type
 #                  _diffrn_detector.variant
 #
-#        category  DIFFRN_DETECTOR_AXIS
+
+#        category  DIFFRN_DETECTOR_AXIS 
 #
 #                  _diffrn_detector_axis.axis_id
 #                  _diffrn_detector_axis.detector_id
+#                  _diffrn_detector_axis.diffrn_id
 #                  _diffrn_detector_axis.variant
 #
-#        category  DIFFRN_DETECTOR_ELEMENT
+
+#        category  DIFFRN_DETECTOR_ELEMENT 
 #
 #                  _diffrn_detector_element.id
 #                  _diffrn_detector_element.detector_id
+#                  _diffrn_detector_element.diffrn_id
 #                  _diffrn_detector_element.reference_center_fast
 #                  _diffrn_detector_element.reference_center_slow
 #                  _diffrn_detector_element.reference_center_units
 #                  _diffrn_detector_element.variant
 #
-#        category  DIFFRN_MEASUREMENT
+
+#        category  DIFFRN_MEASUREMENT 
 #
 #                  _diffrn_measurement.diffrn_id
 #                  _diffrn_measurement.details
 #                  _diffrn_measurement.device
 #                  _diffrn_measurement.device_details
 #                  _diffrn_measurement.device_type
+#                  _diffrn_measurement.diffrn_id
 #                  _diffrn_measurement.id
 #                  _diffrn_measurement.method
 #                  _diffrn_measurement.number_of_axes
@@ -217,14 +242,16 @@ data_CIF_IMG.DIC
 #                  _diffrn_measurement.specimen_support
 #                  _diffrn_measurement.variant
 #
-#        category  DIFFRN_MEASUREMENT_AXIS
+
+#        category  DIFFRN_MEASUREMENT_AXIS 
 #
 #                  _diffrn_measurement_axis.axis_id
 #                  _diffrn_measurement_axis.measurement_device
 #                  _diffrn_measurement_axis.measurement_id
 #                  _diffrn_measurement_axis.variant
 #
-#        category  DIFFRN_RADIATION
+
+#        category  DIFFRN_RADIATION 
 #
 #                  _diffrn_radiation.beam_width
 #                  _diffrn_radiation.beam_height
@@ -259,17 +286,21 @@ data_CIF_IMG.DIC
 #                  _diffrn_radiation.wavelength_id
 #                  _diffrn_radiation.xray_symbol
 #
-#        category  DIFFRN_REFLN
+
+#        category  DIFFRN_REFLN 
 #
+#                  _diffrn_refln.diffrn_id
 #                  _diffrn_refln.frame_id
 #                  _diffrn_refln.variant
 #
-#        category  DIFFRN_SCAN
+
+#        category  DIFFRN_SCAN 
 #
 #                  _diffrn_scan.id
 #                  _diffrn_scan.date_end
 #                  _diffrn_scan.date_end_estimated
 #                  _diffrn_scan.date_start
+#                  _diffrn_scan.diffrn_id
 #                  _diffrn_scan.integration_time
 #                  _diffrn_scan.frame_id_start
 #                  _diffrn_scan.frame_id_end
@@ -278,7 +309,8 @@ data_CIF_IMG.DIC
 #                  _diffrn_scan.time_rstrt_incr
 #                  _diffrn_scan.variant
 #
-#        category  DIFFRN_SCAN_AXIS
+
+#        category  DIFFRN_SCAN_AXIS 
 #
 #                  _diffrn_scan_axis.axis_id
 #                  _diffrn_scan_axis.angle_start
@@ -289,22 +321,27 @@ data_CIF_IMG.DIC
 #                  _diffrn_scan_axis.displacement_range
 #                  _diffrn_scan_axis.displacement_increment
 #                  _diffrn_scan_axis.displacement_rstrt_incr
+#                  _diffrn_scan_axis.displacement_diffrn_id
 #                  _diffrn_scan_axis.reference_angle
 #                  _diffrn_scan_axis.reference_displacement
 #                  _diffrn_scan_axis.scan_id
 #                  _diffrn_scan_axis.variant
 #
-#        category  DIFFRN_SCAN_COLLECTION
+
+#        category  DIFFRN_SCAN_COLLECTION 
 #
 #                  _diffrn_scan_collection.details
+#                  _diffrn_scan_collection.diffrn_id
 #                  _diffrn_scan_collection.scan_id
 #                  _diffrn_scan_collection.type
 #                  _diffrn_scan_collection.translation_width
 #                  _diffrn_scan_collection.variant
 #
-#        category  DIFFRN_SCAN_FRAME
+
+#        category  DIFFRN_SCAN_FRAME 
 #
 #                  _diffrn_scan_frame.date
+#                  _diffrn_scan_frame.diffrn_id
 #                  _diffrn_scan_frame.frame_id
 #                  _diffrn_scan_frame.frame_number
 #                  _diffrn_scan_frame.integration_time
@@ -321,7 +358,8 @@ data_CIF_IMG.DIC
 #                  _diffrn_scan_frame.time_rstrt_incr
 #                  _diffrn_scan_frame.variant
 #
-#        category  DIFFRN_SCAN_FRAME_AXIS
+
+#        category  DIFFRN_SCAN_FRAME_AXIS 
 #
 #                  _diffrn_scan_frame_axis.axis_id
 #                  _diffrn_scan_frame_axis.angle
@@ -330,22 +368,33 @@ data_CIF_IMG.DIC
 #                  _diffrn_scan_frame_axis.displacement
 #                  _diffrn_scan_frame_axis.displacement_increment
 #                  _diffrn_scan_frame_axis.displacement_rstrt_incr
+#                  _diffrn_scan_frame_axis.diffrn_id
 #                  _diffrn_scan_frame_axis.reference_angle
 #                  _diffrn_scan_frame_axis.reference_displacement
 #                  _diffrn_scan_frame_axis.frame_id
 #                  _diffrn_scan_frame_axis.variant
 #
-#        category  DIFFRN_SCAN_FRAME_MONITOR
+
+#        category  DIFFRN_SCAN_FRAME_MONITOR 
 #
 #                  _diffrn_scan_frame_monitor.id
 #                  _diffrn_scan_frame_monitor.detector_id
+#                  _diffrn_scan_frame_monitor.diffrn_id
 #                  _diffrn_scan_frame_monitor.frame_id
 #                  _diffrn_scan_frame_monitor.integration_time
 #                  _diffrn_scan_frame_monitor.monitor_value
 #                  _diffrn_scan_frame_monitor.scan_id
 #                  _diffrn_scan_frame_monitor.variant
 #
-#        category  MAP
+
+#        category  DIFFRN_SOURCE 
+#
+#                  _diffrn_source.diffrn_id
+#                  _diffrn_source.source
+#                  _diffrn_source.type
+#
+
+#        category  MAP 
 #
 #                  _map.details
 #                  _map.diffrn_id
@@ -353,7 +402,8 @@ data_CIF_IMG.DIC
 #                  _map.id
 #                  _map.variant
 #
-#        category  MAP_SEGMENT
+
+#        category  MAP_SEGMENT 
 #
 #                  _map_segment.array_id
 #                  _map_segment.array_section_id
@@ -366,7 +416,8 @@ data_CIF_IMG.DIC
 #                  _map_segment.details
 #                  _map_segment.variant
 #
-#        category  VARIANT
+
+#        category  VARIANT 
 #
 #                  _variant.details
 #                  _variant.diffrn_id
@@ -376,7 +427,8 @@ data_CIF_IMG.DIC
 #                  _variant.variant
 #                  _variant.variant_of
 #
-#       ***DEPRECATED*** data items
+
+#       ***DEPRECATED*** data items 
 #
 #                  _diffrn_detector_axis.id
 #                  _diffrn_detector_element.center[1]
@@ -392,13 +444,14 @@ data_CIF_IMG.DIC
 #                  _diffrn_frame_data.id
 #                  _diffrn_frame_data.details
 #
+
 #        ITEM_TYPE_LIST
 #        ITEM_UNITS_LIST
 #        DICTIONARY_HISTORY
 #
 ##############################################################################
 
-#Category Group Table:
+#Category Group Table:  #
 +--------------------------------------------------------------------------------------------------------------------+
 |ARRAY_DATA_GROUP|Categories that describe array data.                                                               |
 |                |---------------------------------------------------------------------------------------------------|
@@ -517,6 +570,12 @@ data_CIF_IMG.DIC
 |DIFFRN_GROUP    |Categories that describe details of the diffraction experiment.                                    |
 |                |---------------------------------------------------------------------------------------------------|
 |                |+-------------------------------------------------------------------------------------------------+|
+|                || DIFFRN                     | Data items in the DIFFRN category record the details about the     ||
+|                ||                            | diffraction data and their measurement. This is a stub category    ||
+|                ||                            | for the cif_img dicionary to complete the tree for tags that are   ||
+|                ||                            | aliases for tags in the various diffrn_... categories in the       ||
+|                ||                            | mmCIF_PDBx dictionary.                                             ||
+|                ||----------------------------+--------------------------------------------------------------------||
 |                || DIFFRN_DATA_FRAME          | Data items in the DIFFRN_DATA_FRAME category record the details    ||
 |                ||                            | about each frame of data.                                          ||
 |                ||                            |                                                                    ||
@@ -637,6 +696,11 @@ data_CIF_IMG.DIC
 |                || |   | |   |                           | omitted.                                            | | ||
 |                || |   | +-------------------------------------------------------------------------------------+ | ||
 |                || +---------------------------------------------------------------------------------------------+ ||
+|                || DIFFRN_SOURCE              | Data items in the DIFFRN_SOURCE category describe details of the   ||
+|                ||                            | source of radiation used in the diffraction experiment.            ||
+|                ||                            | This is a stub category for use of DIFFRN_SOURCE which is          ||
+|                ||                            | specified in the mmCIF_PDBx dictionary                             ||
+|                |+-------------------------------------------------------------------------------------------------+|
 |                |+-------------------------------------------------------------------------------------------------+|
 |----------------+---------------------------------------------------------------------------------------------------|
 |MAP_GROUP       |Categories that describe maps.                                                                     |
@@ -709,43 +773,39 @@ save_HEAD
     _name.object_id               HEAD
 
     _import.get
-        [
-          {
-          'dupl':Ignore
-   'file':https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_3.2.0.dic
-          'mode':Full  'save':cif_core
-          }
-        ]
+        [{'dupl':Ignore
+          'file':https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
+          'mode':Full  'save':multiblock_core}]
 
 save_
 
 save_ARRAY_DATA
 
-    _definition.id                ARRAY_DATA
+    _definition.id                array_data
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-     Data items in the ARRAY_DATA  category are the containers for
-      the array data items described in the category ARRAY_STRUCTURE.
+    Data items in the ARRAY_DATA category are the containers for
+     the array data items described in the category ARRAY_STRUCTURE.
 
-      It is recognized that the data in this category need to be used in
-      two distinct ways.  During a data collection the lack of ancillary
-      data and timing constraints in processing data may dictate the
-      need to make a 'miniCBF', nothing more than an essential minimum
-      of information to record the results of the data collection.  In that
-      case it is proper to use the ARRAY_DATA  category as a
-      container for just a single image and a compacted, beamline-dependent
-      list of data collection parameter values.  In such
-      a case, only the tags '_array_data.header_convention',
-      '_array_data.header_contents'  and '_array_data.data' need be
-    populated.
+     It is recognized that the data in this category need to be used in
+     two distinct ways.  During a data collection the lack of ancillary
+     data and timing constraints in processing data may dictate the
+     need to make a 'miniCBF', nothing more than an essential minimum
+     of information to record the results of the data collection.  In that
+     case it is proper to use the ARRAY_DATA category as a
+     container for just a single image and a compacted, beamline-dependent
+     list of data collection parameter values.  In such
+     a case, only the tags '_array_data.header_convention',
+     '_array_data.header_contents' and '_array_data.data' need be
+     populated.
 
-      For full processing and archiving, most of the tags in this
-      dictionary will need to be populated.
+     For full processing and archiving, most of the tags in this
+     dictionary will need to be populated.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_DATA
+    _name.object_id               array_data
     _name.ddl2_mandatory          no
 
     loop_
@@ -758,129 +818,156 @@ save_ARRAY_DATA
       _description_example.case
       _description_example.detail
 ;
-          loop_
-         _array_data.array_id
-         _array_data.binary_id
-         _array_data.data
-         image_1 1
-         ;
-         --CIF-BINARY-FORMAT-SECTION--
-         Content-Type: application/octet-stream;
-              conversions="X-CBF_CANONICAL"
-         Content-Transfer-Encoding: X-BASE16
-         X-Binary-Size: 3927126
-         X-Binary-ID: 1
-         Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
 
-         # Hexadecimal encoding, byte 0, byte order ...21
-         #
-         H4< 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
-         ....
-         --CIF-BINARY-FORMAT-SECTION----
-         ;
-         image_2 2
-         ;
-         --CIF-BINARY-FORMAT-SECTION--
-         Content-Type: application/octet-stream;
-              conversions="X-CBF-PACKED"
-         Content-Transfer-Encoding: BASE64
-         X-Binary-Size: 3745758
-         X-Binary-ID: 2
-         Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+         loop_
+        _array_data.array_id
+        _array_data.binary_id
+        _array_data.data
+        image_1 1
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF_CANONICAL"
+        Content-Transfer-Encoding: X-BASE16
+        X-Binary-Size: 3927126
+        X-Binary-ID: 1
+        Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
 
-         ELhQAAAAAAAA...
-         ...
-         --CIF-BINARY-FORMAT-SECTION----
-         ;
+        # Hexadecimal encoding, byte 0, byte order ...21
+        #
+        H4< 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
+        ....
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+        image_2 2
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF-PACKED"
+        Content-Transfer-Encoding: BASE64
+        X-Binary-Size: 3745758
+        X-Binary-ID: 2
+        Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+
+        ELhQAAAAAAAA...
+        ...
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
 ;
 ;
-         Example 1.
+        Example 1.
 
-         This example shows two binary data blocks.  The first one
-         was compressed by the CBF_CANONICAL compression algorithm and is
-         presented as hexadecimal data.  The first character 'H' on the
-         data lines means hexadecimal.  It could have been 'O' for octal
-         or 'D' for decimal.  The second character on the line shows
-         the number of bytes in each word (in this case '4'), which then
-         requires eight hexadecimal digits per word.  The third character
-         gives the order of octets within a word, in this case '<'
-         for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
-         character '>' could have been used for the ordering 1234
-         (i.e. 'little-endian').  The block has a 'message digest'
-         to check the integrity of the data.
+        This example shows two binary data blocks.  The first one
+        was compressed by the CBF_CANONICAL compression algorithm and is
+        presented as hexadecimal data.  The first character 'H' on the
+        data lines means hexadecimal.  It could have been 'O' for octal
+        or 'D' for decimal.  The second character on the line shows
+        the number of bytes in each word (in this case '4'), which then
+        requires eight hexadecimal digits per word.  The third character
+        gives the order of octets within a word, in this case '<'
+        for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
+        character '>' could have been used for the ordering 1234
+        (i.e. 'little-endian').  The block has a 'message digest'
+        to check the integrity of the data.
 
-         The second block is similar, but uses CBF_PACKED compression
-         and BASE64 encoding.  Note that the size and the digest are
-         different.
+        The second block is similar, but uses CBF_PACKED compression
+        and BASE64 encoding.  Note that the size and the digest are
+        different.
 ;
 ;
-         ###CBF: VERSION 1.5
-         # CBF file written by CBFlib v0.7.8
+        ###CBF: VERSION 1.5
+        # CBF file written by CBFlib v0.7.8
 
-         data_insulin_pilatus6m
+        data_insulin_pilatus6m
 
-         _array_data.header_convention  SLS_1.0
-         _array_data.header_contents
-         ;
-         # Detector: PILATUS 6M SN: 60-0001
-         # 2007/Jun/17 15:12:36.928
-         # Pixel_size 172e-6 m x 172e-6 m
-         # Silicon sensor, thickness 0.000320 m
-         # Exposure_time 0.995000 s
-         # Exposure_period 1.000000 s
-         # Tau = 194.0e-09 s
-         # Count_cutoff 1048575 counts
-         # Threshold_setting 5000 eV
-         # Wavelength 1.2398 A
-         # Energy_range (0, 0) eV
-         # Detector_distance 0.15500 m
-         # Detector_Voffset -0.01003 m
-         # Beam_xy (1231.00, 1277.00) pixels
-         # Flux 22487563295 ph/s
-         # Filter_transmission 0.0008
-         # Start_angle 13.0000 deg.
-         # Angle_increment 1.0000 deg.
-         # Detector_2theta 0.0000 deg.
-         # Polarization 0.990
-         # Alpha 0.0000 deg.
-         # Kappa 0.0000 deg.
-         # Phi 0.0000 deg.
-         # Chi 0.0000 deg.
-         # Oscillation_axis  X, CW
-         # N_oscillations 1
-         ;
+        _array_data.header_convention SLS_1.0
+        _array_data.header_contents
+        ;
+        # Detector: PILATUS 6M SN: 60-0001
+        # 2007/Jun/17 15:12:36.928
+        # Pixel_size 172e-6 m x 172e-6 m
+        # Silicon sensor, thickness 0.000320 m
+        # Exposure_time 0.995000 s
+        # Exposure_period 1.000000 s
+        # Tau = 194.0e-09 s
+        # Count_cutoff 1048575 counts
+        # Threshold_setting 5000 eV
+        # Wavelength 1.2398 A
+        # Energy_range (0, 0) eV
+        # Detector_distance 0.15500 m
+        # Detector_Voffset -0.01003 m
+        # Beam_xy (1231.00, 1277.00) pixels
+        # Flux 22487563295 ph/s
+        # Filter_transmission 0.0008
+        # Start_angle 13.0000 deg.
+        # Angle_increment 1.0000 deg.
+        # Detector_2theta 0.0000 deg.
+        # Polarization 0.990
+        # Alpha 0.0000 deg.
+        # Kappa 0.0000 deg.
+        # Phi 0.0000 deg.
+        # Chi 0.0000 deg.
+        # Oscillation_axis  X, CW
+        # N_oscillations 1
+        ;
 
-         _array_data.data
-         ;
-         --CIF-BINARY-FORMAT-SECTION--
-         Content-Type: application/octet-stream;
-              conversions="x-CBF_BYTE_OFFSET"
-         Content-Transfer-Encoding: BINARY
-         X-Binary-Size: 6247567
-         X-Binary-ID: 1
-         X-Binary-Element-Type: "signed 32-bit integer"
-         X-Binary-Element-Byte-Order: LITTLE_ENDIAN
-         Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
-         X-Binary-Number-of-Elements: 6224001
-         X-Binary-Size-Fastest-Dimension: 2463
-         X-Binary-Size-Second-Dimension: 2527
-         X-Binary-Size-Padding: 4095
+        _array_data.data
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="x-CBF_BYTE_OFFSET"
+        Content-Transfer-Encoding: BINARY
+        X-Binary-Size: 6247567
+        X-Binary-ID: 1
+        X-Binary-Element-Type: "signed 32-bit integer"
+        X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+        Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
+        X-Binary-Number-of-Elements: 6224001
+        X-Binary-Size-Fastest-Dimension: 2463
+        X-Binary-Size-Second-Dimension: 2527
+        X-Binary-Size-Padding: 4095
 
-         ...
+        ...
 
-         --CIF-BINARY-FORMAT-SECTION----
-         ;
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
 ;
 ;
-         Example 2.
+        Example 2.
 
-         This example shows a single image in a miniCBF, provided by
-         E. Eikenberry.  The entire CBF consists of one data block
-         containing one category and three tags.  The CBFlib
-         program convert_miniCBF and a suitable template file
-         can be used to convert this miniCBF to a full imgCIF
-         file.
+        This example shows a single image in a miniCBF, provided by
+        E. Eikenberry.  The entire CBF consists of one data block
+        containing one category and three tags.  The CBFlib
+        program convert_miniCBF and a suitable template file
+        can be used to convert this miniCBF to a full imgCIF
+        file.
 ;
+
+    _nx_mapping.details
+;    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.data  DATAARRAY
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -888,11 +975,11 @@ save_array_data.array_id
 
     _definition.id                '_array_data.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 
-     If not given, it defaults to 1.
+              If not given, it defaults to 1.
+
 ;
     _name.category_id             array_data
     _name.object_id               array_id
@@ -911,32 +998,37 @@ save_array_data.binary_id
 
     _definition.id                '_array_data.binary_id'
     _description.text
-;
-    This item is an integer identifier which, along with
-     _array_data.array_id, should uniquely identify the
-     particular block of array data.
+;             This item is an integer identifier which, along with
+              _array_data.array_id, should uniquely identify the
+              particular block of array data.
 
-     If _array_data.binary_id  is not explicitly given,
-     it defaults to 1.
+              If _array_data.binary_id is not explicitly given,
+              it defaults to 1.
 
-     The value of _array_data.binary_id  distinguishes
-     among multiple sets of data with the same array
-     structure.
+              The value of _array_data.binary_id distinguishes
+              among multiple sets of data with the same array
+              structure.
 
-     If the MIME header of the data array specifies a
-     value for X-Binary-ID, the value of  _array_data.binary_id
-     should be equal to the value given for X-Binary-ID.
+              If the MIME header of the data array specifies a
+              value for X-Binary-ID, the value of  _array_data.binary_id
+              should be equal to the value given for X-Binary-ID.
 ;
     _name.category_id             array_data
     _name.object_id               binary_id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
     _enumeration.default          1
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -944,239 +1036,238 @@ save_array_data.data
 
     _definition.id                '_array_data.data'
     _description.text
-;
-    The value of _array_data.data  contains the array data
-     encapsulated in a STAR string.  The value of this item is
-     required unless a value is given for
-      _array_data.external_data_id  instead, in which
-     case, a null value of '.' should be given here.
+;             The value of _array_data.data contains the array data
+              encapsulated in a STAR string.  The value of this item is 
+              required unless a value is given for 
+               _array_data.external_data_id instead, in which 
+              case, a null value of '.' should be given here.
 
-     The representation used is a variant on the
-     Multipurpose Internet Mail Extensions (MIME) specified
-     in RFC 2045-2049 by N. Freed et al.  The boundary
-     delimiter used in writing an imgCIF or CBF is
-     \n--CIF-BINARY-FORMAT-SECTION-- (including the
-     required initial \n--, where \n represents the system
-     newline character(s)).
+              The representation used is a variant on the
+              Multipurpose Internet Mail Extensions (MIME) specified
+              in RFC 2045-2049 by N. Freed et al.  The boundary
+              delimiter used in writing an imgCIF or CBF is
+              \n--CIF-BINARY-FORMAT-SECTION-- (including the
+              required initial \n--, where \n represents the system
+              newline character(s)).
 
-     The Content-Type may be any of the discrete types permitted
-     in RFC 2045; 'application/octet-stream' is recommended
-     for diffraction images in the ARRAY_DATA category.
-     Note:  When appropriate in other categories, e.g. for
-     photographs of crystals, more precise types, such as
-     'image/jpeg', 'image/tiff', 'image/png', etc. should be used.
+              The Content-Type may be any of the discrete types permitted
+              in RFC 2045; 'application/octet-stream' is recommended
+              for diffraction images in the ARRAY_DATA category.
+              Note:  When appropriate in other categories, e.g. for
+              photographs of crystals, more precise types, such as
+              'image/jpeg', 'image/tiff', 'image/png', etc. should be used.
 
-     If an octet stream was compressed, the compression should
-     be specified by the parameter
-       conversions="X-CBF_PACKED"
-     or the parameter
-       conversions="X-CBF_CANONICAL"
-     or the parameter
-       conversions="X-CBF_BYTE_OFFSET"
-     or the parameter
-       conversions="X-CBF_BACKGROUND_OFFSET_DELTA"
+              If an octet stream was compressed, the compression should
+              be specified by the parameter
+                conversions="X-CBF_PACKED"
+              or the parameter
+                conversions="X-CBF_CANONICAL"
+              or the parameter
+                conversions="X-CBF_BYTE_OFFSET"
+              or the parameter
+                conversions="X-CBF_BACKGROUND_OFFSET_DELTA"
 
-     If the parameter
-       conversions="X-CBF_PACKED"
-     is given it may be further modified with the parameters
-       uncorrelated_sections
-     or
-       flat
-     (e.g. conversions="X-CBF_PACKED flat").
-     In such cases the _array_structure.compression_type_flag
-     should also be present with the corresponding value.
+              If the parameter 
+                conversions="X-CBF_PACKED"
+              is given it may be further modified with the parameters
+                uncorrelated_sections
+              or
+                flat
+              (e.g. conversions="X-CBF_PACKED flat").
+              In such cases the _array_structure.compression_type_flag
+              should also be present with the corresponding value.
 
-     If the "uncorrelated_sections" parameter is
-     given, each section will be compressed without using
-     the prior section for averaging.
+              If the "uncorrelated_sections" parameter is
+              given, each section will be compressed without using
+              the prior section for averaging.
 
-     If the "flat" parameter is given, each
-     image will be treated as one long row.
+              If the "flat" parameter is given, each
+              image will be treated as one long row.
 
-     Note that X-CBF_CANONICAL and X-CBF_PACKED are
-     slower but more efficient compressions than the others.
-     The X-CBF_BYTE_OFFSET compression is a good compromise
-     between speed and efficiency for ordinary diffraction
-     images.  The X-CBF_BACKGROUND_OFFSET_DELTA compression
-     is oriented towards sparse data, such as masks and
-     tables of replacement pixel values for images with
-     overloaded spots.
+              Note that X-CBF_CANONICAL and X-CBF_PACKED are
+              slower but more efficient compressions than the others.
+              The X-CBF_BYTE_OFFSET compression is a good compromise
+              between speed and efficiency for ordinary diffraction
+              images.  The X-CBF_BACKGROUND_OFFSET_DELTA compression
+              is oriented towards sparse data, such as masks and
+              tables of replacement pixel values for images with
+              overloaded spots.
 
-     The Content-Transfer-Encoding may be 'BASE64',
-     'Quoted-Printable', 'X-BASE8', 'X-BASE10',
-     'X-BASE16' or 'X-BASE32K', for an imgCIF or 'BINARY'
-     for a CBF.  The octal, decimal and hexadecimal transfer
-     encodings are provided for convenience in debugging and
-     are not recommended for archiving and data interchange.
+              The Content-Transfer-Encoding may be 'BASE64',
+              'Quoted-Printable', 'X-BASE8', 'X-BASE10',
+              'X-BASE16' or 'X-BASE32K', for an imgCIF or 'BINARY'
+              for a CBF.  The octal, decimal and hexadecimal transfer
+              encodings are provided for convenience in debugging and
+              are not recommended for archiving and data interchange.
 
-     In a CIF, one of the parameters 'charset=us-ascii',
-     'charset=utf-8' or 'charset=utf-16' may be used on the
-     Content-Transfer-Encoding to specify the character set
-     used for the external presentation of the encoded data.
-     If no charset parameter is given, the character set of
-     the enclosing CIF is assumed.  In any case, if a BOM
-     flag is detected (FE FF for big-endian UTF-16, FF FE for
-     little-endian UTF-16 or EF BB BF for UTF-8) is detected,
-     the indicated charset will be assumed until the end of the
-     encoded data or the detection of a different BOM.  The
-     charset of the Content-Transfer-Encoding is not the character
-     set of the encoded data, only the character set of the
-     presentation of the encoded data and should be respecified
-     for each distinct STAR string.
+              In a CIF, one of the parameters 'charset=us-ascii',
+              'charset=utf-8' or 'charset=utf-16' may be used on the
+              Content-Transfer-Encoding to specify the character set
+              used for the external presentation of the encoded data.
+              If no charset parameter is given, the character set of
+              the enclosing CIF is assumed.  In any case, if a BOM
+              flag is detected (FE FF for big-endian UTF-16, FF FE for
+              little-endian UTF-16 or EF BB BF for UTF-8) is detected,
+              the indicated charset will be assumed until the end of the
+              encoded data or the detection of a different BOM.  The
+              charset of the Content-Transfer-Encoding is not the character
+              set of the encoded data, only the character set of the
+              presentation of the encoded data and should be respecified
+              for each distinct STAR string.
 
-     In an imgCIF file, the encoded binary data begin after
-     the empty line terminating the header.  In an imgCIF file,
-     the encoded binary data ends with the terminating boundary
-     delimiter '\n--CIF-BINARY-FORMAT-SECTION----'
-     in the currently effective charset or with the '\n;'
-     that terminates the STAR string.
+              In an imgCIF file, the encoded binary data begin after
+              the empty line terminating the header.  In an imgCIF file,
+              the encoded binary data ends with the terminating boundary
+              delimiter '\n--CIF-BINARY-FORMAT-SECTION----'
+              in the currently effective charset or with the '\n;'
+              that terminates the STAR string.
 
-     In a CBF, the raw binary data begin after an empty line
-     terminating the header and after the sequence:
+              In a CBF, the raw binary data begin after an empty line
+              terminating the header and after the sequence:
 
-     Octet   Hex   Decimal  Purpose
-       0     0C       12    Ctrl-L: page break
-       1     1A       26    Ctrl-Z: stop listings, MS-DOS
-       2     04       04    Ctrl-D: stop listings, UNIX
-       3     D5      213    binary section begins
+              Octet   Hex   Decimal  Purpose
+                0     0C       12    Ctrl-L: page break
+                1     1A       26    Ctrl-Z: stop listings, MS-DOS
+                2     04       04    Ctrl-D: stop listings, UNIX
+                3     D5      213    binary section begins
 
-     None of these octets are included in the calculation of
-     the message size or in the calculation of the
-     message digest.
+              None of these octets are included in the calculation of
+              the message size or in the calculation of the
+              message digest.
 
-     The X-Binary-Size header specifies the size of the
-     equivalent binary data in octets.  If compression was
-     used, this size is the size after compression, including
-     any book-keeping fields.  An adjustment is made for
-     the deprecated binary formats in which eight bytes of binary
-     header are used for the compression type.  In this case,
-     the eight bytes used for the compression type are subtracted
-     from the size, so that the same size will be reported
-     if the compression type is supplied in the MIME header.
-     Use of the MIME header is the recommended way to
-     supply the compression type.  In general, no portion of
-     the  binary header is included in the calculation of the size.
+              The X-Binary-Size header specifies the size of the
+              equivalent binary data in octets.  If compression was
+              used, this size is the size after compression, including
+              any book-keeping fields.  An adjustment is made for
+              the deprecated binary formats in which eight bytes of binary
+              header are used for the compression type.  In this case,
+              the eight bytes used for the compression type are subtracted
+              from the size, so that the same size will be reported
+              if the compression type is supplied in the MIME header.
+              Use of the MIME header is the recommended way to
+              supply the compression type.  In general, no portion of
+              the  binary header is included in the calculation of the size.
 
-     The X-Binary-Element-Type header specifies the type of
-     binary data in the octets, using the same descriptive
-     phrases as in _array_structure.encoding_type.  The default
-     value is 'unsigned 32-bit integer'.
+              The X-Binary-Element-Type header specifies the type of
+              binary data in the octets, using the same descriptive
+              phrases as in _array_structure.encoding_type.  The default
+              value is 'unsigned 32-bit integer'.
 
-     An MD5 message digest may, optionally, be used. The 'RSA Data
-     Security, Inc. MD5 Message-Digest Algorithm' should be used.
-     No portion of the header is included in the calculation of the
-     message digest.
+              An MD5 message digest may, optionally, be used. The 'RSA Data
+              Security, Inc. MD5 Message-Digest Algorithm' should be used.
+              No portion of the header is included in the calculation of the
+              message digest.
 
-     If the Transfer Encoding is 'X-BASE8', 'X-BASE10' or
-     'X-BASE16', the data are presented as octal, decimal or
-     hexadecimal data organized into lines or words.  Each word
-     is created by composing octets of data in fixed groups of
-     2, 3, 4, 6 or 8 octets, either in the order ...4321 ('big-
-     endian') or 1234... ('little-endian').  If there are fewer
-     than the specified number of octets to fill the last word,
-     then the missing octets are presented as '==' for each
-     missing octet.  Exactly two equal signs are used for each
-     missing octet even for octal and decimal encoding.
-     The format of lines is:
+              If the Transfer Encoding is 'X-BASE8', 'X-BASE10' or
+              'X-BASE16', the data are presented as octal, decimal or
+              hexadecimal data organized into lines or words.  Each word
+              is created by composing octets of data in fixed groups of
+              2, 3, 4, 6 or 8 octets, either in the order ...4321 ('big-
+              endian') or 1234... ('little-endian').  If there are fewer
+              than the specified number of octets to fill the last word,
+              then the missing octets are presented as '==' for each
+              missing octet.  Exactly two equal signs are used for each
+              missing octet even for octal and decimal encoding.
+              The format of lines is:
 
-     rnd xxxxxx xxxxxx xxxxxx
+              rnd xxxxxx xxxxxx xxxxxx
 
-     where r is 'H', 'O' or 'D' for hexadecimal, octal or
-     decimal, n is the number of octets per word and d is '<'
-     or '>' for the '...4321' and '1234...' octet orderings,
-     respectively.  The '==' padding for the last word should
-     be on the appropriate side to correspond to the missing
-     octets, e.g.
+              where r is 'H', 'O' or 'D' for hexadecimal, octal or
+              decimal, n is the number of octets per word and d is '<'
+              or '>' for the '...4321' and '1234...' octet orderings,
+              respectively.  The '==' padding for the last word should
+              be on the appropriate side to correspond to the missing
+              octets, e.g.
 
-     H4< FFFFFFFF FFFFFFFF 07FFFFFF ====0000
+              H4< FFFFFFFF FFFFFFFF 07FFFFFF ====0000
 
-     or
+              or
 
-     H3> FF0700 00====
+              H3> FF0700 00====
 
-     For these hexadecimal, octal and decimal formats only,
-     comments beginning with '#' are permitted to improve
-     readability.
+              For these hexadecimal, octal and decimal formats only,
+              comments beginning with '#' are permitted to improve
+              readability.
 
-     BASE64 encoding follows MIME conventions.  Octets are
-     in groups of three: c1, c2, c3.  The resulting 24 bits
-     are broken into four six-bit quantities, starting with
-     the high-order six bits (c1 >> 2) of the first octet, then
-     the low-order two bits of the first octet followed by the
-     high-order four bits of the second octet [(c1 & 3)<<4 | (c2>>4)],
-     then the bottom four bits of the second octet followed by the
-     high-order two bits of the last octet [(c2 & 15)<<2 | (c3>>6)],
-     then the bottom six bits of the last octet (c3 & 63).  Each
-     of these four quantities is translated into an ASCII character
-     using the mapping:
+              BASE64 encoding follows MIME conventions.  Octets are
+              in groups of three: c1, c2, c3.  The resulting 24 bits
+              are broken into four six-bit quantities, starting with
+              the high-order six bits (c1 >> 2) of the first octet, then
+              the low-order two bits of the first octet followed by the
+              high-order four bits of the second octet [(c1 & 3)<<4 | (c2>>4)],
+              then the bottom four bits of the second octet followed by the
+              high-order two bits of the last octet [(c2 & 15)<<2 | (c3>>6)],
+              then the bottom six bits of the last octet (c3 & 63).  Each
+              of these four quantities is translated into an ASCII character
+              using the mapping:
 
-               1         2         3         4         5         6
-     0123456789012345678901234567890123456789012345678901234567890123
-     |         |         |         |         |         |         |
-     ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+                        1         2         3         4         5         6
+              0123456789012345678901234567890123456789012345678901234567890123
+              |         |         |         |         |         |         |
+              ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
 
-     with short groups of octets padded on the right with one '='
-     if c3 is missing, and with '==' if both c2 and c3 are missing.
+              with short groups of octets padded on the right with one '='
+              if c3 is missing, and with '==' if both c2 and c3 are missing.
 
-     X-BASE32K encoding is similar to BASE64 encoding, except that
-     sets of 15 octets are encoded as sets of 8 16-bit Unicode
-     characters, by breaking the 120 bits into 8 15-bit quantities.
-     256 is added to each 15-bit quantity to bring it into a
-     printable Unicode range.  When encoding, zero padding is used
-     to fill out the last 15-bit quantity.  If 8 or more bits of
-     padding are used, a single equals sign (hexadecimal 003D) is
-     appended.  Embedded whitespace and newlines are introduced
-     to produce lines of no more than 80 characters each.  On
-     decoding, all printable ASCII characters and ASCII whitespace
-     characters are ignored except for any trailing equals signs.
-     The number of trailing equals signs indicated the number of
-     trailing octets to be trimmed from the end of the decoded data
-     (see Darakev et al., 2006).
+              X-BASE32K encoding is similar to BASE64 encoding, except that
+              sets of 15 octets are encoded as sets of 8 16-bit Unicode
+              characters, by breaking the 120 bits into 8 15-bit quantities.
+              256 is added to each 15-bit quantity to bring it into a
+              printable Unicode range.  When encoding, zero padding is used
+              to fill out the last 15-bit quantity.  If 8 or more bits of
+              padding are used, a single equals sign (hexadecimal 003D) is
+              appended.  Embedded whitespace and newlines are introduced
+              to produce lines of no more than 80 characters each.  On
+              decoding, all printable ASCII characters and ASCII whitespace
+              characters are ignored except for any trailing equals signs.
+              The number of trailing equals signs indicated the number of
+              trailing octets to be trimmed from the end of the decoded data
+              (see Darakev et al., 2006).
 
-     QUOTED-PRINTABLE encoding also follows MIME conventions, copying
-     octets without translation if their ASCII values are 32...38,
-     42, 48...57, 59, 60, 62, 64...126 and the octet is not a ';'
-     in column 1.  All other characters are translated to =nn, where
-     nn is the hexadecimal encoding of the octet.  All lines are
-     'wrapped' with a terminating '=' (i.e. the MIME conventions
-     for an implicit line terminator are never used).
+              QUOTED-PRINTABLE encoding also follows MIME conventions, copying
+              octets without translation if their ASCII values are 32...38,
+              42, 48...57, 59, 60, 62, 64...126 and the octet is not a ';'
+              in column 1.  All other characters are translated to =nn, where
+              nn is the hexadecimal encoding of the octet.  All lines are
+              'wrapped' with a terminating '=' (i.e. the MIME conventions
+              for an implicit line terminator are never used).
 
-     The 'X-Binary-Element-Byte-Order' can specify either
-     'BIG_ENDIAN' or 'LITTLE_ENDIAN' byte order of the image
-     data.  Only LITTLE_ENDIAN is recommended.  Processors
-     may treat BIG_ENDIAN as a warning of data that can
-     only be processed by special software.
+              The 'X-Binary-Element-Byte-Order' can specify either
+              'BIG_ENDIAN' or 'LITTLE_ENDIAN' byte order of the image
+              data.  Only LITTLE_ENDIAN is recommended.  Processors
+              may treat BIG_ENDIAN as a warning of data that can
+              only be processed by special software.
 
-     The 'X-Binary-Number-of-Elements' specifies the number of
-     elements (not the number of octets) in the decompressed,
-     decoded image.
+              The 'X-Binary-Number-of-Elements' specifies the number of
+              elements (not the number of octets) in the decompressed,
+              decoded image.
 
-     The optional 'X-Binary-Size-Fastest-Dimension' specifies the
-     number of elements (not the number of octets) in one row of the
-     fastest changing dimension of the binary data array. This
-     information must be in the MIME header for proper operation of
-     some of the decompression algorithms.
+              The optional 'X-Binary-Size-Fastest-Dimension' specifies the
+              number of elements (not the number of octets) in one row of the
+              fastest changing dimension of the binary data array. This
+              information must be in the MIME header for proper operation of
+              some of the decompression algorithms.
 
-     The optional 'X-Binary-Size-Second-Dimension' specifies the
-     number of elements (not the number of octets) in one column of
-     the second-fastest changing dimension of the binary data array.
-     This information must be in the MIME header for proper operation
-     of some of the decompression algorithms.
+              The optional 'X-Binary-Size-Second-Dimension' specifies the
+              number of elements (not the number of octets) in one column of
+              the second-fastest changing dimension of the binary data array.
+              This information must be in the MIME header for proper operation
+              of some of the decompression algorithms.
 
-     The optional 'X-Binary-Size-Third-Dimension' specifies the
-     number of sections for the third-fastest changing dimension of
-     the binary data array.
+              The optional 'X-Binary-Size-Third-Dimension' specifies the
+              number of sections for the third-fastest changing dimension of
+              the binary data array.
 
-     The optional 'X-Binary-Size-Padding' specifies the size in
-     octets of an optional padding after the binary array data and
-     before the closing flags for a binary section.
+              The optional 'X-Binary-Size-Padding' specifies the size in
+              octets of an optional padding after the binary array data and
+              before the closing flags for a binary section.
 
-     Reference:
+              Reference:
 
-     Darakev, G., Litchev, V., Mitev, K. Z. & Bernstein, H. J. (2006).
-     'Efficient Support of Binary Data in the XML Implementation of
-     the NeXus File Format', abstract W0165, ACA Summer Meeting,
-     Honolulu, HI, USA, July 2006.
+              Darakev, G., Litchev, V., Mitev, K. Z. & Bernstein, H. J. (2006).
+              'Efficient Support of Binary Data in the XML Implementation of
+              the NeXus File Format', abstract W0165, ACA Summer Meeting,
+              Honolulu, HI, USA, July 2006.
 ;
     _name.category_id             array_data
     _name.object_id               data
@@ -1186,6 +1277,7 @@ save_array_data.data
     _type.container               Array
     _type.contents                Complex
     _type.ddl2_code               binary
+    _units.code                   none
 
 save_
 
@@ -1193,14 +1285,14 @@ save_array_data.external_data_id
 
     _definition.id                '_array_data.external_data_id'
     _description.text
-;
-    This item is a pointer to _array_data_external_data.id  in the
-     ARRAY_DATA_EXTERNAL_DATA  category.
+;             This item is a pointer to _array_data_external_data.id in the
+              ARRAY_DATA_EXTERNAL_DATA category.
 
-     If not given, then the actual array data should be specified as
-     the value of _array_data.data.  If
-     both values are given, the value on _array_data.data  takes
-     precedence, and a warning of a possible conflict should be issued.
+              If not given, then the actual array data should be specified as
+              the value of _array_data.data.  If
+              both values are given, the value on _array_data.data takes
+              precedence, and a warning of a possible conflict should be issued. 
+
 ;
     _name.category_id             array_data
     _name.object_id               external_data_id
@@ -1219,15 +1311,14 @@ save_array_data.header_contents
 
     _definition.id                '_array_data.header_contents'
     _description.text
-;
-    This item is a text field for use in minimal CBF files to carry
-     essential header information to be kept with image data
-     in _array_data.data when the tags that normally carry the
-     structured metadata for the image have not been populated.
+;             This item is a text field for use in minimal CBF files to carry
+              essential header information to be kept with image data
+              in _array_data.data when the tags that normally carry the
+              structured metadata for the image have not been populated.
 
-     Normally this data item should not appear when the full set
-     of tags has been populated and _diffrn_data_frame.details
-     appears.
+              Normally this data item should not appear when the full set
+              of tags has been populated and _diffrn_data_frame.details
+              appears.
 ;
     _name.category_id             array_data
     _name.object_id               header_contents
@@ -1244,16 +1335,15 @@ save_array_data.header_convention
 
     _definition.id                '_array_data.header_convention'
     _description.text
-;
-    This item is an identifier for the convention followed in
-     constructing the contents of _array_data.header_contents
+;             This item is an identifier for the convention followed in
+              constructing the contents of _array_data.header_contents
 
-     The permitted values are of an image creator identifier
-     followed by an underscore and a version string.  To avoid
-     confusion about conventions, all creator identifiers
-     should be registered with the IUCr and the conventions
-     for all identifiers and versions should be posted on
-     the MEDSBIO.org web site.
+              The permitted values are of an image creator identifier
+              followed by an underscore and a version string.  To avoid
+              confusion about conventions, all creator identifiers
+              should be registered with the IUCr and the conventions
+              for all identifiers and versions should be posted on
+              the MEDSBIO.org web site.
 ;
     _name.category_id             array_data
     _name.object_id               header_convention
@@ -1270,15 +1360,14 @@ save_array_data.variant
 
     _definition.id                '_array_data.variant'
     _description.text
-;
-    The value of _array_data.variant  gives the variant
-     to which the given ARRAY_DATA row is related.
+;             The value of _array_data.variant gives the variant
+              to which the given ARRAY_DATA row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_data
     _name.object_id               variant
@@ -1295,19 +1384,58 @@ save_
 
 save_ARRAY_DATA_EXTERNAL_DATA
 
-    _definition.id                ARRAY_DATA_EXTERNAL_DATA
+    _definition.id                array_data_external_data
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the ARRAY_DATA_EXTERNAL_DATA  category optionally
+    Data items in the ARRAY_DATA_EXTERNAL_DATA category optionally
      record the location and essential characteristics of arrays of data for
-    use in  ARRAY_DATA  that are found external to the cif_img file.
+    use in  ARRAY_DATA that are found external to the cif_img file.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_DATA_EXTERNAL_DATA
+    _name.object_id               array_data_external_data
     _name.ddl2_mandatory          no
     _category_key.name            '_array_data_external_data.id'
+    _nx_mapping.details
+;    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.external_data_id EXTERNAL_DATA_ID
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    _array_data_external_data.archive_format ARCHIVEFORMAT
+    _array_data_external_data.archive_path ARCHIVEPATH
+    _array_data_external_data.id EXTERNAL_DATA_ID
+    _array_data_external_data.format HDF5
+    _array_data_external_data.uri DATAURI
+    _array_data_external_data.path DATAPATH
+    _array_data_external_data.frame DATAFRAME
+    -->
+
+    /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+       data_ARRAYID_BINARYID --> DATAURI//DATAPATH
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+            @CBF_external_data_archive_format="ARCHIVEFORMAT"
+            @CBF_external_data_archive_path="ARCHIVEPATH""
+            @CBF_external_data_uri="DATAURI"
+            @CBF_external_data_path="DATAPATH"
+            @CBF_external_data_frame="DATAFRAME"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -1353,13 +1481,36 @@ save_array_data_external_data.archive_path
 
 save_
 
+save_array_data_external_data.file_compression
+
+    _definition.id                '_array_data_external_data.file_compression'
+    _description.text
+;
+    The type of compression used for the file corresponding to
+    a single frame, if any.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               file_compression
+    _name.ddl2_mandatory          no
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         GZ                       'A Gzipped file'
+         BZ2                      'File compressed with Bzip2'
+         .                        'Individual file compression not used'
+
+    _enumeration.default          .
+
+save_
+
 save_array_data_external_data.format
 
     _definition.id                '_array_data_external_data.format'
     _description.text
 ;
     The format in which raw array data referenced by
-    _array_data_external_data.uri  and following archive extraction can be
+    _array_data_external_data.uri and following archive extraction can be
     accessed. Items in array_structure and array_structure_list refer
     to the data after any decompressions and other transformations
     performed by standard libraries associated with the format as
@@ -1374,13 +1525,13 @@ save_array_data_external_data.format
     _array_data_external_data.archive_path,
     _array_data_external_data.format,
     _array_data_external_data.path, and
-    _array_data_external_data.frame  while
+    _array_data_external_data.frame while
     if no single file archive is used, so that a CBF, HDF5, TIFF or SMV is
     specified at _array_data_external_data.uri, then
     the particular image is specified by the combination of
     _array_data_external_data.format,
     _array_data_external_data.path, and
-    _array_data_external_data.frame  directly.
+    _array_data_external_data.frame directly.
 ;
     _name.category_id             array_data_external_data
     _name.object_id               format
@@ -1404,12 +1555,20 @@ save_array_data_external_data.format
          An array of numbers contained in a dataset in an HDF5 file as returned
          by HDF5 library functions. '_array_data_external_data.path' is the
          internal HDF5 path. In an HDF5 file, the path typically identifies a
-         dataset with multiple images.
+         dataset with multiple images. '_array_data_external_data.frame' is
+         used to select a particular image.
+;
+         TIFF
+;
+         An array of numbers corresponding to a decompressed single frame
+         contained within a TIFF file that meets the TIFF 6.0 baseline
+         specification. '_array_data_external_data.frame' is the image number
+         when multiple images are contained in a single TIFF file.
 ;
          MAR
 ;
-         An array of numbers corresponding to a decompressed single frame
-         contained within a MARCCD file (TIFF format).
+         An array of numbers corresponding to a decompressed single frame from
+         the Rayonix company.
 ;
          Bruker
 ;
@@ -1464,30 +1623,51 @@ save_array_data_external_data.format
          accessible using https://uni_repo.edu/5341 in subdirectory run1.
 ;
 ;
-                  loop_
-                  _array_data.array_id
-                  _array_data.binary_id
-                  _array_data.external_data_id
-                  1 1 1
-                  1 2 2
-                  loop_
-                  _array_data_external_data.id
-                  _array_data_external_data.format
-                  _array_data_external_data.uri
-                  _array_data_external_data.archive_format
-                  _array_data_external_data.archive_path
-                  1 SMV
-https://data.proteindiffraction.org/ssgcid/sddc0001574_7k69.tar.bz2
-                      TBZ
-MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0001.img
-                  2 SMV
-https://data.proteindiffraction.org/ssgcid/sddc0001574_7k69.tar.bz2
-                      TBZ
-MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0002.img
+    loop_
+    _array_data.array_id
+    _array_data.binary_id
+    _array_data.external_data_id
+    1 1 1
+    1 2 2
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.archive_format
+    _array_data_external_data.archive_path
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0001.img
+    2 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0002.img
 ;
 ;
          Frames with SMV format are contained at data.proteindiffraction.org in
          a tarred archive compressed with bzip2.
+;
+; 
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.archive_format
+    _array_data_external_data.archive_path
+    _array_data_external_data.file_compression
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/4jga.tar
+        TAR
+        3lls/series/200873f12_x0085.img.bz2 BZ2
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/4jga.tar
+        TAR
+        3lls/series/200873f12_x0085.img.bz2 BZ2
+;
+;
+         Frames with SMV format are contained at data.proteindiffraction.org in
+         a tarred archive with each frame individually compressed with Bzip2.
 ;
 
 save_
@@ -1497,22 +1677,24 @@ save_array_data_external_data.frame
     _definition.id                '_array_data_external_data.frame'
     _description.text
 ;
+
     The position of the raw data array in what may possibly be a
-    multi-dimensional array of data referenced by
+    multi-dimensional array of data referenced by   
        _array_data_external_data.uri and _array_data_external_data.path.
     For many of the formats, data for a single frame is identified by that
     reference.  If data for multiple frames or data for portions of
     one or more frames is referenced, the desired portion can be
-    identified dimension by dimension as an array section identifier
+    identified dimension by dimension as an array section identifier 
     the form
        ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
     or other valid ARRAY_STRUCTURE_LIST_SECTION
     identifier.
-
+    
     Note that the precendence ordering of dimensions varies, even within a
     single specified format.  For example HDF5 supports both C slowest first
     and Fortran fastest first, so it is essential to properly populate
-    ARRAY_STRUCTURE_LIST  category.
+    ARRAY_STRUCTURE_LIST category.
+    
 ;
     _name.category_id             array_data_external_data
     _name.object_id               frame
@@ -1532,19 +1714,18 @@ save_array_data_external_data.id
 
     _definition.id                '_array_data_external_data.id'
     _description.text
-;
-    The value of _array_data_external_data.id  must uniquely identify
-     each item of array_data_external_data.
+;             The value of _array_data_external_data.id must uniquely identify
+              each item of array_data_external_data.              
 
-     This item has been made implicit and given a default value of 1
-     as a convenience in writing miniCBF files.  Normally an
-     explicit name with useful content should be used.
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
 ;
     _name.category_id             array_data_external_data
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -1601,15 +1782,14 @@ save_array_data_external_data.variant
 
     _definition.id                '_array_data_external_data.variant'
     _description.text
-;
-    The value of _array_data_external_data.variant  gives the variant
-     to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
+;             The value of _array_data_external_data.variant gives the variant
+              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_data_external_data
     _name.object_id               variant
@@ -1643,16 +1823,16 @@ save_
 
 save_ARRAY_ELEMENT_SIZE
 
-    _definition.id                ARRAY_ELEMENT_SIZE
+    _definition.id                array_element_size
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the ARRAY_ELEMENT_SIZE  category record the physical
+    Data items in the ARRAY_ELEMENT_SIZE category record the physical
      size of array elements along each array dimension.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_ELEMENT_SIZE
+    _name.object_id               array_element_size
     _name.ddl2_mandatory          no
 
     loop_
@@ -1662,19 +1842,40 @@ save_ARRAY_ELEMENT_SIZE
          '_array_element_size.variant'
 
     _description_example.case
-;
-     loop_
-    _array_element_size.array_id
-    _array_element_size.index
-    _array_element_size.size
-     image_1   1    1.22e-6
-     image_1   2    1.22e-6
+;        loop_
+       _array_element_size.array_id
+       _array_element_size.index
+       _array_element_size.size
+        image_1   1    1.22e-6
+        image_1   2    1.22e-6
 ;
     _description_example.detail
+;      Example 1. A regular 2D array with a uniform element dimension
+                    of 1220 nanometres.
 ;
-    Example 1. A regular 2D array with a uniform element dimension
-                  of 1220 nanometres.
+    _nx_mapping.details
+;    _array_element_size.array_id ARRAYID 
+    _array_element_size.index INDEX   (See _array_element_size.array_id)
+    _array_element_size.size SIZE
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+          /?_pixel_size_ARRAYID=SIZE
+            @CBF_array_id="ARRAYID"
+    where "?" is "x", "y", "z" for
+    _array_element_size.index == 1,2, or 3 respectively
 ;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -1682,9 +1883,8 @@ save_array_element_size.array_id
 
     _definition.id                '_array_element_size.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_element_size
     _name.object_id               array_id
@@ -1701,9 +1901,8 @@ save_array_element_size.index
 
     _definition.id                '_array_element_size.index'
     _description.text
-;
-    This item is a pointer to _array_structure_list.index  in
-     the ARRAY_STRUCTURE_LIST category.
+;             This item is a pointer to _array_structure_list.index in
+              the ARRAY_STRUCTURE_LIST category.
 ;
     _name.category_id             array_element_size
     _name.object_id               index
@@ -1721,10 +1920,9 @@ save_array_element_size.size
 
     _definition.id                '_array_element_size.size'
     _description.text
-;
-    The size in metres of an image element in this
-     dimension. This supposes that the elements are arranged
-     on a regular grid.
+;             The size in metres of an image element in this
+              dimension. This supposes that the elements are arranged
+              on a regular grid.
 ;
     _name.category_id             array_element_size
     _name.object_id               size
@@ -1736,6 +1934,8 @@ save_array_element_size.size
     _type.ddl2_code               float
     _type.ddl2_units              metres
     _units.code                   metres
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -1743,15 +1943,14 @@ save_array_element_size.variant
 
     _definition.id                '_array_element_size.variant'
     _description.text
-;
-    The value of _array_element_size.variant  gives the variant
-     to which the given ARRAY_ELEMENT_SIZE row is related.
+;             The value of _array_element_size.variant gives the variant
+              to which the given ARRAY_ELEMENT_SIZE row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_element_size
     _name.object_id               variant
@@ -1768,14 +1967,14 @@ save_
 
 save_ARRAY_INTENSITIES
 
-    _definition.id                ARRAY_INTENSITIES
+    _definition.id                array_intensities
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the ARRAY_INTENSITIES  category record the
+    Data items in the ARRAY_INTENSITIES category record the
      information required to recover the intensity data from
-     the set of data values stored in the ARRAY_DATA  category.
+     the set of data values stored in the ARRAY_DATA category.
 
      The detector may have a complex relationship
      between the raw intensity values and the number of
@@ -1784,11 +1983,11 @@ save_ARRAY_INTENSITIES
      to the actual number of incident photons, given by
      _array_intensities.gain.  If raw, uncorrected values
      are presented (e.g. for calibration experiments), the
-     value of _array_intensities.linearity  will be 'raw'
+     value of _array_intensities.linearity will be 'raw'
      and _array_intensities.gain will not be used.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_INTENSITIES
+    _name.object_id               array_intensities
     _name.ddl2_mandatory          no
 
     loop_
@@ -1798,22 +1997,81 @@ save_ARRAY_INTENSITIES
          '_array_intensities.variant'
 
     _description_example.case
-;
-    loop_
-    _array_intensities.array_id
-    _array_intensities.linearity
-    _array_intensities.gain
-    _array_intensities.overload
-    _array_intensities.undefined_value
-    _array_intensities.pixel_fast_bin_size
-    _array_intensities.pixel_slow_bin_size
-    _array_intensities.pixel_binning_method
-    image_1   linear  1.2    655535   0   2   2    hardware
+;        loop_
+        _array_intensities.array_id
+        _array_intensities.linearity
+        _array_intensities.gain
+        _array_intensities.overload
+        _array_intensities.undefined_value
+        _array_intensities.pixel_fast_bin_size
+        _array_intensities.pixel_slow_bin_size
+        _array_intensities.pixel_binning_method
+        image_1   linear  1.2    655535   0   2   2    hardware
 ;
     _description_example.detail
 ;
     Example 1
 ;
+    _nx_mapping.details
+;    _array_intensities.array_id ARRAYID
+    _array_intensities.binary_id BINARYID
+    _array_intensities.details DETAILS
+    _array_intensities.gain GAIN
+    _array_intensities.gain_esd GAINESD
+    _array_intensities.linearity LINEARITY
+    _array_intensities.offset OFFSET
+    _array_intensities.scaling SCALING
+    _array_intensities.overload OVERLOAD
+    _array_intensities.undefined_value UNDEFVAL
+    _array_intensities.underload UNDERLOAD
+    _array_intensities.pixel_fast_bin_size FBINSIZE
+    _array_intensities.pixel_slow_bin_size SBINSIZE
+    _array_intensities.pixel_binning_method METHOD
+    -->
+
+      /entry:NXentry
+        /data_ARRAYID_BINARYID:NXdata
+          /data_ARRAYID_BINARYID
+              @CBF_array_id="ARRAYID"
+              @CBF_binary_id="BINARYID"
+              @details="DETAILS"
+              @gain=[GAIN]          
+              @gain_esd=[GAINESD]
+              @linearity="LINEARITY"          
+              @offset=[OFFSET]
+              @saturation_value=[OVERLOAD]
+              @scaling_factor=[SCALING]
+              @undefined_value=[UNDEFVAL]
+              @underload_value=[UNDERLOAD]
+              @CBF_array_intensities__pixel_fast_bin_size=[FBINSIZE]
+              @CBF_array_intensities__pixel_slow_bin_size=[SBINSIZE]
+              @CBF_array_intensities__pixel_binning_method="METHOD"
+       /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+
+    The argument has been made that these attributes are not needed
+    because NeXus files are supposed to have 'true values' stored.
+    In many cases that is true and then none of these attributes
+    are needed.  However, with some detectors and some experiments
+    there are good technical and scientific reasons to bring in values
+    that will need processing later to derive 'true values', and in
+    those case some or all of these attributes will be needed.  They
+    are provided for such cases.
+
+    The same attributes could be used as fields in the case of a single
+    data array, but in that case links for all the fields would be needed
+    from NXdata to NXdetector, so it is preferable to use attributes even
+    in the case of a single data array.  The reverse mapping will support
+    both uses.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -1821,9 +2079,8 @@ save_array_intensities.array_id
 
     _definition.id                '_array_intensities.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_intensities
     _name.object_id               array_id
@@ -1841,9 +2098,8 @@ save_array_intensities.binary_id
 
     _definition.id                '_array_intensities.binary_id'
     _description.text
-;
-    This item is a pointer to _array_data.binary_id  in the
-     ARRAY_DATA  category.
+;             This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
 ;
     _name.category_id             array_intensities
     _name.object_id               binary_id
@@ -1861,9 +2117,8 @@ save_array_intensities.details
 
     _definition.id                '_array_intensities.details'
     _description.text
-;
-    A description of special aspects of the calculation of array
-     intensities.
+;             A description of special aspects of the calculation of array 
+              intensities.
 ;
     _name.category_id             array_intensities
     _name.object_id               details
@@ -1881,10 +2136,9 @@ save_array_intensities.gain
 
     _definition.id                '_array_intensities.gain'
     _description.text
-;
-    Detector 'gain'. The factor by which linearized
-     intensity count values should be divided to produce
-     true photon counts.
+;             Detector 'gain'. The factor by which linearized
+              intensity count values should be divided to produce
+              true photon counts.
 ;
     _name.category_id             array_intensities
     _name.object_id               gain
@@ -1896,6 +2150,10 @@ save_array_intensities.gain
     _type.ddl2_code               float
     _type.ddl2_units              counts_per_photon
     _units.code                   counts_per_photon
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_array_intensities.gain_esd'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -1903,9 +2161,8 @@ save_array_intensities.gain_esd
 
     _definition.id                '_array_intensities.gain_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of detector 'gain'.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of detector 'gain'.
 ;
     _name.category_id             array_intensities
     _name.object_id               gain_esd
@@ -1918,6 +2175,10 @@ save_array_intensities.gain_esd
     _type.ddl2_code               float
     _type.ddl2_units              counts_per_photon
     _units.code                   counts_per_photon
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_array_intensities.gain'
+    _ddl2_item_related.function_code associated_esd
 
 save_
 
@@ -1925,39 +2186,38 @@ save_array_intensities.linearity
 
     _definition.id                '_array_intensities.linearity'
     _description.text
-;
-    The intensity linearity scaling method used to convert
-     from the raw intensity to the stored element value:
+;             The intensity linearity scaling method used to convert
+              from the raw intensity to the stored element value:
 
-    'linear' is linear.
+             'linear' is linear.
 
-    'offset'  means that the value defined by
-    _array_intensities.offset  should be added to each
-    element value.
+             'offset'  means that the value defined by
+             _array_intensities.offset should be added to each
+             element value.
 
-    'scaling' means that the value defined by
-    _array_intensities.scaling  should be multiplied with each
-    element value.
+             'scaling' means that the value defined by
+             _array_intensities.scaling should be multiplied with each
+             element value.
 
-    'scaling_offset' is the combination of the two previous cases,
-    with the scale factor applied before the offset value.
+             'scaling_offset' is the combination of the two previous cases,
+             with the scale factor applied before the offset value.
 
-    'sqrt_scaled' means that the square root of raw
-    intensities multiplied by _array_intensities.scaling  is
-    calculated and stored, perhaps rounded to the nearest
-    integer. Thus, linearization involves dividing the stored
-    values by _array_intensities.scaling  and squaring the
-    result.
+             'sqrt_scaled' means that the square root of raw
+             intensities multiplied by _array_intensities.scaling is
+             calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling and squaring the
+             result.
 
-    'logarithmic_scaled' means that the logarithm base 10 of
-    raw intensities multiplied by _array_intensities.scaling
-    is calculated and stored, perhaps rounded to the nearest
-    integer. Thus, linearization involves dividing the stored
-    values by _array_intensities.scaling  and calculating 10
-    to the power of this number.
+             'logarithmic_scaled' means that the logarithm base 10 of
+             raw intensities multiplied by _array_intensities.scaling
+             is calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling and calculating 10
+             to the power of this number.
 
-    'raw' means that the data are a set of raw values straight
-    from the detector.
+             'raw' means that the data are a set of raw values straight
+             from the detector.
 ;
     _name.category_id             array_intensities
     _name.object_id               linearity
@@ -1974,44 +2234,43 @@ save_array_intensities.linearity
          linear
              .
          offset
-;
-         The value defined by _array_intensities.offset should be added to each
-         element value.
+;            The value defined by  _array_intensities.offset should
+             be added to each element value.
 ;
          scaling
-;
-         The value defined by _array_intensities.scaling should be multiplied
-         with each element value.
+;            The value defined by _array_intensities.scaling should be
+             multiplied with each element value.
 ;
          scaling_offset
-;
-         The combination of the scaling and offset with the scale factor
-         applied before the offset value.
+;            The combination of the scaling and offset
+             with the scale factor applied before the offset value.
 ;
          sqrt_scaled
-;
-         The square root of raw intensities multiplied by
-         _array_intensities.scaling is calculated and stored, perhaps rounded
-         to the nearest integer. Thus, linearization involves dividing the
-         stored values by _array_intensities.scaling and squaring the result.
+;            The square root of raw intensities multiplied by
+             _array_intensities.scaling is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored
+             values by _array_intensities.scaling and squaring the
+             result.
 ;
          logarithmic_scaled
-;
-         The logarithm base 10 of raw intensities multiplied by
-         _array_intensities.scaling is calculated and stored, perhaps rounded
-         to the nearest integer. Thus, linearization involves dividing the
-         stored values by _array_intensities.scaling and calculating 10 to the
-         power of this number.
+;            The logarithm base 10 of raw intensities multiplied by
+             _array_intensities.scaling  is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored values by
+             _array_intensities.scaling and calculating 10 to the
+             power of this number.
 ;
          raw
-;
-         The array consists of raw values to which no corrections have been
-         applied. While the handling of the data is similar to that given for
-         'linear' data with no offset, the meaning of the data differs in that
-         the number of incident photons is not necessarily linearly related to
-         the number of counts reported. This value is intended for use either
-         in calibration experiments or to allow for handling more complex
-         data-fitting algorithms than are allowed for by this data item.
+;            The array consists of raw values to which no corrections have
+             been applied.  While the handling of the data is similar to
+             that given for 'linear' data with no offset, the meaning of
+             the data differs in that the number of incident photons is
+             not necessarily linearly related to the number of counts
+             reported.  This value is intended for use either in
+             calibration experiments or to allow for handling more
+             complex data-fitting algorithms than are allowed for by
+             this data item.
 ;
 
 save_
@@ -2020,9 +2279,8 @@ save_array_intensities.offset
 
     _definition.id                '_array_intensities.offset'
     _description.text
-;
-    Offset value to add to array element values in the manner
-     described by the item _array_intensities.linearity.
+;             Offset value to add to array element values in the manner
+              described by the item _array_intensities.linearity.
 ;
     _name.category_id             array_intensities
     _name.object_id               offset
@@ -2032,6 +2290,7 @@ save_array_intensities.offset
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -2039,13 +2298,12 @@ save_array_intensities.overload
 
     _definition.id                '_array_intensities.overload'
     _description.text
-;
-    The saturation intensity level for this data array, i.e. the
-     value above which correct intensities may not be recorded.
+;             The saturation intensity level for this data array, i.e. the
+              value at or above which correct intensities may not be recorded.
 
-     The valid pixel values are those less than
-     _array_intensities.overload  and greater than or equal to
-     _array_intensities.underload
+              The valid pixel values are those less than
+              _array_intensities.overload and greater than or equal to 
+              _array_intensities.underload
 ;
     _name.category_id             array_intensities
     _name.object_id               overload
@@ -2064,9 +2322,8 @@ save_array_intensities.pixel_binning_method
 
     _definition.id                '_array_intensities.pixel_binning_method'
     _description.text
-;
-    The value of _array_intensities.pixel_binning_method  specifies
-     the method used to derive array elements from multiple pixels.
+;             The value of _array_intensities.pixel_binning_method specifies
+              the method used to derive array elements from multiple pixels.
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_binning_method
@@ -2081,33 +2338,30 @@ save_array_intensities.pixel_binning_method
       _enumeration_set.state
       _enumeration_set.detail
          hardware
-;
-         The element intensities were derived from the raw data of one or more
-         pixels by use of hardware in the detector, e.g. by use of shift
-         registers in a CCD to combine pixels into super-pixels.
+;              The element intensities were derived from the raw data of one
+               or more pixels by use of hardware in the detector, e.g. by use
+               of shift registers in a CCD to combine pixels into super-pixels.
 ;
          software
-;
-         The element intensities were derived from the raw data of more than
-         one pixel by use of software.
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of software.
 ;
          combined
-;
-         The element intensities were derived from the raw data of more than
-         one pixel by use of both hardware and software, as when hardware
-         binning is used in one direction and software in the other.
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of both hardware and software, as when
+               hardware binning is used in one direction and software in the
+               other.
 ;
          none
-;
-         In both directions, the data have not been binned. The number of
-         pixels is equal to the number of elements. When the value of
-         _array_intensities.pixel_binning_method is 'none' the values of
-         _array_intensities.pixel_fast_bin_size and
-         _array_intensities.pixel_slow_bin_size both must be 1.
+;              In both directions, the data have not been binned.  The
+               number of pixels is equal to the number of elements.
+
+               When the value of _array_intensities.pixel_binning_method is
+               'none' the values of _array_intensities.pixel_fast_bin_size
+               and _array_intensities.pixel_slow_bin_size both must be 1.
 ;
          unspecified
-;
-         The method used to derive element intensities is not specified.
+;              The method used to derive element intensities is not specified.
 ;
 
     _enumeration.default          unspecified
@@ -2118,19 +2372,18 @@ save_array_intensities.pixel_fast_bin_size
 
     _definition.id                '_array_intensities.pixel_fast_bin_size'
     _description.text
-;
-    The value of _array_intensities.pixel_fast_bin_size  specifies
-     the number of pixels that compose one element in the direction
-     of the most rapidly varying array dimension.
+;             The value of _array_intensities.pixel_fast_bin_size specifies
+              the number of pixels that compose one element in the direction
+              of the most rapidly varying array dimension.
 
-     Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
-     array element in both directions, the value given for
-     _array_intensities.pixel_binning_method  normally should be
-     'none'.
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method normally should be
+              'none'.
 
-     It is specified as a float to allow for binning algorithms that
-     create array elements that are not integer multiples of the
-     detector pixel size.
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the 
+              detector pixel size.
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_fast_bin_size
@@ -2143,6 +2396,8 @@ save_array_intensities.pixel_fast_bin_size
     _type.ddl2_units              pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -2150,19 +2405,18 @@ save_array_intensities.pixel_slow_bin_size
 
     _definition.id                '_array_intensities.pixel_slow_bin_size'
     _description.text
-;
-    The value of _array_intensities.pixel_slow_bin_size  specifies
-     the number of pixels that compose one element in the direction
-     of the second most rapidly varying array dimension.
+;             The value of _array_intensities.pixel_slow_bin_size specifies
+              the number of pixels that compose one element in the direction
+              of the second most rapidly varying array dimension.
 
-     Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
-     array element in both directions, the value given for
-     _array_intensities.pixel_binning_method  normally should be
-     'none'.
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method normally should be
+              'none'.
 
-     It is specified as a float to allow for binning algorithms that
-     create array elements that are not integer multiples of the
-     detector pixel size.
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the
+              detector pixel size.
 ;
     _name.category_id             array_intensities
     _name.object_id               pixel_slow_bin_size
@@ -2175,6 +2429,8 @@ save_array_intensities.pixel_slow_bin_size
     _type.ddl2_units              pixels_per_element
     _enumeration.default          1.
     _units.code                   pixels_per_element
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -2182,10 +2438,9 @@ save_array_intensities.scaling
 
     _definition.id                '_array_intensities.scaling'
     _description.text
-;
-    Multiplicative scaling value to be applied to array data
-     in the manner described by the item
-     _array_intensities.linearity.
+;             Multiplicative scaling value to be applied to array data
+              in the manner described by the item
+              _array_intensities.linearity.
 ;
     _name.category_id             array_intensities
     _name.object_id               scaling
@@ -2195,6 +2450,7 @@ save_array_intensities.scaling
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -2202,9 +2458,8 @@ save_array_intensities.undefined_value
 
     _definition.id                '_array_intensities.undefined_value'
     _description.text
-;
-    A value to be substituted for undefined values in
-     the data array.
+;             A value to be substituted for undefined values in
+              the data array.
 ;
     _name.category_id             array_intensities
     _name.object_id               undefined_value
@@ -2214,6 +2469,7 @@ save_array_intensities.undefined_value
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -2221,13 +2477,13 @@ save_array_intensities.underload
 
     _definition.id                '_array_intensities.underload'
     _description.text
-;
-    The lowest value at which pixels for this detector are
-     measured.
+;             The lowest value at which pixels for this detector are
+              measured.
 
-     The valid pixel values are those less than
-     _array_intensities.overload  and greater than or equal to
-     _array_intensities.underload
+              The valid pixel values are those less than 
+              _array_intensities.overload and greater than or equal to 
+              _array_intensities.underload
+
 ;
     _name.category_id             array_intensities
     _name.object_id               underload
@@ -2246,15 +2502,14 @@ save_array_intensities.variant
 
     _definition.id                '_array_intensities.variant'
     _description.text
-;
-    The value of _array_intensities.variant  gives the variant
-     to which the given ARRAY_INTENSITIES row is related.
+;             The value of _array_intensities.variant gives the variant
+              to which the given ARRAY_INTENSITIES row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_intensities
     _name.object_id               variant
@@ -2271,16 +2526,16 @@ save_
 
 save_ARRAY_STRUCTURE
 
-    _definition.id                ARRAY_STRUCTURE
+    _definition.id                array_structure
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the ARRAY_STRUCTURE  category record the organization and
-     encoding of array data that may be stored in the ARRAY_DATA  category.
+    Data items in the ARRAY_STRUCTURE category record the organization and
+     encoding of array data that may be stored in the ARRAY_DATA category.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_STRUCTURE
+    _name.object_id               array_structure
     _name.ddl2_mandatory          no
 
     loop_
@@ -2289,8 +2544,7 @@ save_ARRAY_STRUCTURE
          '_array_structure.variant'
 
     _description_example.case
-;
-     loop_
+;     loop_
     _array_structure.id
     _array_structure.encoding_type
     _array_structure.compression_type
@@ -2298,6 +2552,25 @@ save_ARRAY_STRUCTURE
      image_1       "unsigned 16-bit integer"  none  little_endian
 ;
     _description_example.detail   'Example 1.'
+    _nx_mapping.details
+;
+    Note that this is essentially a type that may apply to multiple
+    binary images, and corresponds to some of the detailed HDF5
+    information about an array.   The following mapping is a placeholder
+    for the names given for future reference, if needed.
+
+    The information in this category is the byte order, the compression
+    information, and the encoding, which is carried in and retrievable
+    from the HDF5 types, properties lists, etc.
+
+    At present NeXus does not expose this information.  This should be
+    discussed.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -2305,15 +2578,14 @@ save_array_structure.byte_order
 
     _definition.id                '_array_structure.byte_order'
     _description.text
-;
-    The order of bytes for integer values which require more
-     than 1 byte.
+;             The order of bytes for integer values which require more
+              than 1 byte.
 
-     (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
-     ordered integers, whereas Hewlett Packard 700
-     series, Sun-4 and Silicon Graphics use high-byte-first
-     ordered integers.  DEC Alphas can produce/use either
-     depending on a compiler switch.)
+              (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
+              ordered integers, whereas Hewlett Packard 700
+              series, Sun-4 and Silicon Graphics use high-byte-first
+              ordered integers.  DEC Alphas can produce/use either
+              depending on a compiler switch.)
 ;
     _name.category_id             array_structure
     _name.object_id               byte_order
@@ -2328,14 +2600,12 @@ save_array_structure.byte_order
       _enumeration_set.state
       _enumeration_set.detail
          big_endian
-;
-         The first byte in the byte stream of the bytes which make up an
-         integer value is the most significant byte of an integer.
+;       The first byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
 ;
          little_endian
-;
-         The last byte in the byte stream of the bytes which make up an integer
-         value is the most significant byte of an integer.
+;       The last byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
 ;
 
 save_
@@ -2344,9 +2614,8 @@ save_array_structure.compression_type
 
     _definition.id                '_array_structure.compression_type'
     _description.text
-;
-    Type of data-compression method used to compress the array
-     data.
+;             Type of data-compression method used to compress the array
+              data.
 ;
     _name.category_id             array_structure
     _name.object_id               compression_type
@@ -2361,35 +2630,30 @@ save_array_structure.compression_type
       _enumeration_set.state
       _enumeration_set.detail
          byte_offset
-;
-         Using the 'byte_offset' compression scheme as per A. Hammersley and
-         the CBFlib manual, section 3.3.3
+;       Using the 'byte_offset' compression scheme as per A. Hammersley
+        and the CBFlib manual, section 3.3.3
 ;
          canonical
-;
-         Using the 'canonical' compression scheme (International Tables for
-         Crystallography Volume G, Section 5.6.3.1) and CBFlib manual section
-         3.3.1
+;       Using the 'canonical' compression scheme (International Tables
+        for Crystallography Volume G, Section 5.6.3.1) and CBFlib
+        manual section 3.3.1
 ;
          nibble_offset
-;
-         Using the 'nibble_offset' compression scheme as per H. Bernstein and
-         the CBFlib manual, section 3.3.4
+;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+        and the CBFlib manual, section 3.3.4
 ;
          none
-;
-         Data are stored in normal format as defined by
-         _array_structure.encoding_type and _array_structure.byte_order.
+;       Data are stored in normal format as defined by
+        _array_structure.encoding_type and
+        _array_structure.byte_order.
 ;
          packed
-;
-         Using the 'packed' compression scheme, a CCP4-style packing as per J.
-         P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;       Using the 'packed' compression scheme, a CCP4-style packing
+        as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
          packed_v2
-;
-         Using the 'packed' compression scheme, version 2, as per J. P.
-         Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;       Using the 'packed' compression scheme, version 2, as per
+        J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
 
     _enumeration.default          none
@@ -2400,9 +2664,8 @@ save_array_structure.compression_type_flag
 
     _definition.id                '_array_structure.compression_type_flag'
     _description.text
-;
-    Flags modifying the type of data-compression method used to
-     compress the arraydata.
+;             Flags modifying the type of data-compression method used to 
+              compress the arraydata.
 ;
     _name.category_id             array_structure
     _name.object_id               compression_type_flag
@@ -2417,17 +2680,17 @@ save_array_structure.compression_type_flag
       _enumeration_set.state
       _enumeration_set.detail
          uncorrelated_sections
-;
-         When applying packed or packed_v2 compression on an array with
-         uncorrelated sections, do not average in points from the prior section.
+;       When applying packed or packed_v2 compression on an array with
+        uncorrelated sections, do not average in points from the prior
+        section.
 ;
          flat
-;
-         When applying packed or packed_v2 compression on an array that treats
-         the entire image as a single line set the maximum number of bits for
-         an offset to 65 bits. The flag is included for compatibility with
-         software prior to CBFlib_0.7.7, and should not be used for new data
-         sets.
+;       When applying packed or packed_v2 compression on an array that
+        treats the entire image as a single line set the maximum number
+        of bits for an offset to 65 bits.
+
+        The flag is included for compatibility with software prior to
+        CBFlib_0.7.7, and should not be used for new data sets.
 ;
 
 save_
@@ -2436,20 +2699,19 @@ save_array_structure.encoding_type
 
     _definition.id                '_array_structure.encoding_type'
     _description.text
-;
-    Data encoding of a single element of array data.
+;             Data encoding of a single element of array data.
 
-     The type 'unsigned 1-bit integer' is used for
-     packed Boolean arrays for masks.  Each element
-     of the array corresponds to a single bit
-     packed in unsigned 8-bit data.
+              The type 'unsigned 1-bit integer' is used for
+              packed Boolean arrays for masks.  Each element
+              of the array corresponds to a single bit
+              packed in unsigned 8-bit data.
 
-     In several cases, the IEEE format is referenced.
-     See IEEE Standard 754-1985 (IEEE, 1985).
+              In several cases, the IEEE format is referenced.
+              See IEEE Standard 754-1985 (IEEE, 1985).
 
-     Reference: IEEE (1985). IEEE Standard for Binary Floating-Point
-     Arithmetic. ANSI/IEEE Std 754-1985. New York: Institute of
-     Electrical and Electronics Engineers.
+              Reference: IEEE (1985). IEEE Standard for Binary Floating-Point
+              Arithmetic. ANSI/IEEE Std 754-1985. New York: Institute of
+              Electrical and Electronics Engineers.
 ;
     _name.category_id             array_structure
     _name.object_id               encoding_type
@@ -2479,19 +2741,18 @@ save_array_structure.id
 
     _definition.id                '_array_structure.id'
     _description.text
-;
-    The value of _array_structure.id  must uniquely identify
-     each item of array data.
+;             The value of _array_structure.id must uniquely identify
+              each item of array data.              
 
-     This item has been made implicit and given a default value of 1
-     as a convenience in writing miniCBF files.  Normally an
-     explicit name with useful content should be used.
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
 ;
     _name.category_id             array_structure
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -2503,15 +2764,14 @@ save_array_structure.variant
 
     _definition.id                '_array_structure.variant'
     _description.text
-;
-    The value of _array_structure.variant  gives the variant
-     to which the given ARRAY_STRUCTURE row is related.
+;             The value of _array_structure.variant gives the variant
+              to which the given ARRAY_STRUCTURE row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_structure
     _name.object_id               variant
@@ -2528,18 +2788,17 @@ save_
 
 save_ARRAY_STRUCTURE_LIST
 
-    _definition.id                ARRAY_STRUCTURE_LIST
+    _definition.id                array_structure_list
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;
-    Data items in the ARRAY_STRUCTURE_LIST  category record the size
+;    Data items in the ARRAY_STRUCTURE_LIST category record the size
      and organization of each array dimension.
 
      The relationship to physical axes may be given.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST
+    _name.object_id               array_structure_list
     _name.ddl2_mandatory          no
 
     loop_
@@ -2549,24 +2808,193 @@ save_ARRAY_STRUCTURE_LIST
          '_array_structure_list.variant'
 
     _description_example.case
-;
-     loop_
-    _array_structure_list.array_id
-    _array_structure_list.index
-    _array_structure_list.dimension
-    _array_structure_list.precedence
-    _array_structure_list.direction
-    _array_structure_list.axis_set_id
-     image_1   1    1300    1     increasing  ELEMENT_X
-     image_1   2    1200    2     decreasing  ELEMENY_Y
+;        loop_
+       _array_structure_list.array_id
+       _array_structure_list.index
+       _array_structure_list.dimension
+       _array_structure_list.precedence
+       _array_structure_list.direction
+       _array_structure_list.axis_set_id
+        image_1   1    1300    1     increasing  ELEMENT_X
+        image_1   2    1200    2     decreasing  ELEMENY_Y
 ;
     _description_example.detail
+;       Example 1. An image array of 1300 x 1200 elements.  The raster
+                    order of the image is left to right (increasing) in the
+                    first dimension and bottom to top (decreasing) in
+                    the second dimension.
 ;
-    Example 1. An image array of 1300 x 1200 elements.  The raster
-                 order of the image is left to right (increasing) in the
-                 first dimension and bottom to top (decreasing) in
-                 the second dimension.
+    _nx_mapping.details
+;    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_derived CENDERIVED
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
 ;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -2574,9 +3002,8 @@ save_array_structure_list.array_id
 
     _definition.id                '_array_structure_list.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list
     _name.object_id               array_id
@@ -2594,9 +3021,8 @@ save_array_structure_list.array_section_id
 
     _definition.id                '_array_structure_list.array_section_id'
     _description.text
-;
-    This item is a pointer to _array_structure_list_section.id  in the
-     ARRAY_STRUCTURE_LIST_SECTION  category.
+;             This item is a pointer to _array_structure_list_section.id in the
+              ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             array_structure_list
     _name.object_id               array_section_id
@@ -2613,20 +3039,19 @@ save_array_structure_list.axis_set_id
 
     _definition.id                '_array_structure_list.axis_set_id'
     _description.text
-;
-    This is a descriptor for the physical axis or set of axes
-     corresponding to an array index.
+;             This is a descriptor for the physical axis or set of axes
+              corresponding to an array index.
 
-     This data item is related to the axes of the detector
-     itself given in DIFFRN_DETECTOR_AXIS, but usually differs
-     in that the axes in this category are the axes of the
-     coordinate system of reported data points, while the axes in
-     DIFFRN_DETECTOR_AXIS  are the physical axes
-     of the detector describing the 'poise' of the detector as an
-     overall physical object.
+              This data item is related to the axes of the detector
+              itself given in DIFFRN_DETECTOR_AXIS, but usually differs
+              in that the axes in this category are the axes of the
+              coordinate system of reported data points, while the axes in
+              DIFFRN_DETECTOR_AXIS are the physical axes
+              of the detector describing the 'poise' of the detector as an
+              overall physical object.
 
-     If there is only one axis in the set, the identifier of
-     that axis should be used as the identifier of the set.
+              If there is only one axis in the set, the identifier of
+              that axis should be used as the identifier of the set.
 ;
     _name.category_id             array_structure_list
     _name.object_id               axis_set_id
@@ -2643,9 +3068,8 @@ save_array_structure_list.dimension
 
     _definition.id                '_array_structure_list.dimension'
     _description.text
-;
-    The number of elements stored in the array structure in
-     this dimension.
+;             The number of elements stored in the array structure in 
+              this dimension.
 ;
     _name.category_id             array_structure_list
     _name.object_id               dimension
@@ -2656,6 +3080,13 @@ save_array_structure_list.dimension
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -2663,8 +3094,7 @@ save_array_structure_list.direction
 
     _definition.id                '_array_structure_list.direction'
     _description.text
-;
-    Identifies the direction in which this array index changes.
+;             Identifies the direction in which this array index changes.
 ;
     _name.category_id             array_structure_list
     _name.object_id               direction
@@ -2679,12 +3109,10 @@ save_array_structure_list.direction
       _enumeration_set.state
       _enumeration_set.detail
          increasing
-;
-         Indicates the index changes from 1 to the maximum dimension.
+;       Indicates the index changes from 1 to the maximum dimension.
 ;
          decreasing
-;
-         Indicates the index changes from the maximum dimension to 1.
+;       Indicates the index changes from the maximum dimension to 1.
 ;
 
 save_
@@ -2693,19 +3121,24 @@ save_array_structure_list.index
 
     _definition.id                '_array_structure_list.index'
     _description.text
-;
-    Identifies the one-based index of the row or column in the
-     array structure.
+;             Identifies the one-based index of the row or column in the
+              array structure.
 ;
     _name.category_id             array_structure_list
     _name.object_id               index
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -2713,10 +3146,9 @@ save_array_structure_list.precedence
 
     _definition.id                '_array_structure_list.precedence'
     _description.text
-;
-    Identifies the rank order in which this array index changes
-     with respect to other array indices.  The precedence of 1
-     indicates the index which changes fastest.
+;             Identifies the rank order in which this array index changes
+              with respect to other array indices.  The precedence of 1
+              indicates the index which changes fastest.
 ;
     _name.category_id             array_structure_list
     _name.object_id               precedence
@@ -2727,6 +3159,13 @@ save_array_structure_list.precedence
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -2734,15 +3173,14 @@ save_array_structure_list.variant
 
     _definition.id                '_array_structure_list.variant'
     _description.text
-;
-    The value of _array_structure_list.variant  gives the variant
-     to which the given ARRAY_STRUCTURE_LIST row is related.
+;             The value of _array_structure_list.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_structure_list
     _name.object_id               variant
@@ -2759,15 +3197,15 @@ save_
 
 save_ARRAY_STRUCTURE_LIST_AXIS
 
-    _definition.id                ARRAY_STRUCTURE_LIST_AXIS
+    _definition.id                array_structure_list_axis
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the ARRAY_STRUCTURE_LIST_AXIS  category describe
+    Data items in the ARRAY_STRUCTURE_LIST_AXIS category describe
      the physical settings of sets of axes for the centres of pixels that
      correspond to data points described in the
-     ARRAY_STRUCTURE_LIST  category.
+     ARRAY_STRUCTURE_LIST category.
 
      In the simplest cases, the physical increments of a single axis correspond
      to the increments of a single array index.  More complex organizations,
@@ -2782,7 +3220,7 @@ save_ARRAY_STRUCTURE_LIST_AXIS
      of an array.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST_AXIS
+    _name.object_id               array_structure_list_axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -2791,20 +3229,184 @@ save_ARRAY_STRUCTURE_LIST_AXIS
          '_array_structure_list_axis.axis_id'
          '_array_structure_list_axis.variant'
 
+    _nx_mapping.details
+;    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
 save_
 
 save_array_structure_list_axis.angle
 
     _definition.id                '_array_structure_list_axis.angle'
     _description.text
-;
-    The setting of the specified axis in degrees for the first
-      data point of the array index with the corresponding value
-      of _array_structure_list.axis_set_id.  If the index is
-      specified as 'increasing', this will be the centre of the
-      pixel with index value 1.  If the index is specified as
-    'decreasing', this will be the centre of the pixel with
-      maximum index value.
+;             The setting of the specified axis in degrees for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angle
@@ -2824,13 +3426,13 @@ save_array_structure_list_axis.angle_increment
 
     _definition.id                '_array_structure_list_axis.angle_increment'
     _description.text
-;
-    The pixel-centre-to-pixel-centre increment in the angular
-      setting of the specified axis in degrees.  This is not
-      meaningful in the case of 'constant velocity' spiral scans
-      and should not be specified for this case.
+;             The pixel-centre-to-pixel-centre increment in the angular
+               setting of the specified axis in degrees.  This is not
+               meaningful in the case of 'constant velocity' spiral scans
+               and should not be specified for this case.
 
-      See _array_structure_list_axis.angular_pitch.
+               See _array_structure_list_axis.angular_pitch.
+
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angle_increment
@@ -2850,17 +3452,16 @@ save_array_structure_list_axis.angular_pitch
 
     _definition.id                '_array_structure_list_axis.angular_pitch'
     _description.text
-;
-    The pixel-centre-to-pixel-centre distance for a one-step
-      change in the setting of the specified axis in millimetres.
+;             The pixel-centre-to-pixel-centre distance for a one-step
+               change in the setting of the specified axis in millimetres.
 
-      This is meaningful only for 'constant velocity' spiral scans
-      or for uncoupled angular scans at a constant radius
-      (cylindrical scans) and should not be specified for cases
-      in which the angle between pixels (rather than the distance
-      between pixels) is uniform.
+               This is meaningful only for 'constant velocity' spiral scans
+               or for uncoupled angular scans at a constant radius
+               (cylindrical scans) and should not be specified for cases
+               in which the angle between pixels (rather than the distance
+               between pixels) is uniform.
 
-      See _array_structure_list_axis.angle_increment.
+               See _array_structure_list_axis.angle_increment.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               angular_pitch
@@ -2880,16 +3481,15 @@ save_array_structure_list_axis.axis_id
 
     _definition.id                '_array_structure_list_axis.axis_id'
     _description.text
-;
-    The value of this data item is the identifier of one of
-     the axes in the set of axes for which settings are being
-     specified.
+;             The value of this data item is the identifier of one of
+              the axes in the set of axes for which settings are being
+              specified.
 
-     Multiple axes may be specified for the same value of
-     _array_structure_list_axis.axis_set_id.
+              Multiple axes may be specified for the same value of
+              _array_structure_list_axis.axis_set_id.
 
-     This item is a pointer to _axis.id  in the
-     AXIS  category.
+              This item is a pointer to _axis.id in the
+              AXIS category.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_id
@@ -2907,19 +3507,18 @@ save_array_structure_list_axis.axis_set_id
 
     _definition.id                '_array_structure_list_axis.axis_set_id'
     _description.text
-;
-    The value of this data item is the identifier of the
-      set of axes for which axis settings are being specified.
+;             The value of this data item is the identifier of the
+               set of axes for which axis settings are being specified.
 
-      Multiple axes may be specified for the same value of
-      _array_structure_list_axis.axis_set_id.
+               Multiple axes may be specified for the same value of
+               _array_structure_list_axis.axis_set_id.
 
-      This item is a pointer to
-      _array_structure_list.axis_set_id
-      in the ARRAY_STRUCTURE_LIST  category.
+               This item is a pointer to
+               _array_structure_list.axis_set_id
+               in the ARRAY_STRUCTURE_LIST category.
 
-      If this item is not specified, it defaults to the corresponding
-      axis identifier.
+               If this item is not specified, it defaults to the corresponding
+               axis identifier.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_set_id
@@ -2937,14 +3536,13 @@ save_array_structure_list_axis.displacement
 
     _definition.id                '_array_structure_list_axis.displacement'
     _description.text
-;
-    The setting of the specified axis in millimetres for the first
-      data point of the array index with the corresponding value
-      of _array_structure_list.axis_set_id.  If the index is
-      specified as 'increasing', this will be the centre of the
-      pixel with index value 1.  If the index is specified as
-    'decreasing', this will be the centre of the pixel with
-      maximum index value.
+;             The setting of the specified axis in millimetres for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               displacement
@@ -2965,9 +3563,8 @@ save_array_structure_list_axis.displacement_increment
     _definition.id
         '_array_structure_list_axis.displacement_increment'
     _description.text
-;
-    The pixel-centre-to-pixel-centre increment for the displacement
-      setting of the specified axis in millimetres.
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis in millimetres.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               displacement_increment
@@ -2988,16 +3585,15 @@ save_array_structure_list_axis.fract_displacement
     _definition.id
         '_array_structure_list_axis.fract_displacement'
     _description.text
-;
-    The setting of the specified axis as a decimal fraction of
-      the axis unit vector for the first data point of the array
-      index with the corresponding value of
-      _array_structure_list.axis_set_id.
+;             The setting of the specified axis as a decimal fraction of 
+               the axis unit vector for the first data point of the array 
+               index with the corresponding value of 
+               _array_structure_list.axis_set_id.  
 
-      If the index is specified as 'increasing', this will be the
-      centre of the pixel with index value 1.  If the index is
-      specified as 'decreasing', this will be the centre of the
-      pixel with maximum index value.
+               If the index is specified as 'increasing', this will be the 
+               centre of the pixel with index value 1.  If the index is 
+               specified as 'decreasing', this will be the centre of the 
+               pixel with maximum index value.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               fract_displacement
@@ -3008,6 +3604,7 @@ save_array_structure_list_axis.fract_displacement
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.default          0.0
+    _units.code                   none
 
 save_
 
@@ -3016,10 +3613,9 @@ save_array_structure_list_axis.fract_displacement_increment
     _definition.id
         '_array_structure_list_axis.fract_displacement_increment'
     _description.text
-;
-    The pixel-centre-to-pixel-centre increment for the displacement
-      setting of the specified axis as a decimal fraction of the
-      axis unit vector.
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis as a decimal fraction of the
+               axis unit vector.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               fract_displacement_increment
@@ -3039,12 +3635,11 @@ save_array_structure_list_axis.radial_pitch
 
     _definition.id                '_array_structure_list_axis.radial_pitch'
     _description.text
-;
-    The radial distance from one 'cylinder' of pixels to the
-      next in millimetres.  If the scan is a 'constant velocity'
-      scan with differing angular displacements between pixels,
-      the value of this item may differ significantly from the
-      value of _array_structure_list_axis.displacement_increment.
+;             The radial distance from one 'cylinder' of pixels to the
+               next in millimetres.  If the scan is a 'constant velocity'
+               scan with differing angular displacements between pixels,
+               the value of this item may differ significantly from the
+               value of _array_structure_list_axis.displacement_increment.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               radial_pitch
@@ -3064,12 +3659,12 @@ save_array_structure_list_axis.reference_angle
 
     _definition.id                '_array_structure_list_axis.reference_angle'
     _description.text
-;
-    The value of _array_structure_list_axis.reference_angle
-      specifies the setting of the angle of this axis used for
-      determining a reference beam centre and a reference detector
-      distance.  It is normally expected to be identical to the
-      value of _array_structure_list_axis.angle.
+;             The value of _array_structure_list_axis.reference_angle
+               specifies the setting of the angle of this axis used for 
+               determining a reference beam centre and a reference detector 
+               distance.  It is normally expected to be identical to the 
+               value of _array_structure_list_axis.angle.
+
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               reference_angle
@@ -3089,12 +3684,12 @@ save_array_structure_list_axis.reference_displacement
     _definition.id
         '_array_structure_list_axis.reference_displacement'
     _description.text
-;
-    The value of _array_structure_list_axis.reference_displacement
-      specifies the setting of the displacement of this axis used
-      for determining a reference beam centre and a reference detector
-      distance.  It is normally expected to be identical to the value
-      of _array_structure_list_axis.displacement.
+;             The value of _array_structure_list_axis.reference_displacement
+               specifies the setting of the displacement of this axis used 
+               for determining a reference beam centre and a reference detector
+               distance.  It is normally expected to be identical to the value
+               of _array_structure_list_axis.displacement.
+
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               reference_displacement
@@ -3113,15 +3708,14 @@ save_array_structure_list_axis.variant
 
     _definition.id                '_array_structure_list_axis.variant'
     _description.text
-;
-    The value of _array_structure_list_axis.variant  gives the variant
-      to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
+;            The value of _array_structure_list_axis.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
 
-      If this value is not given, the variant is assumed to be
-      the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-      This item is a pointer to _variant.variant  in the
-      VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               variant
@@ -3138,38 +3732,34 @@ save_
 
 save_ARRAY_STRUCTURE_LIST_SECTION
 
-    _definition.id                ARRAY_STRUCTURE_LIST_SECTION
+    _definition.id                array_structure_list_section
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;
-    Data items in the ARRAY_STRUCTURE_LIST_SECTION  category identify
-     the dimension-by-dimension start, end and stride of each section of an
-     array that is to be referenced.
+;   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
+    the dimension-by-dimension start, end and stride of each section of an
+    array that is to be referenced.
 
-     For any array with identifier ARRAYID, array section ids of the form
-     ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
-     by default.
+    For any array with identifier ARRAYID, array section ids of the form
+    ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
+    by default.
 
-     For the given index, the elements in the section are of indices:
-     _array_structure_list_section.start,
-     _array_structure_list_section.start + _array_structure_list_section.stride,
-     _array_structure_list_section.start +
-    2*_array_structure_list_section.stride,  ...
+    For the given index, the elements in the section are of indices:
+    _array_structure_list_section.start,
+    _array_structure_list_section.start + _array_structure_list_section.stride,
+    _array_structure_list_section.start + 2*_array_structure_list_section.stride,
+    ...
 
-     stopping either when the indices leave the limits of the indices
-     of that dimension or
-     [min(_array_structure_list_section.start,
-    _array_structure_list_section.end),
-    max(_array_structure_list_section.start,
-    _array_structure_list_section.end)].
-
-     The ordering of these elements is determined by the overall ordering of
-     _array_structure_list_section.array_id  and not by the ordering implied
-     by the stride.
+    stopping either when the indices leave the limits of the indices
+    of that dimension or 
+    [min(_array_structure_list_section.start, _array_structure_list_section.end),
+     max(_array_structure_list_section.start, _array_structure_list_section.end)].
+    The ordering of these elements is determined by the overall ordering of
+    _array_structure_list_section.array_id and not by the ordering implied
+    by the stride.
 ;
     _name.category_id             HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST_SECTION
+    _name.object_id               array_structure_list_section
     _name.ddl2_mandatory          no
 
     loop_
@@ -3180,8 +3770,7 @@ save_ARRAY_STRUCTURE_LIST_SECTION
          '_array_structure_list_section.variant'
 
     _description_example.case
-;
-     loop_
+;     loop_
     _array_structure_list.array_id
     _array_structure_list.index
     _array_structure_list.dimension
@@ -3199,23 +3788,50 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     _array_structure_list_section.start
     _array_structure_list_section.end
     _array_structure_list_section.stride
-    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200  .
-    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100  .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
     "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
 ;
     _description_example.detail
-;
-    Example 1. An image array, myarray, of 1300 x 1200 elements, and
-                 700 frames is defined in ARRAY_STRUCTURE_LIST, and
-                 the array section identifier
+;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+                    700 frames is defined in ARRAY_STRUCTURE_LIST, and
+                    the array section identifier
 
-                 "myarray(101:1200,101:1100,1:700:10)"
+                    "myarray(101:1200,101:1100,1:700:10)"
 
-                 is explicitly defined taking every 10th frame and
-                 removing a 100 pixel border.  Note that even though
-                 the slow index high is 700, the last frame that
-                 will actually be included is only 691.
+                    is explicitly defined taking every 10th frame and
+                    removing a 100 pixel border.  Note that even though
+                    the slow index high is 700, the last frame that
+                    will actually be included is only 691.
 ;
+    _nx_mapping.details
+;    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id SECTIONID -->
+    _array_structure_list_section.index INDEX-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+    /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
 
 save_
 
@@ -3223,9 +3839,8 @@ save_array_structure_list_section.array_id
 
     _definition.id                '_array_structure_list_section.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               array_id
@@ -3243,19 +3858,18 @@ save_array_structure_list_section.end
 
     _definition.id                '_array_structure_list_section.end'
     _description.text
-;
-    Identifies the ending ordinal, numbered from 1, for an array
-     element of index _array_structure_list_section.index  in the
-     section.
+;             Identifies the ending ordinal, numbered from 1, for an array
+              element of index _array_structure_list_section.index in the
+              section.
 
-     The value defaults to the dimension for index
-     _array_structure_list_section.index
-     of the array.
+              The value defaults to the dimension for index
+              _array_structure_list_section.index
+              of the array.
 
-     Note that this agrees with the Fortran convention, rather than
-     the Python convention in that, if compatible with the stride,
-     the end element is included in the section as in Fortran, rather
-     than being one beyond the section as in Python.
+              Note that this agrees with the Fortran convention, rather than
+              the Python convention in that, if compatible with the stride,
+              the end element is included in the section as in Fortran, rather
+              than being one beyond the section as in Python.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               end
@@ -3266,6 +3880,13 @@ save_array_structure_list_section.end
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -3273,19 +3894,18 @@ save_array_structure_list_section.id
 
     _definition.id                '_array_structure_list_section.id'
     _description.text
-;
-    Uniquely identifies the array section chosen.
+;             Uniquely identifies the array section chosen.
 
-     To avoid confusion array section IDs that contain parentheses
-     should conform to the default syntax
+              To avoid confusion array section IDs that contain parentheses
+              should conform to the default syntax
 
-     ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+              ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -3296,17 +3916,16 @@ save_array_structure_list_section.index
 
     _definition.id                '_array_structure_list_section.index'
     _description.text
-;
-    This item is a pointer to _array_structure_list.index
-     in the ARRAY_STRUCTURE_LIST  category.
+;             This item is a pointer to _array_structure_list.index
+              in the ARRAY_STRUCTURE_LIST category.
 
-     Identifies the one-based index of the row, column, sheet ...
-     the ARRAY_STRUCTURE_LIST  category.
+              Identifies the one-based index of the row, column, sheet ...
+              the ARRAY_STRUCTURE_LIST category.
 
-     For a multidimensional array, a value must be explicitly given.
+              For a multidimensional array, a value must be explicitly given.
 
-     If an index is omitted from a section then all elements for that
-     index are assumed to be included in the section.
+              If an index is omitted from a section then all elements for that
+              index are assumed to be included in the section.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               index
@@ -3324,30 +3943,28 @@ save_array_structure_list_section.start
 
     _definition.id                '_array_structure_list_section.start'
     _description.text
-;
-    Identifies the starting ordinal, numbered from 1,
-     for an array element of index _array_structure_list_section.index
-     in the section.
+;             Identifies the starting ordinal, numbered from 1,
+              for an array element of index _array_structure_list_section.index
+              in the section.
 
-     The value defaults to 1.   For the given index, the elements in
-     the section are of indices:
-     _array_structure_list_section.start,
-     _array_structure_list_section.start
-        + _array_structure_list_section.stride,
-     _array_structure_list_section.start
-        + 2*_array_structure_list_section.stride,
-         ...
+              The value defaults to 1.   For the given index, the elements in
+              the section are of indices:
+              _array_structure_list_section.start,
+              _array_structure_list_section.start
+                 + _array_structure_list_section.stride,
+              _array_structure_list_section.start
+                 + 2*_array_structure_list_section.stride,
+                  ...
 
-     stopping either when the indices leave the limits of the indices
-     of that dimension or
-     [min(_array_structure_list_section.start,
-         _array_structure_list_section.end ),
-      max(_array_structure_list_section.start,
-         _array_structure_list_section.end )].
-
-     The ordering of these elements is determined by the overall
-     ordering of _array_structure_list_section.array_id  and not by
-     the ordering implied by the stride.
+              stopping either when the indices leave the limits of the indices
+              of that dimension or 
+              [min(_array_structure_list_section.start,
+                  _array_structure_list_section.end),
+               max(_array_structure_list_section.start,
+                  _array_structure_list_section.end)].
+              The ordering of these elements is determined by the overall
+              ordering of _array_structure_list_section.array_id and not by
+              the ordering implied by the stride.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               start
@@ -3358,6 +3975,13 @@ save_array_structure_list_section.start
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -3365,12 +3989,11 @@ save_array_structure_list_section.stride
 
     _definition.id                '_array_structure_list_section.stride'
     _description.text
-;
-    Identifies the incremental steps to be taken when moving
-     element to element in the section in that particular
-     dimension.  The value of _array_structure_list_section.stride
-     may be positive or negative.  If the stride is zero, the section
-     is just defined by _array_structure_list_section.start.
+;             Identifies the incremental steps to be taken when moving
+              element to element in the section in that particular
+              dimension.  The value of _array_structure_list_section.stride
+              may be positive or negative.  If the stride is zero, the section
+              is just defined by _array_structure_list_section.start.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               stride
@@ -3382,6 +4005,13 @@ save_array_structure_list_section.stride
     _type.ddl2_code               int
     _enumeration.range            1:
     _enumeration.default          1
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
 
 save_
 
@@ -3389,16 +4019,15 @@ save_array_structure_list_section.variant
 
     _definition.id                '_array_structure_list_section.variant'
     _description.text
-;
-    The value of _array_structure_list_section.variant  gives the
-     variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
-     is related.
+;             The value of _array_structure_list_section.variant gives the
+              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
+              is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               variant
@@ -3414,363 +4043,348 @@ save_
 
 save_AXIS
 
-    _definition.id                AXIS
+    _definition.id                axis
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;
-    Data items in the AXIS  category record the information required
-      to describe the various goniometer, detector, source and other
-      axes needed to specify a data collection or the axes defining the
-      coordinate system of an image.
+;   Data items in the AXIS category record the information required
+     to describe the various goniometer, detector, source and other
+     axes needed to specify a data collection or the axes defining the
+     coordinate system of an image.  
 
-      The location of each axis is specified by two vectors: the axis
-      itself, given by a unit vector in the direction of the axis, and
-      an offset to the base of the unit vector.
+     The location of each axis is specified by two vectors: the axis 
+     itself, given by a unit vector in the direction of the axis, and 
+     an offset to the base of the unit vector.  
 
-      The vectors defining an axis are referenced to an appropriate
-      coordinate system, given in _axis.system.  The axis vector itself,
-        [_axis.vector[1], _axis.vector[2], _axis.vector[3]],
-      is a dimensionless unit vector.  Where meaningful, an offset vector
-        [_axis.offset[1], _axis.offset[2], _axis.offset[3]]
-      supplies the offsets to the base of a rotation or translation axis in
-      X, Y and Z.  This is appropriate for the imgCIF standard laboratory
-      coordinate system, the NeXus/HDF5 McStas laboratory coordinate system
-      and the last two Cartesian coordinate systems, but for the direct lattice,
-      X corresponds to a, Y to b and Z to c, while for the reciprocal lattice,
-      X corresponds to a*, Y to b* and Z to c*.
+     The vectors defining an axis are referenced to an appropriate
+     coordinate system, given in _axis.system.  The axis vector itself,
+       [_axis.vector[1], _axis.vector[2], _axis.vector[3]],
+     is a dimensionless unit vector.  Where meaningful, an offset vector
+       [_axis.offset[1], _axis.offset[2], _axis.offset[3]]
+     supplies the offsets to the base of a rotation or translation axis in
+     X, Y and Z.  This is appropriate for the imgCIF standard laboratory 
+     coordinate system, the NeXus/HDF5 McStas laboratory coordinate system 
+     and the last two Cartesian coordinate systems, but for the direct lattice, 
+     X corresponds to a, Y to b and Z to c, while for the reciprocal lattice,
+     X corresponds to a*, Y to b* and Z to c*.
 
-      For purposes of visualization, all the coordinate systems are
-      taken as right-handed, i.e. using the convention that the extended
-      thumb of a right hand could point along the first (X) axis, the
-      straightened pointer finger could point along the second (Y) axis
-      and the middle finger folded inward could point along the third (Z)
-      axis.  For a right-handed rotation axis, if the right hand is wrapped
-      around the axis with the thumb pointed in the direction of the axis,
-      the fingers point in the positive rotation direction, i.e. clockwise.
+     For purposes of visualization, all the coordinate systems are 
+     taken as right-handed, i.e. using the convention that the extended 
+     thumb of a right hand could point along the first (X) axis, the 
+     straightened pointer finger could point along the second (Y) axis 
+     and the middle finger folded inward could point along the third (Z)
+     axis.  For a right-handed rotation axis, if the right hand is wrapped
+     around the axis with the thumb pointed in the direction of the axis,
+     the fingers point in the positive rotation direction, i.e. clockwise.  
 
-      THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM
+     THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM 
+     The imgCIF standard laboratory coordinate system is a right-handed   
+     orthogonal coordinate system similar to that used by MOSFLM,  
+     but imgCIF puts Z along the X-ray beam, rather than putting X along the
+     X-ray beam as in MOSFLM.
 
-      The imgCIF standard laboratory coordinate system is a right-handed
-      orthogonal coordinate system similar to that used by MOSFLM,
-      but imgCIF puts Z along the X-ray beam, rather than putting X along the
-      X-ray beam as in MOSFLM.
-
-      The vectors for the imgCIF standard laboratory coordinate system
-      form a right-handed Cartesian coordinate system with its origin
-      in the sample or specimen.  The origin of the axis system should,
-      if possible, be defined in terms of mechanically stable axes to be
-      both in the sample and in the beam.  If the sample goniometer or other
-      sample positioner has two axes the intersection of which defines a
-      unique point at which the sample should be mounted to be bathed
-      by the beam, that will be the origin of the axis system.  If no such
-      point is defined, then the midpoint of the line of intersection
-      between the sample and the centre of the beam will define the origin.
-      For this definition the sample positioning system will be set at
-      its initial reference position for the experiment.
-
-                              | Y (to complete right-handed system)
-                              |
-                              |
-                              |
-                              |
-                              |
-                              |________________X
-                             /       principal goniometer axis
-                            /
+     The vectors for the imgCIF standard laboratory coordinate system
+     form a right-handed Cartesian coordinate system with its origin
+     in the sample or specimen.  The origin of the axis system should,
+     if possible, be defined in terms of mechanically stable axes to be
+     both in the sample and in the beam.  If the sample goniometer or other
+     sample positioner has two axes the intersection of which defines a
+     unique point at which the sample should be mounted to be bathed
+     by the beam, that will be the origin of the axis system.  If no such
+     point is defined, then the midpoint of the line of intersection
+     between the sample and the centre of the beam will define the origin.
+     For this definition the sample positioning system will be set at 
+     its initial reference position for the experiment.
+                             | Y (to complete right-handed system)
+                             |
+                             |
+                             |
+                             |
+                             |
+                             |________________X
+                            /       principal goniometer axis
                            /
                           /
                          /
-                        /Z (to source)
+                        /
+                       /Z (to source)
+     Axis 1 (X): The X-axis is aligned to the mechanical axis pointing from
+     the sample or specimen along the  principal axis of the goniometer or
+     sample positioning system if the sample positioning system has an axis 
+     that intersects the origin and which forms an angle of more than 22.5 
+     degrees with the beam axis.
 
-      Axis 1 (X): The X-axis is aligned to the mechanical axis pointing from
-      the sample or specimen along the  principal axis of the goniometer or
-      sample positioning system if the sample positioning system has an axis
-      that intersects the origin and which forms an angle of more than 22.5
-      degrees with the beam axis.
+     Axis 2 (Y): The Y-axis completes an orthogonal right-handed system
+     defined by the X-axis and the Z-axis (see below).
 
-      Axis 2 (Y): The Y-axis completes an orthogonal right-handed system
-      defined by the X-axis and the Z-axis (see below).
+     Axis 3 (Z): The Z-axis is derived from the source axis which goes from
+     the sample to the source.  The Z-axis is the component of the source axis
+     in the direction of the source orthogonal to the X-axis in the plane
+     defined by the X-axis and the source axis.
 
-      Axis 3 (Z): The Z-axis is derived from the source axis which goes from
-      the sample to the source.  The Z-axis is the component of the source axis
-      in the direction of the source orthogonal to the X-axis in the plane
-      defined by the X-axis and the source axis.
+     If the conditions for the X-axis can be met, the coordinate system
+     will be based on the goniometer or other sample positioning system
+     and the beam and not on the orientation of the detector, gravity etc.  
+     The vectors necessary to specify all other axes are given by sets of 
+     three components in the order (X, Y, Z).
+     If the axis involved is a rotation axis, it is right-handed, i.e. as
+     one views the object to be rotated from the origin (the tail) of the
+     unit vector, the rotation is clockwise.  If a translation axis is
+     specified, the direction of the unit vector specifies the sense of
+     positive translation.
 
-      If the conditions for the X-axis can be met, the coordinate system
-      will be based on the goniometer or other sample positioning system
-      and the beam and not on the orientation of the detector, gravity etc.
-      The vectors necessary to specify all other axes are given by sets of
-      three components in the order (X, Y, Z).
-      If the axis involved is a rotation axis, it is right-handed, i.e. as
-      one views the object to be rotated from the origin (the tail) of the
-      unit vector, the rotation is clockwise.  If a translation axis is
-      specified, the direction of the unit vector specifies the sense of
-      positive translation.
+     In some experimental techniques, there is no goniometer or the principal
+     axis of the goniometer is at a small acute angle with respect to
+     the source axis.  In such cases, other reference axes are needed
+     to define a useful coordinate system.  The order of priority in
+     defining directions in such cases is to use the detector, then
+     gravity, then north.
 
-      In some experimental techniques, there is no goniometer or the principal
-      axis of the goniometer is at a small acute angle with respect to
-      the source axis.  In such cases, other reference axes are needed
-      to define a useful coordinate system.  The order of priority in
-      defining directions in such cases is to use the detector, then
-      gravity, then north.
+     If the X-axis cannot be defined as above, then the
+     direction (not the origin) of the X-axis should be parallel to the axis 
+     of the primary detector element corresponding to the most rapidly 
+     varying dimension of that detector element's data array, with its 
+     positive sense corresponding to increasing values of the index for 
+     that dimension.  If the detector is such that such a direction cannot 
+     be defined (as with a point detector) or that the direction forms an
+     angle of less than 22.5 degrees with respect to the source axis, then 
+     the X-axis should be chosen so that if the Y-axis is chosen 
+     in the direction of gravity, and the Z-axis is chosen to be along 
+     the source axis, a right-handed orthogonal coordinate system is chosen.  
+     In the case of a vertical source axis, as a last resort, the 
+     X-axis should be chosen to point north.
 
-      If the X-axis cannot be defined as above, then the
-      direction (not the origin) of the X-axis should be parallel to the axis
-      of the primary detector element corresponding to the most rapidly
-      varying dimension of that detector element's data array, with its
-      positive sense corresponding to increasing values of the index for
-      that dimension.  If the detector is such that such a direction cannot
-      be defined (as with a point detector) or that the direction forms an
-      angle of less than 22.5 degrees with respect to the source axis, then
-      the X-axis should be chosen so that if the Y-axis is chosen
-      in the direction of gravity, and the Z-axis is chosen to be along
-      the source axis, a right-handed orthogonal coordinate system is chosen.
-      In the case of a vertical source axis, as a last resort, the
-      X-axis should be chosen to point north.
+     All rotations are given in degrees and all translations are given in mm.
 
-      All rotations are given in degrees and all translations are given in mm.
+     Axes may be dependent on one another.  The X-axis is the only goniometer
+     axis the direction of which is strictly connected to the hardware.  All
+     other axes are specified by the positions they would assume when the
+     axes upon which they depend are at their zero points.
 
-      Axes may be dependent on one another.  The X-axis is the only goniometer
-      axis the direction of which is strictly connected to the hardware.  All
-      other axes are specified by the positions they would assume when the
-      axes upon which they depend are at their zero points.
+     When specifying detector axes, the axis is given to the beam centre.
+     The location of the beam centre on the detector should be given in the
+     DIFFRN_DETECTOR category in distortion-corrected millimetres from
+     the (0,0) corner of the detector.
 
-      When specifying detector axes, the axis is given to the beam centre.
-      The location of the beam centre on the detector should be given in the
-      DIFFRN_DETECTOR  category in distortion-corrected millimetres from
-      the (0,0) corner of the detector.
+     For convenience when describing detector element (module) placement,
+     an optional mounting rotation axis and rotation angle may be
+     specified.  In such cases, the mounting rotation axis and angle
+     of rotation around the mounting rotation axis are applied after
+     applying the transformations upon which the given axis depends.
 
-      For convenience when describing detector element (module) placement,
-      an optional mounting rotation axis and rotation angle may be
-      specified.  In such cases, the mounting rotation axis and angle
-      of rotation around the mounting rotation axis are applied after
-      applying the transformations upon which the given axis depends.
+     It should be noted that many different origins arise in the definition
+     of an experiment.  In particular, as noted above, it is necessary to
+     specify the location of the beam centre on the detector in terms
+     of the origin of the detector, which is, of course, not coincident
+     with the centre of the sample.
+     THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM 
+     The standard coordinate frame in NeXus is the McStas coordinate frame,
+     in which the Z-axis points in the direction of the incident beam, the
+     X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
+     left as seen from the source and the Y-axis points upwards.  The
+     origin is in the sample.
 
-      It should be noted that many different origins arise in the definition
-      of an experiment.  In particular, as noted above, it is necessary to
-      specify the location of the beam centre on the detector in terms
-      of the origin of the detector, which is, of course, not coincident
-      with the centre of the sample.
+     Differences in Coordinate Frames
 
-      THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM
+     The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
+     principal goniometer axis, and chooses the Z-axis to point from the sample
+     into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
+     is the component of the vector that points into the beam orthogonal to the
+     X-axis.  The Y-axis is chosen to complete a right-handed axis system.
 
-      The standard coordinate frame in NeXus is the McStas coordinate frame,
-      in which the Z-axis points in the direction of the incident beam, the
-      X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
-      left as seen from the source and the Y-axis points upwards.  The
-      origin is in the sample.
+     Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
+     imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
+     of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
+     from the NeXus coordinate system to the imgCIF coordinate system, we
+     also need two additional axes, as unit vectors, Gravity_cbf the downwards
+     direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).   
 
-      Differences in Coordinate Frames
+     In practice, the beam is not necessarily perfectly horizontal, so Y_nx
+     is not necessarily perfectly vertical. Therefore, in order to generate
+     X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
+     vectors a and b is a new vector c orthogonal to both a and b,
+     chosen so that a, b, c is a right-handed system.  If a and b are
+     orthogonal unit vectors, this right-handed system is an orthonormal
+     coordinate system.
 
-      The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
-      principal goniometer axis, and chooses the Z-axis to point from the sample
-      into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
-      is the component of the vector that points into the beam orthogonal to the
-      X-axis.  The Y-axis is chosen to complete a right-handed axis system.
+     In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
 
-      Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
-      imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
-      of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
-      from the NeXus coordinate system to the imgCIF coordinate system, we
-      also need two additional axes, as unit vectors, Gravity_cbf the downwards
-      direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).
+        Z_nx = Beam_cbf.
 
-      In practice, the beam is not necessarily perfectly horizontal, so Y_nx
-      is not necessarily perfectly vertical. Therefore, in order to generate
-      X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
-      vectors a and b is a new vector c orthogonal to both a and b,
-      chosen so that a, b, c is a right-handed system.  If a and b are
-      orthogonal unit vectors, this right-handed system is an orthonormal
-      coordinate system.
+     X_nx is defined as being horizontal at right angles to the beam,
+     pointing to the left when seen from the source.  Assuming the beam is
+     not vertical, we can compute X_nx as the normalized cross product of
+     the  beam and gravity:
 
-      In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
+        X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
 
-         Z_nx = Beam_cbf.
+     To see that this satisfies the constraint of being horizontal and
+     pointing to the left, consider the case of Beam = ( 0, 0, -1 )
+     and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
+     from the cross product above.  The normalization is only necessary
+     if the beam is not horizontal.
 
-      X_nx is defined as being horizontal at right angles to the beam,
-      pointing to the left when seen from the source.  Assuming the beam is
-      not vertical, we can compute X_nx as the normalized cross product of
-      the  beam and gravity:
+     Finally Y_nx is computed as the cross product of the beam and X_nx,
+     completing an orthonormal right-handed system with Y_nx pointing upwards
 
-         X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
+        Y_nx = Beam_cbf x X_nx.
 
-      To see that this satisfies the constraint of being horizontal and
-      pointing to the left, consider the case of Beam = ( 0, 0, -1 )
-      and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
-      from the cross product above.  The normalization is only necessary
-      if the beam is not horizontal.
+     Then we know that in the imgCIF/CBF coordinate frame
 
-      Finally Y_nx is computed as the cross product of the beam and X_nx,
-      completing an orthonormal right-handed system with Y_nx pointing upwards
+        v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
 
-         Y_nx = Beam_cbf x X_nx.
+     Thus, given the imgCIF/CBF vectors for the true direction of the beam
+     and the true direction of gravity, we have a linear transformation from
+     the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
+     origins of the two frames agree.   The inverse linear transformation will
+     transform a vector in the imgCIF/CBF coordinate frame into the NeXus
+     coordinate frame.
 
-      Then we know that in the imgCIF/CBF coordinate frame
+     In the common case in which the beam is orthogonal to the principal
+     goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
+     Y-axis points upwards, the transformation inverts the X and Z axes.
+     In the other common case in which the beam is orthogonal to the
+     principal goniometer axis and the imgCIF/CBF Y-axis points
+     downwards, the transformation inverts the Y and Z axes.
 
-         v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
+     Mapping axes
 
-      Thus, given the imgCIF/CBF vectors for the true direction of the beam
-      and the true direction of gravity, we have a linear transformation from
-      the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
-      origins of the two frames agree.   The inverse linear transformation will
-      transform a vector in the imgCIF/CBF coordinate frame into the NeXus
-      coordinate frame.
+     There are two transformations needed:  coord_xform(v) which takes a vector,
+     v, in the CBF imgCIF Standard Laboratory Coordinate System and returns the
+     equivalent McStas coordinate vector, and offset_xform(o) which takes an
+     offset, o, in the CBF imgCIF Standard Laboratory Coordinate System and
+     returns the equivalent NeXus offset.
 
-      In the common case in which the beam is orthogonal to the principal
-      goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
-      Y-axis points upwards, the transformation inverts the X and Z axes.
-      In the other common case in which the beam is orthogonal to the
-      principal goniometer axis and the imgCIF/CBF Y-axis points
-      downwards, the transformation inverts the Y and Z axes.
+     In imgCIF/CBF all the information about all axes other than their
+     settings are gathered in one AXIS category.  The closest equivalent
+     container in NeXus is the NXinstrument class.  We put the information
+     about detector axes into a
+     detector:NXdetector/transformations:NXtransformations NeXus class instance,
+     information about the goniometer into a
+     goniometer:NXgoniometer/transformations:NXtransformations NeXus
+     class instance, etc.  Additionally, in view of the general nature of
+     some axes, such as the coordinate frame axes and gravity, we add a
+     transformations:NXtransformation NeXus class instance under NXentry with
+     axis__gravity, axis__beam and other axes not tied to specific equipment.
 
-      Mapping axes
+     We have applied the coordinate frame transformation changing
+     the CBF laboratory coordinates into McStas coordinates.  Notice that X and
+     Z have changed direction, but Y has not.   In other experimental setups,
+     other transformations may occur.   The offsets for dependent axes are
+     given relative to the total offset of axes on which that axis is dependent.
+     Note that the axis settings do not enter into this calculation, because the
+     offsets of dependent axes are given with all axes at their zero settings.
+     The cbf_location attribute gives a mapping back into the CBF AXIS category
+     in dotted notation.  The first component is the data block.  The second
+     component is "axis".  The third component is either "vector" or
+     "offset"  for information drawn from the AXIS.VECTOR[...] or
+     AXIS.OFFSET[...] respectively.  The last component is the CBF row number
+     to facilitate recovering the original CBF layout.
 
-      There are two transformations needed:  coord_xform(v) which takes a
-    vector,   v, in the CBF imgCIF Standard Laboratory Coordinate System and
-    returns the   equivalent McStas coordinate vector, and offset_xform(o)
-    which takes an   offset, o, in the CBF imgCIF Standard Laboratory
-    Coordinate System and   returns the equivalent NeXus offset.
+     THE DIRECT LATTICE (FRACTIONAL COORDINATES) 
+     The unit cell, reciprocal cell and crystallographic orthogonal 
+     Cartesian coordinate system are defined by the CELL and the matrices 
+     in the ATOM_SITES category.
 
-      In imgCIF/CBF all the information about all axes other than their
-      settings are gathered in one AXIS category.  The closest equivalent
-      container in NeXus is the NXinstrument class.  We put the information
-      about detector axes into a
-      detector:NXdetector/transformations:NXtransformations NeXus class
-    instance,   information about the goniometer into a
-      goniometer:NXgoniometer/transformations:NXtransformations NeXus
-      class instance, etc.  Additionally, in view of the general nature of
-      some axes, such as the coordinate frame axes and gravity, we add a
-      transformations:NXtransformation NeXus class instance under NXentry with
-      axis__gravity, axis__beam and other axes not tied to specific equipment.
+     The direct lattice coordinate system is a system of fractional
+     coordinates aligned to the crystal, rather than to the laboratory.
+     This is a natural coordinate system for maps and atomic coordinates.
+     It is the simplest coordinate system in which to apply symmetry.
+     The axes are determined by the cell edges, and are not necessarily
+     orthogonal.  This coordinate system is not uniquely defined and 
+     depends on the cell parameters in the CELL category and the
+     settings chosen to index the crystal. 
 
-      We have applied the coordinate frame transformation changing
-      the CBF laboratory coordinates into McStas coordinates.  Notice that X and
-      Z have changed direction, but Y has not.   In other experimental setups,
-      other transformations may occur.   The offsets for dependent axes are
-      given relative to the total offset of axes on which that axis is
-    dependent.   Note that the axis settings do not enter into this
-    calculation, because the   offsets of dependent axes are given with all
-    axes at their zero settings.
+     Molecules in a crystal studied by X-ray diffraction are organized
+     into a repeating regular array of unit cells.  Each unit cell is defined 
+     by three vectors, a, b and c.  To quote from Drenth (2001),
+     "The choice of the unit cell is not unique and therefore, guidelines
+     have been established for selecting the standard basis vectors and
+     the origin.  They are based on symmetry and metric considerations:
 
-      The cbf_location attribute gives a mapping back into the CBF AXIS category
-      in dotted notation.  The first component is the data block.  The second
-      component is "axis".  The third component is either "vector" or
-      "offset"  for information drawn from the AXIS.VECTOR[...] or
-      AXIS.OFFSET[...] respectively.  The last component is the CBF row number
-      to facilitate recovering the original CBF layout.
+      "(1)  The axial system should be right-handed.
+       (2)  The basis vectors should coincide as much as possible with
+       directions of highest symmetry.
+       (3)  The cell taken should be the smallest one that satisfies
+       condition (2)
+       (4)  Of all the lattice vectors, none is shorter than a.
+       (5)  Of those not directed along a, none is shorter than b.
+       (6)  Of those not lying in the ab plane, none is shorter than c.
+       (7)  The three angles between the basis vectors a, b and c are
+       either all acute (<90 degrees) or all obtuse (&ge;90 degrees)."
 
-      THE DIRECT LATTICE (FRACTIONAL COORDINATES)
+     These rules do not produce a unique result that is stable under
+     the assumption of experimental errors, and the resulting cell
+     may not be primitive.
 
-      The unit cell, reciprocal cell and crystallographic orthogonal
-      Cartesian coordinate system are defined by the CELL and the matrices
-      in the ATOM_SITES category.
+     In this coordinate system, the vector (.5, .5, .5) is in the middle
+     of the given unit cell.
 
-      The direct lattice coordinate system is a system of fractional
-      coordinates aligned to the crystal, rather than to the laboratory.
-      This is a natural coordinate system for maps and atomic coordinates.
-      It is the simplest coordinate system in which to apply symmetry.
-      The axes are determined by the cell edges, and are not necessarily
-      orthogonal.  This coordinate system is not uniquely defined and
-      depends on the cell parameters in the CELL category and the
-      settings chosen to index the crystal.
+     Grid coordinates are an important variation on fractional coordinates
+     used when working with maps.  In imgCIF, the conversion from
+     fractional to grid coordinates is implicit in the array indexing
+     specified by _array_structure_list.dimension.  Note that this
+     implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
+     the origin of the cell for axes along the cell edges with no
+     specified _array_structure_list_axis.displacement will have
+     grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+     THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE) 
+     The orthogonal Cartesian coordinate system is a transformation of
+     the direct lattice to the actual physical coordinates of atoms in
+     space.  It is similar to the laboratory coordinate system, but
+     is anchored to and moves with the crystal, rather than being
+     anchored to the laboratory.  The transformation from fractional
+     to orthogonal Cartesian coordinates is given by the
+              _atom_sites.Cartn_transf_matrix[i][j]  and
+              _atom_sites.Cartn_transf_vector[i]
+     tags.  A common choice for the matrix of the transformation is 
+     given in Protein Data Bank (1992):
 
-      Molecules in a crystal studied by X-ray diffraction are organized
-      into a repeating regular array of unit cells.  Each unit cell is defined
-      by three vectors, a, b and c.  To quote from Drenth (2001),
+              | a      b cos \g   c cos \b                            |
+              | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
+              | 0      0          V/(a b sin \g)                      |
 
-      "The choice of the unit cell is not unique and therefore, guidelines
-      have been established for selecting the standard basis vectors and
-      the origin.  They are based on symmetry and metric considerations:
+     This is a convenient coordinate system in which to do fitting
+     of models to maps and in which to understand the chemistry of
+     a molecule.
+     THE RECIPROCAL LATTICE 
+     The reciprocal lattice coordinate system is used for diffraction
+     intensities.  It is based on the reciprocal cell, the dual of the cell,
+     in which reciprocal cell edges are derived from direct cell faces:
 
-       "(1)  The axial system should be right-handed.
-        (2)  The basis vectors should coincide as much as possible with
-        directions of highest symmetry.
-        (3)  The cell taken should be the smallest one that satisfies
-        condition (2)
-        (4)  Of all the lattice vectors, none is shorter than a.
-        (5)  Of those not directed along a, none is shorter than b.
-        (6)  Of those not lying in the ab plane, none is shorter than c.
-        (7)  The three angles between the basis vectors a, b and c are
-        either all acute (< 90 degrees) or all obtuse ( >= 90 degrees)."
+        a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
+        cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
+        cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
+        cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
+        V = abc (1 - cos^2^ \a 
+                       - cos^2^ \b
+                       - cos^2^ \g
+                       + 2 cos \a cos \b cos \g )^1/2^
 
-      These rules do not produce a unique result that is stable under
-      the assumption of experimental errors, and the resulting cell
-      may not be primitive.
+     In this form the dimensions of the reciprocal lattice are in reciprocal
+     \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by 
+     multiplying by the wavelength.  Reflections are commonly indexed against
+     this coordinate system as (h, k, l) triples.
+     References:
 
-      In this coordinate system, the vector (.5, .5, .5) is in the middle
-      of the given unit cell.
+     Drenth, J. (2001). Introduction to basic crystallography.
+     International tables for crystallography, Vol. F, Crystallography of
+     biological macromolecules, edited by M. G. Rossmann & E. Arnold,
+     1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.    
 
-      Grid coordinates are an important variation on fractional coordinates
-      used when working with maps.  In imgCIF, the conversion from
-      fractional to grid coordinates is implicit in the array indexing
-      specified by _array_structure_list.dimension.  Note that this
-      implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
-      the origin of the cell for axes along the cell edges with no
-      specified _array_structure_list_axis.displacement will have
-      grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+     Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
+     MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
+     http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
 
-      THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE)
+     Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
+     2nd ed., 453 pp. New York: Wiley.
 
-      The orthogonal Cartesian coordinate system is a transformation of
-      the direct lattice to the actual physical coordinates of atoms in
-      space.  It is similar to the laboratory coordinate system, but
-      is anchored to and moves with the crystal, rather than being
-      anchored to the laboratory.  The transformation from fractional
-      to orthogonal Cartesian coordinates is given by the
-               _atom_sites.Cartn_transf_matrix[i][j]  and
-               _atom_sites.Cartn_transf_vector[i]
-      tags.  A common choice for the matrix of the transformation is
-      given in Protein Data Bank (1992):
-
-               | a      b cos \g   c cos \b                            |
-               | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
-               | 0      0          V/(a b sin \g)                      |
-
-      This is a convenient coordinate system in which to do fitting
-      of models to maps and in which to understand the chemistry of
-      a molecule.
-
-      THE RECIPROCAL LATTICE
-
-      The reciprocal lattice coordinate system is used for diffraction
-      intensities.  It is based on the reciprocal cell, the dual of the cell,
-      in which reciprocal cell edges are derived from direct cell faces:
-
-         a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
-         cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
-         cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
-         cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
-         V = abc (1 - cos^2^ \a
-                        - cos^2^ \b
-                        - cos^2^ \g
-                        + 2 cos \a cos \b cos \g )^1/2^
-
-      In this form the dimensions of the reciprocal lattice are in reciprocal
-      \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by
-      multiplying by the wavelength.  Reflections are commonly indexed against
-      this coordinate system as (h, k, l) triples.
-
-      References:
-
-      Drenth, J. (2001). Introduction to basic crystallography.
-      International tables for crystallography, Vol. F, Crystallography of
-      biological macromolecules, edited by M. G. Rossmann & E. Arnold,
-      1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.
-
-      Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
-      MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
-      http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
-
-      Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
-      2nd ed., 453 pp. New York: Wiley.
-
-      Protein Data Bank (1992). Atomic Coordinate and Bibliographic
-      Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
-      Brookhaven National Laboratory.
+     Protein Data Bank (1992). Atomic Coordinate and Bibliographic
+     Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
+     Brookhaven National Laboratory.
 ;
     _name.category_id             HEAD
-    _name.object_id               AXIS
+    _name.object_id               axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -3783,1510 +4397,1461 @@ save_AXIS
       _description_example.case
       _description_example.detail
 ;
-          loop_
-         _axis.id
-         _axis.type
-         _axis.equipment
-         _axis.depends_on
-         _axis.vector[1] _axis.vector[2] _axis.vector[3]
-         omega rotation goniometer     .    1        0        0
-         kappa rotation goniometer omega    -.64279  0       -.76604
-         phi   rotation goniometer kappa    1        0        0
-;
-;
-         Example 1.
-
-           This example shows the axis specification of the axes of a
-           kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
-           (1989). X-ray structure determination. A practical
-           guide, 2nd ed. p. 134. New York: Wiley Interscience].
-
-           There are three axes specified, and no offsets.  The outermost axis,
-           omega, is pointed along the X axis.  The next innermost axis, kappa,
-           is at a 50 degree angle to the X axis, pointed away from the source.
-           The innermost axis, phi, aligns with the X axis when omega and
-           phi are at their zero points.  If T-omega, T-kappa and T-phi
-           are the transformation matrices derived from the axis settings,
-           the complete transformation would be:
-               X' = (T-omega) (T-kappa) (T-phi) X
-;
-;
          loop_
-         _axis.id
-         _axis.type
-         _axis.equipment
-         _axis.depends_on
-         _axis.vector[1] _axis.vector[2] _axis.vector[3]
-         _axis.offset[1] _axis.offset[2] _axis.offset[3]
-         source       .        source     .       0     0     1   . . .
-         gravity      .        gravity    .       0    -1     0   . . .
-         tranz     translation detector rotz      0     0     1   0 0 -68
-         twotheta  rotation    detector   .       1     0     0   . . .
-         roty      rotation    detector twotheta  0     1     0   0 0 -68
-         rotz      rotation    detector roty      0     0     1   0 0 -68
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        omega rotation goniometer     .    1        0        0
+        kappa rotation goniometer omega    -.64279  0       -.76604
+        phi   rotation goniometer kappa    1        0        0
+;
+;      Example 1.
+
+        This example shows the axis specification of the axes of a
+        kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
+        (1989). X-ray structure determination. A practical
+        guide, 2nd ed. p. 134. New York: Wiley Interscience].
+
+        There are three axes specified, and no offsets.  The outermost axis,
+        omega, is pointed along the X axis.  The next innermost axis, kappa,
+        is at a 50 degree angle to the X axis, pointed away from the source.
+        The innermost axis, phi, aligns with the X axis when omega and
+        phi are at their zero points.  If T-omega, T-kappa and T-phi
+        are the transformation matrices derived from the axis settings,
+        the complete transformation would be:
+            X' = (T-omega) (T-kappa) (T-phi) X
 ;
 ;
-         Example 2.
+        loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        _axis.offset[1] _axis.offset[2] _axis.offset[3]
+        source       .        source     .       0     0     1   . . .
+        gravity      .        gravity    .       0    -1     0   . . .
+        tranz     translation detector rotz      0     0     1   0 0 -68
+        twotheta  rotation    detector   .       1     0     0   . . .
+        roty      rotation    detector twotheta  0     1     0   0 0 -68
+        rotz      rotation    detector roty      0     0     1   0 0 -68
+;
+;      Example 2.
 
-           This example shows the axis specification of the axes of a
-           detector, source and gravity.  The order has been changed as a
-           reminder that the ordering of presentation of tokens is not
-           significant.  The centre of rotation of the detector has been taken
-           to be 68 mm in the direction away from the source.
+        This example shows the axis specification of the axes of a
+        detector, source and gravity.  The order has been changed as a
+        reminder that the ordering of presentation of tokens is not
+        significant.  The centre of rotation of the detector has been taken
+        to be 68 mm in the direction away from the source.
 ;
 ;
-         loop_
-         _axis.id
-         _axis.system
-         _axis.vector[1] _axis.vector[2] _axis.vector[3]
-         CELL_A_AXIS    fractional       1 0 0
-         CELL_B_AXIS    fractional       0 1 0
-         CELL_C_AXIS    fractional       0 0 1
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        CELL_A_AXIS    fractional       1 0 0
+        CELL_B_AXIS    fractional       0 1 0
+        CELL_C_AXIS    fractional       0 0 1
 
-         loop_
-         _array_structure_list.array_id
-         _array_structure_list.index
-         _array_structure_list.dimension
-         _array_structure_list.precedence
-         _array_structure_list.direction
-         _array_structure_list.axis_set_id
-         map 1 25 1 increasing CELL_A_AXIS
-         map 1 25 2 increasing CELL_B_AXIS
-         map 1 25 3 increasing CELL_C_AXIS
+        loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing CELL_A_AXIS
+        map 1 25 2 increasing CELL_B_AXIS
+        map 1 25 3 increasing CELL_C_AXIS
 
-         loop_
-         _array_structure_list_axis.axis_id
-         _array_structure_list_axis.fract_displacement
-         _array_structure_list_axis.fract_displacement_increment
-         CELL_A_AXIS 0.01 0.02
-         CELL_B_AXIS 0.01 0.02
-         CELL_C_AXIS 0.01 0.02
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.fract_displacement
+        _array_structure_list_axis.fract_displacement_increment
+        CELL_A_AXIS 0.01 0.02
+        CELL_B_AXIS 0.01 0.02
+        CELL_C_AXIS 0.01 0.02
+;
+;      Example 3.
+
+        This example shows the axis specification of the axes for a map,
+        using fractional coordinates.  Each cell edge has been divided
+        into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS 
+        category.  The map is using only the first octant of the grid
+        in the ARRAY_STRUCTURE_LIST category.
+
+        The fastest changing axis is along A, then along B,
+        and the slowest is along C. 
+
+        The map sampling is being done in the middle of each grid
+        division.
+
 ;
 ;
-         Example 3.
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        X    orthogonal       1 0 0
+        Y    orthogonal       0 1 0
+        Z    orthogonal       0 0 1
 
-           This example shows the axis specification of the axes for a map,
-           using fractional coordinates.  Each cell edge has been divided
-           into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS
-           category.  The map is using only the first octant of the grid
-           in the ARRAY_STRUCTURE_LIST category.
+                loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing X
+        map 2 25 2 increasing Y
+        map 3 25 3 increasing Z
 
-           The fastest changing axis is along A, then along B,
-           and the slowest is along C.
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.displacement
+        _array_structure_list_axis.displacement_increment
+        X 7.5e-8 1.5e-7
+        Y 7.5e-8 1.5e-7
+        Z 7.5e-8 1.5e-7
+;
+;      Example 4.
 
-           The map sampling is being done in the middle of each grid
-           division.
+        This example shows the axis specification of the axes for a map,
+        this time as orthogonal \%angstr\"oms, using the same coordinate system 
+        as for the atomic coordinates.  The map is sampling every 1.5
+        \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
 ;
 ;
-         loop_
-         _axis.id
-         _axis.system
-         _axis.vector[1] _axis.vector[2] _axis.vector[3]
-         X    orthogonal       1 0 0
-         Y    orthogonal       0 1 0
-         Z    orthogonal       0 0 1
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_D0_X
+    CSPAD_FRONT AXIS_D0_Y
+    CSPAD_FRONT AXIS_D0_Z
+    CSPAD_FRONT AXIS_D0_R
+    CSPAD_FRONT FS_D0Q0
+    CSPAD_FRONT FS_D0Q0S0
+    CSPAD_FRONT FS_D0Q0S0A0
+    CSPAD_FRONT FS_D0Q0S0A1
+    CSPAD_FRONT FS_D0Q0S1
+    CSPAD_FRONT FS_D0Q0S1A0
+    CSPAD_FRONT FS_D0Q0S1A1
+    CSPAD_FRONT FS_D0Q0S2
+    CSPAD_FRONT FS_D0Q0S2A0
+    CSPAD_FRONT FS_D0Q0S2A1
+    CSPAD_FRONT FS_D0Q0S3
+    CSPAD_FRONT FS_D0Q0S3A0
+    CSPAD_FRONT FS_D0Q0S3A1
+    CSPAD_FRONT FS_D0Q0S4
+    CSPAD_FRONT FS_D0Q0S4A0
+    CSPAD_FRONT FS_D0Q0S4A1
+    CSPAD_FRONT FS_D0Q0S5
+    CSPAD_FRONT FS_D0Q0S5A0
+    CSPAD_FRONT FS_D0Q0S5A1
+    CSPAD_FRONT FS_D0Q0S6
+    CSPAD_FRONT FS_D0Q0S6A0
+    CSPAD_FRONT FS_D0Q0S6A1
+    CSPAD_FRONT FS_D0Q0S7
+    CSPAD_FRONT FS_D0Q0S7A0
+    CSPAD_FRONT FS_D0Q0S7A1
+    CSPAD_FRONT FS_D0Q1
+    CSPAD_FRONT FS_D0Q1S0
+    CSPAD_FRONT FS_D0Q1S0A0
+    CSPAD_FRONT FS_D0Q1S0A1
+    CSPAD_FRONT FS_D0Q1S1
+    CSPAD_FRONT FS_D0Q1S1A0
+    CSPAD_FRONT FS_D0Q1S1A1
+    CSPAD_FRONT FS_D0Q1S2
+    CSPAD_FRONT FS_D0Q1S2A0
+    CSPAD_FRONT FS_D0Q1S2A1
+    CSPAD_FRONT FS_D0Q1S3
+    CSPAD_FRONT FS_D0Q1S3A0
+    CSPAD_FRONT FS_D0Q1S3A1
+    CSPAD_FRONT FS_D0Q1S4
+    CSPAD_FRONT FS_D0Q1S4A0
+    CSPAD_FRONT FS_D0Q1S4A1
+    CSPAD_FRONT FS_D0Q1S5
+    CSPAD_FRONT FS_D0Q1S5A0
+    CSPAD_FRONT FS_D0Q1S5A1
+    CSPAD_FRONT FS_D0Q1S6
+    CSPAD_FRONT FS_D0Q1S6A0
+    CSPAD_FRONT FS_D0Q1S6A1
+    CSPAD_FRONT FS_D0Q1S7
+    CSPAD_FRONT FS_D0Q1S7A0
+    CSPAD_FRONT FS_D0Q1S7A1
+    CSPAD_FRONT FS_D0Q2
+    CSPAD_FRONT FS_D0Q2S0
+    CSPAD_FRONT FS_D0Q2S0A0
+    CSPAD_FRONT FS_D0Q2S0A1
+    CSPAD_FRONT FS_D0Q2S1
+    CSPAD_FRONT FS_D0Q2S1A0
+    CSPAD_FRONT FS_D0Q2S1A1
+    CSPAD_FRONT FS_D0Q2S2
+    CSPAD_FRONT FS_D0Q2S2A0
+    CSPAD_FRONT FS_D0Q2S2A1
+    CSPAD_FRONT FS_D0Q2S3
+    CSPAD_FRONT FS_D0Q2S3A0
+    CSPAD_FRONT FS_D0Q2S3A1
+    CSPAD_FRONT FS_D0Q2S4
+    CSPAD_FRONT FS_D0Q2S4A0
+    CSPAD_FRONT FS_D0Q2S4A1
+    CSPAD_FRONT FS_D0Q2S5
+    CSPAD_FRONT FS_D0Q2S5A0
+    CSPAD_FRONT FS_D0Q2S5A1
+    CSPAD_FRONT FS_D0Q2S6
+    CSPAD_FRONT FS_D0Q2S6A0
+    CSPAD_FRONT FS_D0Q2S6A1
+    CSPAD_FRONT FS_D0Q2S7
+    CSPAD_FRONT FS_D0Q2S7A0
+    CSPAD_FRONT FS_D0Q2S7A1
+    CSPAD_FRONT FS_D0Q3
+    CSPAD_FRONT FS_D0Q3S0
+    CSPAD_FRONT FS_D0Q3S0A0
+    CSPAD_FRONT FS_D0Q3S0A1
+    CSPAD_FRONT FS_D0Q3S1
+    CSPAD_FRONT FS_D0Q3S1A0
+    CSPAD_FRONT FS_D0Q3S1A1
+    CSPAD_FRONT FS_D0Q3S2
+    CSPAD_FRONT FS_D0Q3S2A0
+    CSPAD_FRONT FS_D0Q3S2A1
+    CSPAD_FRONT FS_D0Q3S3
+    CSPAD_FRONT FS_D0Q3S3A0
+    CSPAD_FRONT FS_D0Q3S3A1
+    CSPAD_FRONT FS_D0Q3S4
+    CSPAD_FRONT FS_D0Q3S4A0
+    CSPAD_FRONT FS_D0Q3S4A1
+    CSPAD_FRONT FS_D0Q3S5
+    CSPAD_FRONT FS_D0Q3S5A0
+    CSPAD_FRONT FS_D0Q3S5A1
+    CSPAD_FRONT FS_D0Q3S6
+    CSPAD_FRONT FS_D0Q3S6A0
+    CSPAD_FRONT FS_D0Q3S6A1
+    CSPAD_FRONT FS_D0Q3S7
+    CSPAD_FRONT FS_D0Q3S7A0
+    CSPAD_FRONT FS_D0Q3S7A1
 
-                 loop_
-         _array_structure_list.array_id
-         _array_structure_list.index
-         _array_structure_list.dimension
-         _array_structure_list.precedence
-         _array_structure_list.direction
-         _array_structure_list.axis_set_id
-         map 1 25 1 increasing X
-         map 2 25 2 increasing Y
-         map 3 25 3 increasing Z
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.equipment_component
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source . 0 0 1 . . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
+    AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
+    AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
+    AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
+    AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm . .
+    FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125 0.0 detector_quadrant . .
+    FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0 1.0 11.3696 -23.189925 0.0 detector_sensor . .
+    FS_D0Q0S0A0 rotation detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A0_S translation detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S0A1 rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A1_S translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0 detector_sensor . .
+    FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A0_F translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1A1 rotation detector FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A1_S translation detector AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2 rotation detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0 detector_sensor . .
+    FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1 -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A0_F translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2A1 rotation detector FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A1_S translation detector AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3 rotation detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor . .
+    FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A0_F translation detector FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A1_F translation detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0 -11.2651 24.282775 0.0 detector_sensor . .
+    FS_D0Q0S4A0 rotation detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A0_S translation detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4A1 rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A1_S translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0 detector_sensor . .
+    FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1 -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A0_F translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5A1 rotation detector FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A1_S translation detector AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6 rotation detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
+    FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A0_F translation detector FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A1_F translation detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0 23.3541 9.829875 0.0 detector_sensor . .
+    FS_D0Q0S7A0 rotation detector FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A0_S translation detector AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7A1 rotation detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A1_S translation detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1 rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0 detector_quadrant . .
+    FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.1589875 -11.451825 0.0 detector_sensor . .
+    FS_D0Q1S0A0 rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A0_S translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A1_F translation detector FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.2073875 -34.782825 0.0 detector_sensor . .
+    FS_D0Q1S1A0 rotation detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A0_F translation detector FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A1_F translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2 rotation detector FS_D0Q1 0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . .
+    FS_D0Q1S2A0 rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A0_S translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A1_F translation detector FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0 -34.1402875 23.344475 0.0 detector_sensor . .
+    FS_D0Q1S3A0 rotation detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A0_S translation detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3A1 rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A1_S translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275 0.0 detector_sensor . .
+    FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1 -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A0_F translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4A1 rotation detector FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A1_S translation detector AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor . .
+    FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A0_F translation detector FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A1_F translation detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0 33.2523125 -23.321925 0.0 detector_sensor . .
+    FS_D0Q1S6A0 rotation detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A0_S translation detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6A1 rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A1_S translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225 0.0 detector_sensor . .
+    FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1 -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A0_F translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7A1 rotation detector FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A1_S translation detector AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2 rotation detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0 detector_quadrant . .
+    FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -11.3150125 23.1242 0.0 detector_sensor . .
+    FS_D0Q2S0A0 rotation detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A0_S translation detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S0A1 rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A1_S translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155 0.0 detector_sensor . .
+    FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A0_F translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1A1 rotation detector FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A1_S translation detector AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2 rotation detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor . .
+    FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A0_F translation detector FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A1_F translation detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0 23.6220875 34.2221 0.0 detector_sensor . .
+    FS_D0Q2S3A0 rotation detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A0_S translation detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3A1 rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A1_S translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954 0.0 detector_sensor . .
+    FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1 -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A0_F translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4A1 rotation detector FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A1_S translation detector AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5 rotation detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor . .
+    FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A0_F translation detector FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A1_F translation detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.4854125 -33.2552 0.0 detector_sensor . .
+    FS_D0Q2S6A0 rotation detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A0_S translation detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6A1 rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A1_S translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417 0.0 detector_sensor . .
+    FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1 -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A0_F translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7A1 rotation detector FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A1_S translation detector AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3 rotation detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0 detector_quadrant . .
+    FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1056375 11.6367625 0.0 detector_sensor . .
+    FS_D0Q3S0A0 rotation detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A0_S translation detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S0A1 rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A1_S translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625 0.0 detector_sensor . .
+    FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1 -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A0_F translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1A1 rotation detector FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A1_S translation detector AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0 detector_sensor . .
+    FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1 -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A0_F translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2A1 rotation detector FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A1_S translation detector AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0 detector_sensor . .
+    FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1 -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A0_F translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3A1 rotation detector FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A1_S translation detector AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0 detector_sensor . .
+    FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1 -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A0_F translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4A1 rotation detector FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A1_S translation detector AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0 detector_sensor . .
+    FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1 -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A0_F translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5A1 rotation detector FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A1_S translation detector AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0 detector_sensor . .
+    FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1 -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A0_F translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6A1 rotation detector FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A1_S translation detector AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0 detector_sensor . .
+    FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1 -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A0_F translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7A1 rotation detector FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+;
+;       Example 5.
 
-         loop_
-         _array_structure_list_axis.axis_id
-         _array_structure_list_axis.displacement
-         _array_structure_list_axis.displacement_increment
-         X 7.5e-8 1.5e-7
-         Y 7.5e-8 1.5e-7
-         Z 7.5e-8 1.5e-7
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
 ;
 ;
-         Example 4.
 
-           This example shows the axis specification of the axes for a map,
-           this time as orthogonal \%angstr\"oms, using the same coordinate
-         system   as for the atomic coordinates.  The map is sampling every 1.5
-           \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_DETECTOR_X
+    CSPAD_FRONT AXIS_DETECTOR_Y
+    CSPAD_FRONT AXIS_DETECTOR_Z
+    CSPAD_FRONT AXIS_DETECTOR_PITCH
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source   . 0 0 1 . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
+    AXIS_DETECTOR_Z translation detector
+                                 . 0 0 1 0 0 0 . .
+    AXIS_DETECTOR_Y translation detector
+                   AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_X translation detector
+                   AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
+    AXIS_DETECTOR_PITCH rotation detector
+                   AXIS_DETECTOR_X 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_ROT rotation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
+    AXIS_D0_ORIGIN translation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
+    AXIS_D0_ROT rotation detector
+                    AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0 translation detector
+                    AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
+    AXIS_D0Q0_ROT rotation detector
+                           AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0 translation detector
+                           AXIS_D0 . . . -49.860765625 41.643353125 0.0
+                                      0.0 AXIS_D0Q0_ROT
+    AXIS_D0Q0S0_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S0 translation detector
+                          AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
+                                      89.66181 AXIS_D0Q0S0_ROT
+    AXIS_D0Q0S0A0_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A0 translation detector
+                        AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S0A0_ROT
+    AXIS_D0Q0S0A0_F translation detector
+                      AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A0_S translation detector
+                      AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S0A1_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A1 translation detector
+                        AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S0A1_ROT
+    AXIS_D0Q0S0A1_F translation detector
+                      AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A1_S translation detector
+                      AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S1 translation detector
+                          AXIS_D0Q0 . . . 34.815 -23.309825 0.0
+                                      90.00132 AXIS_D0Q0S1_ROT
+    AXIS_D0Q0S1A0_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A0 translation detector
+                        AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S1A0_ROT
+    AXIS_D0Q0S1A0_F translation detector
+                      AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A0_S translation detector
+                      AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1A1_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A1 translation detector
+                        AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S1A1_ROT
+    AXIS_D0Q0S1A1_F translation detector
+                      AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A1_S translation detector
+                      AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2_ROT rotation detector
+                          AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q0S2 translation detector
+                          AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
+                                     359.68548 AXIS_D0Q0S2_ROT
+    AXIS_D0Q0S2A0_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A0 translation detector
+                        AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S2A0_ROT
+    AXIS_D0Q0S2A0_F translation detector
+                        AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A0_S translation detector
+                        AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2A1_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A1 translation detector
+                        AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S2A1_ROT
+    AXIS_D0Q0S2A1_F translation detector
+                        AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A1_S translation detector
+                        AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S3 translation detector
+                        AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
+                                   359.96513 AXIS_D0Q0S3_ROT
+    AXIS_D0Q0S3A0_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A0 translation detector
+                        AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S3A0_ROT
+    AXIS_D0Q0S3A0_F translation detector
+                        AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A0_S translation detector
+                        AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3A1_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A1 translation detector
+                        AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S3A1_ROT
+    AXIS_D0Q0S3A1_F translation detector
+                        AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A1_S translation detector
+                        AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S4 translation detector
+                        AXIS_D0Q0 . . . -11.2651 24.282775 0.0
+                                   270.14738 AXIS_D0Q0S4_ROT
+    AXIS_D0Q0S4A0_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A0 translation detector
+                        AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S4A0_ROT
+    AXIS_D0Q0S4A0_F translation detector
+                        AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A0_S translation detector
+                        AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4A1_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A1 translation detector
+                        AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S4A1_ROT
+    AXIS_D0Q0S4A1_F translation detector
+                        AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A1_S translation detector
+                        AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S5 translation detector
+                        AXIS_D0Q0 . . . -34.7336 24.169475 0.0
+                                   270.07896 AXIS_D0Q0S5_ROT
+    AXIS_D0Q0S5A0_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A0 translation detector
+                        AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S5A0_ROT
+    AXIS_D0Q0S5A0_F translation detector
+                        AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A0_S translation detector
+                        AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5A1_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A1 translation detector
+                        AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S5A1_ROT
+    AXIS_D0Q0S5A1_F translation detector
+                        AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A1_S translation detector
+                        AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S6 translation detector
+                        AXIS_D0Q0 . . . 23.5488 33.320375 0.0
+                                   359.78222 AXIS_D0Q0S6_ROT
+    AXIS_D0Q0S6A0_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A0 translation detector
+                        AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S6A0_ROT
+    AXIS_D0Q0S6A0_F translation detector
+                        AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A0_S translation detector
+                        AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6A1_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A1 translation detector
+                        AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S6A1_ROT
+    AXIS_D0Q0S6A1_F translation detector
+                        AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A1_S translation detector
+                        AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S7 translation detector
+                        AXIS_D0Q0 . . . 23.3541 9.829875 0.0
+                                   359.89604 AXIS_D0Q0S7_ROT
+    AXIS_D0Q0S7A0_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A0 translation detector
+                        AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S7A0_ROT
+    AXIS_D0Q0S7A0_F translation detector
+                        AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A0_S translation detector
+                        AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7A1_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A1 translation detector
+                        AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S7A1_ROT
+    AXIS_D0Q0S7A1_F translation detector
+                        AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A1_S translation detector
+                        AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1 translation detector
+                        AXIS_D0 . . . 41.512521875 50.149653125 0.0
+                                   0.0 AXIS_D0Q1_ROT
+    AXIS_D0Q1S0_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S0 translation detector
+                        AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
+                                     0.27238 AXIS_D0Q1S0_ROT
+    AXIS_D0Q1S0A0_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A0 translation detector
+                        AXIS_D0Q1S0 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q1S0A0_ROT
+    AXIS_D0Q1S0A0_F translation detector
+                        AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A0_S translation detector
+                        AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S0A1_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A1 translation detector
+                        AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S0A1_ROT
+    AXIS_D0Q1S0A1_F translation detector
+                        AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A1_S translation detector
+                        AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S1 translation detector
+                        AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
+                                     0.00525999986641 AXIS_D0Q1S1_ROT
+    AXIS_D0Q1S1A0_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A0 translation detector
+                        AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S1A0_ROT
+    AXIS_D0Q1S1A0_F translation detector
+                        AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A0_S translation detector
+                        AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1A1_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A1 translation detector
+                        AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S1A1_ROT
+    AXIS_D0Q1S1A1_F translation detector
+                        AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A1_S translation detector
+                        AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S2 translation detector
+                        AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
+                                   270.02545 AXIS_D0Q1S2_ROT
+    AXIS_D0Q1S2A0_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A0 translation detector
+                        AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S2A0_ROT
+    AXIS_D0Q1S2A0_F translation detector
+                        AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A0_S translation detector
+                        AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2A1_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A1 translation detector
+                        AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S2A1_ROT
+    AXIS_D0Q1S2A1_F translation detector
+                        AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A1_S translation detector
+                        AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S3 translation detector
+                        AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
+                                   270.03066 AXIS_D0Q1S3_ROT
+    AXIS_D0Q1S3A0_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A0 translation detector
+                        AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S3A0_ROT
+    AXIS_D0Q1S3A0_F translation detector
+                        AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A0_S translation detector
+                        AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3A1_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A1 translation detector
+                        AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S3A1_ROT
+    AXIS_D0Q1S3A1_F translation detector
+                        AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A1_S translation detector
+                        AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S4 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
+                                    179.96381 AXIS_D0Q1S4_ROT
+    AXIS_D0Q1S4A0_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A0 translation detector
+                        AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S4A0_ROT
+    AXIS_D0Q1S4A0_F translation detector
+                        AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A0_S translation detector
+                        AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4A1_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A1 translation detector
+                        AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S4A1_ROT
+    AXIS_D0Q1S4A1_F translation detector
+                        AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A1_S translation detector
+                        AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S5 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
+                                   180.02434 AXIS_D0Q1S5_ROT
+    AXIS_D0Q1S5A0_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A0 translation detector
+                        AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S5A0_ROT
+    AXIS_D0Q1S5A0_F translation detector
+                        AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A0_S translation detector
+                        AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5A1_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A1 translation detector
+                        AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S5A1_ROT
+    AXIS_D0Q1S5A1_F translation detector
+                        AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A1_S translation detector
+                        AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S6 translation detector
+                        AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
+                                   270.08027 AXIS_D0Q1S6_ROT
+    AXIS_D0Q1S6A0_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A0 translation detector
+                        AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S6A0_ROT
+    AXIS_D0Q1S6A0_F translation detector
+                        AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A0_S translation detector
+                        AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6A1_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A1 translation detector
+                        AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S6A1_ROT
+    AXIS_D0Q1S6A1_F translation detector
+                        AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A1_S translation detector
+                        AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S7 translation detector
+                        AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
+                                   270.15067 AXIS_D0Q1S7_ROT
+    AXIS_D0Q1S7A0_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A0 translation detector
+                        AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S7A0_ROT
+    AXIS_D0Q1S7A0_F translation detector
+                        AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A0_S translation detector
+                        AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7A1_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A1 translation detector
+                        AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S7A1_ROT
+    AXIS_D0Q1S7A1_F translation detector
+                        AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A1_S translation detector
+                        AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2 translation detector
+                        AXIS_D0 . . . 49.596146875 -41.351371875 0.0
+                                   0.0 AXIS_D0Q2_ROT
+    AXIS_D0Q2S0_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S0 translation detector
+                        AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
+                                    90.04803 AXIS_D0Q2S0_ROT
+    AXIS_D0Q2S0A0_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A0 translation detector
+                        AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S0A0_ROT
+    AXIS_D0Q2S0A0_F translation detector
+                        AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A0_S translation detector
+                        AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S0A1_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A1 translation detector
+                        AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S0A1_ROT
+    AXIS_D0Q2S0A1_F translation detector
+                        AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A1_S translation detector
+                        AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S1 translation detector
+                        AXIS_D0Q2 . . . -34.6999125 23.155 0.0
+                                    90.00592 AXIS_D0Q2S1_ROT
+    AXIS_D0Q2S1A0_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A0 translation detector
+                        AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S1A0_ROT
+    AXIS_D0Q2S1A0_F translation detector
+                        AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A0_S translation detector
+                        AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1A1_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A1 translation detector
+                        AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S1A1_ROT
+    AXIS_D0Q2S1A1_F translation detector
+                        AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A1_S translation detector
+                        AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S2 translation detector
+                        AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
+                                    180.11318 AXIS_D0Q2S2_ROT
+    AXIS_D0Q2S2A0_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A0 translation detector
+                        AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S2A0_ROT
+    AXIS_D0Q2S2A0_F translation detector
+                        AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A0_S translation detector
+                        AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2A1_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A1 translation detector
+                        AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S2A1_ROT
+    AXIS_D0Q2S2A1_F translation detector
+                        AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A1_S translation detector
+                        AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S3 translation detector
+                        AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
+                                   179.92104 AXIS_D0Q2S3_ROT
+    AXIS_D0Q2S3A0_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A0 translation detector
+                        AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S3A0_ROT
+    AXIS_D0Q2S3A0_F translation detector
+                        AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A0_S translation detector
+                        AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3A1_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A1 translation detector
+                        AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S3A1_ROT
+    AXIS_D0Q2S3A1_F translation detector
+                        AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A1_S translation detector
+                        AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S4 translation detector
+                        AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
+                                      89.63875 AXIS_D0Q2S4_ROT
+    AXIS_D0Q2S4A0_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A0 translation detector
+                        AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S4A0_ROT
+    AXIS_D0Q2S4A0_F translation detector
+                        AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A0_S translation detector
+                        AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4A1_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A1 translation detector
+                        AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S4A1_ROT
+    AXIS_D0Q2S4A1_F translation detector
+                        AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A1_S translation detector
+                        AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S5 translation detector
+                        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
+                                    89.68154 AXIS_D0Q2S5_ROT
+    AXIS_D0Q2S5A0_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A0 translation detector
+                        AXIS_D0Q2S5 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A0_ROT
+    AXIS_D0Q2S5A0_F translation detector
+                        AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A0_S translation detector
+                        AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5A1_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A1 translation detector
+                        AXIS_D0Q2S5 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A1_ROT
+    AXIS_D0Q2S5A1_F translation detector
+                        AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A1_S translation detector
+                        AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S6 translation detector
+                        AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
+                                   179.83473 AXIS_D0Q2S6_ROT
+    AXIS_D0Q2S6A0_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A0 translation detector
+                        AXIS_D0Q2S6 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A0_ROT
+    AXIS_D0Q2S6A0_F translation detector
+                        AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A0_S translation detector
+                        AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6A1_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A1 translation detector
+                        AXIS_D0Q2S6 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A1_ROT
+    AXIS_D0Q2S6A1_F translation detector
+                        AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A1_S translation detector
+                        AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S7 translation detector
+                        AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
+                                   180.092 AXIS_D0Q2S7_ROT
+    AXIS_D0Q2S7A0_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A0 translation detector
+                        AXIS_D0Q2S7 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S7A0_ROT
+    AXIS_D0Q2S7A0_F translation detector
+                        AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A0_S translation detector
+                        AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7A1_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A1 translation detector
+                        AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S7A1_ROT
+    AXIS_D0Q2S7A1_F translation detector
+                        AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A1_S translation detector
+                        AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3 translation detector
+                        AXIS_D0 . . . -41.247903125 -50.441634375 0.0
+                                   0.0 AXIS_D0Q3_ROT
+    AXIS_D0Q3S0_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S0 translation detector
+                        AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
+                                   180.12436 AXIS_D0Q3S0_ROT
+    AXIS_D0Q3S0A0_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A0 translation detector
+                        AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S0A0_ROT
+    AXIS_D0Q3S0A0_F translation detector
+                        AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A0_S translation detector
+                        AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S0A1_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A1 translation detector
+                        AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S0A1_ROT
+    AXIS_D0Q3S0A1_F translation detector
+                        AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A1_S translation detector
+                        AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S1 translation detector
+                        AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
+                                   180.00263 AXIS_D0Q3S1_ROT
+    AXIS_D0Q3S1A0_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A0 translation detector
+                        AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S1A0_ROT
+    AXIS_D0Q3S1A0_F translation detector
+                        AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A0_S translation detector
+                        AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1A1_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A1 translation detector
+                        AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S1A1_ROT
+    AXIS_D0Q3S1A1_F translation detector
+                        AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A1_S translation detector
+                        AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S2 translation detector
+                        AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
+                                   269.55191 AXIS_D0Q3S2_ROT
+    AXIS_D0Q3S2A0_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A0 translation detector
+                        AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S2A0_ROT
+    AXIS_D0Q3S2A0_F translation detector
+                        AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A0_S translation detector
+                        AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2A1_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A1 translation detector
+                        AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S2A1_ROT
+    AXIS_D0Q3S2A1_F translation detector
+                        AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A1_S translation detector
+                        AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S3 translation detector
+                        AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
+                                   269.74206 AXIS_D0Q3S3_ROT
+    AXIS_D0Q3S3A0_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A0 translation detector
+                        AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S3A0_ROT
+    AXIS_D0Q3S3A0_F translation detector
+                        AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A0_S translation detector
+                        AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3A1_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A1 translation detector
+                        AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S3A1_ROT
+    AXIS_D0Q3S3A1_F translation detector
+                        AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A1_S translation detector
+                        AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S4 translation detector
+                        AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
+                                   359.81971 AXIS_D0Q3S4_ROT
+    AXIS_D0Q3S4A0_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A0 translation detector
+                        AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S4A0_ROT
+    AXIS_D0Q3S4A0_F translation detector
+                        AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A0_S translation detector
+                        AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4A1_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A1 translation detector
+                        AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S4A1_ROT
+    AXIS_D0Q3S4A1_F translation detector
+                        AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A1_S translation detector
+                        AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S5 translation detector
+                        AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
+                                   359.99883 AXIS_D0Q3S5_ROT
+    AXIS_D0Q3S5A0_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A0 translation detector
+                        AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S5A0_ROT
+    AXIS_D0Q3S5A0_F translation detector
+                        AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A0_S translation detector
+                        AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5A1_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A1 translation detector
+                        AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S5A1_ROT
+    AXIS_D0Q3S5A1_F translation detector
+                        AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A1_S translation detector
+                        AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S6 translation detector
+                        AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
+                                   269.67299 AXIS_D0Q3S6_ROT
+    AXIS_D0Q3S6A0_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A0 translation detector
+                        AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S6A0_ROT
+    AXIS_D0Q3S6A0_F translation detector
+                        AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A0_S translation detector
+                        AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6A1_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A1 translation detector
+                        AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S6A1_ROT
+    AXIS_D0Q3S6A1_F translation detector
+                        AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A1_S translation detector
+                        AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S7 translation detector
+                        AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
+                                   269.67561 AXIS_D0Q3S7_ROT
+    AXIS_D0Q3S7A0_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A0 translation detector
+                        AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S7A0_ROT
+    AXIS_D0Q3S7A0_F translation detector
+                        AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A0_S translation detector
+                        AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7A1_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A1 translation detector
+                        AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S7A1_ROT
+    AXIS_D0Q3S7A1_F translation detector
+                        AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A1_S translation detector
+                        AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
+
 ;
+;       Example 6.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
+    _axis.rotation to organize the positional dependencies.  The approach
+    in Example 5 is now preferred.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+
+    To do this, the first vector of importance is an initial placement axis
+    that moves from the origin along the Z axis a distance equal to the
+    detector distance.  This is the origin for the rest of the axes and is
+    called AXIS_D0_ORIGIN.
+
+    Each subsequent movement involves a frame shift.  This is done by using
+    two imgCIF axes: a rotation axis and a translation axis.  The rotation
+    axis is listed first, and includes no offset or angle.  The actual frame
+    shift is done by using a translation axis.  An offset is used first in
+    the parent's frame, and then an angle is listed to rotate around the
+    rotation axis.
+
+    Example, sensor five of quadrant 2.  First a rotation axis is listed:
+
+    AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    This defines a rotation axis around the z axis in the frame of quadrant 2.
+
+    Next a translation axis is listed:
+    AXIS_D0Q2S5 translation detector
+        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
+    Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
+    then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
+
+    And so forth.
 ;
-          loop_
-         _diffrn_detector_axis.detector_id
-         _diffrn_detector_axis.axis_id
-         CSPAD_FRONT AXIS_D0_X
-         CSPAD_FRONT AXIS_D0_Y
-         CSPAD_FRONT AXIS_D0_Z
-         CSPAD_FRONT AXIS_D0_R
-         CSPAD_FRONT FS_D0Q0
-         CSPAD_FRONT FS_D0Q0S0
-         CSPAD_FRONT FS_D0Q0S0A0
-         CSPAD_FRONT FS_D0Q0S0A1
-         CSPAD_FRONT FS_D0Q0S1
-         CSPAD_FRONT FS_D0Q0S1A0
-         CSPAD_FRONT FS_D0Q0S1A1
-         CSPAD_FRONT FS_D0Q0S2
-         CSPAD_FRONT FS_D0Q0S2A0
-         CSPAD_FRONT FS_D0Q0S2A1
-         CSPAD_FRONT FS_D0Q0S3
-         CSPAD_FRONT FS_D0Q0S3A0
-         CSPAD_FRONT FS_D0Q0S3A1
-         CSPAD_FRONT FS_D0Q0S4
-         CSPAD_FRONT FS_D0Q0S4A0
-         CSPAD_FRONT FS_D0Q0S4A1
-         CSPAD_FRONT FS_D0Q0S5
-         CSPAD_FRONT FS_D0Q0S5A0
-         CSPAD_FRONT FS_D0Q0S5A1
-         CSPAD_FRONT FS_D0Q0S6
-         CSPAD_FRONT FS_D0Q0S6A0
-         CSPAD_FRONT FS_D0Q0S6A1
-         CSPAD_FRONT FS_D0Q0S7
-         CSPAD_FRONT FS_D0Q0S7A0
-         CSPAD_FRONT FS_D0Q0S7A1
-         CSPAD_FRONT FS_D0Q1
-         CSPAD_FRONT FS_D0Q1S0
-         CSPAD_FRONT FS_D0Q1S0A0
-         CSPAD_FRONT FS_D0Q1S0A1
-         CSPAD_FRONT FS_D0Q1S1
-         CSPAD_FRONT FS_D0Q1S1A0
-         CSPAD_FRONT FS_D0Q1S1A1
-         CSPAD_FRONT FS_D0Q1S2
-         CSPAD_FRONT FS_D0Q1S2A0
-         CSPAD_FRONT FS_D0Q1S2A1
-         CSPAD_FRONT FS_D0Q1S3
-         CSPAD_FRONT FS_D0Q1S3A0
-         CSPAD_FRONT FS_D0Q1S3A1
-         CSPAD_FRONT FS_D0Q1S4
-         CSPAD_FRONT FS_D0Q1S4A0
-         CSPAD_FRONT FS_D0Q1S4A1
-         CSPAD_FRONT FS_D0Q1S5
-         CSPAD_FRONT FS_D0Q1S5A0
-         CSPAD_FRONT FS_D0Q1S5A1
-         CSPAD_FRONT FS_D0Q1S6
-         CSPAD_FRONT FS_D0Q1S6A0
-         CSPAD_FRONT FS_D0Q1S6A1
-         CSPAD_FRONT FS_D0Q1S7
-         CSPAD_FRONT FS_D0Q1S7A0
-         CSPAD_FRONT FS_D0Q1S7A1
-         CSPAD_FRONT FS_D0Q2
-         CSPAD_FRONT FS_D0Q2S0
-         CSPAD_FRONT FS_D0Q2S0A0
-         CSPAD_FRONT FS_D0Q2S0A1
-         CSPAD_FRONT FS_D0Q2S1
-         CSPAD_FRONT FS_D0Q2S1A0
-         CSPAD_FRONT FS_D0Q2S1A1
-         CSPAD_FRONT FS_D0Q2S2
-         CSPAD_FRONT FS_D0Q2S2A0
-         CSPAD_FRONT FS_D0Q2S2A1
-         CSPAD_FRONT FS_D0Q2S3
-         CSPAD_FRONT FS_D0Q2S3A0
-         CSPAD_FRONT FS_D0Q2S3A1
-         CSPAD_FRONT FS_D0Q2S4
-         CSPAD_FRONT FS_D0Q2S4A0
-         CSPAD_FRONT FS_D0Q2S4A1
-         CSPAD_FRONT FS_D0Q2S5
-         CSPAD_FRONT FS_D0Q2S5A0
-         CSPAD_FRONT FS_D0Q2S5A1
-         CSPAD_FRONT FS_D0Q2S6
-         CSPAD_FRONT FS_D0Q2S6A0
-         CSPAD_FRONT FS_D0Q2S6A1
-         CSPAD_FRONT FS_D0Q2S7
-         CSPAD_FRONT FS_D0Q2S7A0
-         CSPAD_FRONT FS_D0Q2S7A1
-         CSPAD_FRONT FS_D0Q3
-         CSPAD_FRONT FS_D0Q3S0
-         CSPAD_FRONT FS_D0Q3S0A0
-         CSPAD_FRONT FS_D0Q3S0A1
-         CSPAD_FRONT FS_D0Q3S1
-         CSPAD_FRONT FS_D0Q3S1A0
-         CSPAD_FRONT FS_D0Q3S1A1
-         CSPAD_FRONT FS_D0Q3S2
-         CSPAD_FRONT FS_D0Q3S2A0
-         CSPAD_FRONT FS_D0Q3S2A1
-         CSPAD_FRONT FS_D0Q3S3
-         CSPAD_FRONT FS_D0Q3S3A0
-         CSPAD_FRONT FS_D0Q3S3A1
-         CSPAD_FRONT FS_D0Q3S4
-         CSPAD_FRONT FS_D0Q3S4A0
-         CSPAD_FRONT FS_D0Q3S4A1
-         CSPAD_FRONT FS_D0Q3S5
-         CSPAD_FRONT FS_D0Q3S5A0
-         CSPAD_FRONT FS_D0Q3S5A1
-         CSPAD_FRONT FS_D0Q3S6
-         CSPAD_FRONT FS_D0Q3S6A0
-         CSPAD_FRONT FS_D0Q3S6A1
-         CSPAD_FRONT FS_D0Q3S7
-         CSPAD_FRONT FS_D0Q3S7A0
-         CSPAD_FRONT FS_D0Q3S7A1
 
-          loop_
-         _diffrn_detector_element.id
-         _diffrn_detector_element.detector_id
-         ELE_D0Q0S0A0 CSPAD_FRONT
-         ELE_D0Q0S0A1 CSPAD_FRONT
-         ELE_D0Q0S1A0 CSPAD_FRONT
-         ELE_D0Q0S1A1 CSPAD_FRONT
-         ELE_D0Q0S2A0 CSPAD_FRONT
-         ELE_D0Q0S2A1 CSPAD_FRONT
-         ELE_D0Q0S3A0 CSPAD_FRONT
-         ELE_D0Q0S3A1 CSPAD_FRONT
-         ELE_D0Q0S4A0 CSPAD_FRONT
-         ELE_D0Q0S4A1 CSPAD_FRONT
-         ELE_D0Q0S5A0 CSPAD_FRONT
-         ELE_D0Q0S5A1 CSPAD_FRONT
-         ELE_D0Q0S6A0 CSPAD_FRONT
-         ELE_D0Q0S6A1 CSPAD_FRONT
-         ELE_D0Q0S7A0 CSPAD_FRONT
-         ELE_D0Q0S7A1 CSPAD_FRONT
-         ELE_D0Q1S0A0 CSPAD_FRONT
-         ELE_D0Q1S0A1 CSPAD_FRONT
-         ELE_D0Q1S1A0 CSPAD_FRONT
-         ELE_D0Q1S1A1 CSPAD_FRONT
-         ELE_D0Q1S2A0 CSPAD_FRONT
-         ELE_D0Q1S2A1 CSPAD_FRONT
-         ELE_D0Q1S3A0 CSPAD_FRONT
-         ELE_D0Q1S3A1 CSPAD_FRONT
-         ELE_D0Q1S4A0 CSPAD_FRONT
-         ELE_D0Q1S4A1 CSPAD_FRONT
-         ELE_D0Q1S5A0 CSPAD_FRONT
-         ELE_D0Q1S5A1 CSPAD_FRONT
-         ELE_D0Q1S6A0 CSPAD_FRONT
-         ELE_D0Q1S6A1 CSPAD_FRONT
-         ELE_D0Q1S7A0 CSPAD_FRONT
-         ELE_D0Q1S7A1 CSPAD_FRONT
-         ELE_D0Q2S0A0 CSPAD_FRONT
-         ELE_D0Q2S0A1 CSPAD_FRONT
-         ELE_D0Q2S1A0 CSPAD_FRONT
-         ELE_D0Q2S1A1 CSPAD_FRONT
-         ELE_D0Q2S2A0 CSPAD_FRONT
-         ELE_D0Q2S2A1 CSPAD_FRONT
-         ELE_D0Q2S3A0 CSPAD_FRONT
-         ELE_D0Q2S3A1 CSPAD_FRONT
-         ELE_D0Q2S4A0 CSPAD_FRONT
-         ELE_D0Q2S4A1 CSPAD_FRONT
-         ELE_D0Q2S5A0 CSPAD_FRONT
-         ELE_D0Q2S5A1 CSPAD_FRONT
-         ELE_D0Q2S6A0 CSPAD_FRONT
-         ELE_D0Q2S6A1 CSPAD_FRONT
-         ELE_D0Q2S7A0 CSPAD_FRONT
-         ELE_D0Q2S7A1 CSPAD_FRONT
-         ELE_D0Q3S0A0 CSPAD_FRONT
-         ELE_D0Q3S0A1 CSPAD_FRONT
-         ELE_D0Q3S1A0 CSPAD_FRONT
-         ELE_D0Q3S1A1 CSPAD_FRONT
-         ELE_D0Q3S2A0 CSPAD_FRONT
-         ELE_D0Q3S2A1 CSPAD_FRONT
-         ELE_D0Q3S3A0 CSPAD_FRONT
-         ELE_D0Q3S3A1 CSPAD_FRONT
-         ELE_D0Q3S4A0 CSPAD_FRONT
-         ELE_D0Q3S4A1 CSPAD_FRONT
-         ELE_D0Q3S5A0 CSPAD_FRONT
-         ELE_D0Q3S5A1 CSPAD_FRONT
-         ELE_D0Q3S6A0 CSPAD_FRONT
-         ELE_D0Q3S6A1 CSPAD_FRONT
-         ELE_D0Q3S7A0 CSPAD_FRONT
-         ELE_D0Q3S7A1 CSPAD_FRONT
+    _nx_mapping.details
+;    _axis.id                  AXISID
+    _axis.type                AXISTYPE
+    _axis.equipment           AXISEQUIPMENT
+    _axis.equipment_component AXISEQUIPCOMP
+    _axis.depends_on          AXISDEPENDSON
+    _axis.rotation_axis       AXISROTAXIS
+    _axis.rotation            AXISROTATION
+    _axis.vector[1]           AXISV1
+    _axis.vector[2]           AXISV2
+    _axis.vector[3]           AXISV3
+    _axis.offset[1]           AXISO1
+    _axis.offset[2]           AXISO2
+    _axis.offset[3]           AXISO3
+    _axis.system              AXISSYSTEM
 
-          loop_
-         _axis.id
-         _axis.type
-         _axis.equipment
-         _axis.depends_on
-         _axis.vector[1]
-         _axis.vector[2]
-         _axis.vector[3]
-         _axis.offset[1]
-         _axis.offset[2]
-         _axis.offset[3]
-         _axis.equipment_component
-         _axis.rotation
-         _axis.rotation_axis
-         AXIS_SOURCE general source . 0 0 1 . . . . . .
-         AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
-         AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
-         AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
-         AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
-         AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm .
-         . FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125
-         0.0 detector_quadrant . . FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0
-         1.0 11.3696 -23.189925 0.0 detector_sensor . . FS_D0Q0S0A0 rotation
-         detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181
-         FS_D0Q0S0 AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q0S0A0_S translation
-         detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S0A1
-         rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic
-         89.66181 FS_D0Q0S0 AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q0S0A1_S
-         translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0
-         detector_sensor . . FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1
-         -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1 AXIS_D0Q0S1A0_F
-         translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S1A1 rotation detector
-         FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
-         AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q0S1A1_S translation detector
-         AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S2 rotation
-         detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0
-         detector_sensor . . FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1
-         -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2 AXIS_D0Q0S2A0_F
-         translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S2A1 rotation detector
-         FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
-         AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q0S2A1_S translation detector
-         AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S3 rotation
-         detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor .
-         . FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0
-         detector_asic 359.96513 FS_D0Q0S3 AXIS_D0Q0S3A0_F translation detector
-         FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835
-         0.0 0.0 detector_asic 359.96513 FS_D0Q0S3 AXIS_D0Q0S3A1_F translation
-         detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0
-         -11.2651 24.282775 0.0 detector_sensor . . FS_D0Q0S4A0 rotation
-         detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738
-         FS_D0Q0S4 AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q0S4A0_S translation
-         detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S4A1
-         rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic
-         270.14738 FS_D0Q0S4 AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q0S4A1_S
-         translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0
-         detector_sensor . . FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1
-         -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5 AXIS_D0Q0S5A0_F
-         translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S5A1 rotation detector
-         FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
-         AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q0S5A1_S translation detector
-         AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S6 rotation
-         detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
-         FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0
-         detector_asic 359.78222 FS_D0Q0S6 AXIS_D0Q0S6A0_F translation detector
-         FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835
-         0.0 0.0 detector_asic 359.78222 FS_D0Q0S6 AXIS_D0Q0S6A1_F translation
-         detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0
-         23.3541 9.829875 0.0 detector_sensor . . FS_D0Q0S7A0 rotation detector
-         FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
-         AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q0S7A0_S translation detector
-         AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q0S7A1 rotation
-         detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604
-         FS_D0Q0S7 AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q0S7A1_S translation
-         detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1
-         rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0
-         detector_quadrant . . FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0
-         -1.0 -23.1589875 -11.451825 0.0 detector_sensor . . FS_D0Q1S0A0
-         rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic
-         0.27238 FS_D0Q1S0 AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0
-         0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S0A0_S
-         translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0
-         detector_asic 0.27238 FS_D0Q1S0 AXIS_D0Q1S0A1_F translation detector
-         FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0
-         -23.2073875 -34.782825 0.0 detector_sensor . . FS_D0Q1S1A0 rotation
-         detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic
-         0.00525999986641 FS_D0Q1S1 AXIS_D0Q1S1A0_F translation detector
-         FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835
-         0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1 AXIS_D0Q1S1A1_F
-         translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S2 rotation detector FS_D0Q1
-         0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . . FS_D0Q1S2A0
-         rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic
-         270.02545 FS_D0Q1S2 AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S2A0_S
-         translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0
-         detector_asic 270.02545 FS_D0Q1S2 AXIS_D0Q1S2A1_F translation detector
-         FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0
-         -34.1402875 23.344475 0.0 detector_sensor . . FS_D0Q1S3A0 rotation
-         detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066
-         FS_D0Q1S3 AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S3A0_S translation
-         detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S3A1
-         rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic
-         270.03066 FS_D0Q1S3 AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S3A1_S
-         translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275
-         0.0 detector_sensor . . FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1
-         -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4 AXIS_D0Q1S4A0_F
-         translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S4A1 rotation detector
-         FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
-         AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q1S4A1_S translation detector
-         AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S5 rotation
-         detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor
-         . . FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0
-         detector_asic 180.02434 FS_D0Q1S5 AXIS_D0Q1S5A0_F translation detector
-         FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835
-         0.0 0.0 detector_asic 180.02434 FS_D0Q1S5 AXIS_D0Q1S5A1_F translation
-         detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0
-         33.2523125 -23.321925 0.0 detector_sensor . . FS_D0Q1S6A0 rotation
-         detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027
-         FS_D0Q1S6 AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S6A0_S translation
-         detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S6A1
-         rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic
-         270.08027 FS_D0Q1S6 AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q1S6A1_S
-         translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225
-         0.0 detector_sensor . . FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1
-         -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7 AXIS_D0Q1S7A0_F
-         translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q1S7A1 rotation detector
-         FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
-         AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q1S7A1_S translation detector
-         AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2 rotation
-         detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0
-         detector_quadrant . . FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0
-         -1.0 -11.3150125 23.1242 0.0 detector_sensor . . FS_D0Q2S0A0 rotation
-         detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803
-         FS_D0Q2S0 AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S0A0_S translation
-         detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S0A1
-         rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic
-         90.04803 FS_D0Q2S0 AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S0A1_S
-         translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155
-         0.0 detector_sensor . . FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1
-         -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1 AXIS_D0Q2S1A0_F
-         translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S1A1 rotation detector
-         FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
-         AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q2S1A1_S translation detector
-         AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S2 rotation
-         detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor .
-         . FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0
-         detector_asic 180.11318 FS_D0Q2S2 AXIS_D0Q2S2A0_F translation detector
-         FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835
-         0.0 0.0 detector_asic 180.11318 FS_D0Q2S2 AXIS_D0Q2S2A1_F translation
-         detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0
-         23.6220875 34.2221 0.0 detector_sensor . . FS_D0Q2S3A0 rotation
-         detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104
-         FS_D0Q2S3 AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S3A0_S translation
-         detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S3A1
-         rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic
-         179.92104 FS_D0Q2S3 AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S3A1_S
-         translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954
-         0.0 detector_sensor . . FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1
-         -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4 AXIS_D0Q2S4A0_F
-         translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S4A1 rotation detector
-         FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
-         AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q2S4A1_S translation detector
-         AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S5 rotation
-         detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor .
-         . FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0
-         detector_asic 89.68154 FS_D0Q2S5 AXIS_D0Q2S5A0_F translation detector
-         FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835
-         0.0 0.0 detector_asic 89.68154 FS_D0Q2S5 AXIS_D0Q2S5A1_F translation
-         detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
-         AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0
-         detector_asic . . FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0
-         -23.4854125 -33.2552 0.0 detector_sensor . . FS_D0Q2S6A0 rotation
-         detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473
-         FS_D0Q2S6 AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S6A0_S translation
-         detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S6A1
-         rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic
-         179.83473 FS_D0Q2S6 AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q2S6A1_S
-         translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417
-         0.0 detector_sensor . . FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1
-         -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7 AXIS_D0Q2S7A0_F
-         translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q2S7A1 rotation detector
-         FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
-         AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q2S7A1_S translation detector
-         AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3 rotation
-         detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0
-         detector_quadrant . . FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0
-         23.1056375 11.6367625 0.0 detector_sensor . . FS_D0Q3S0A0 rotation
-         detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436
-         FS_D0Q3S0 AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0
-         -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q3S0A0_S translation
-         detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S0A1
-         rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic
-         180.12436 FS_D0Q3S0 AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1
-         0 0 -10.615000 10.120000 0.0 detector_asic . . AXIS_D0Q3S0A1_S
-         translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
-         FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625
-         0.0 detector_sensor . . FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1
-         -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1 AXIS_D0Q3S1A0_F
-         translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S1A1 rotation detector
-         FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
-         AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S1A1_S translation detector
-         AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S2 rotation
-         detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0
-         detector_sensor . . FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1
-         -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2 AXIS_D0Q3S2A0_F
-         translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S2A1 rotation detector
-         FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
-         AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S2A1_S translation detector
-         AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S3 rotation
-         detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0
-         detector_sensor . . FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1
-         -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3 AXIS_D0Q3S3A0_F
-         translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S3A1 rotation detector
-         FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
-         AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S3A1_S translation detector
-         AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S4 rotation
-         detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0
-         detector_sensor . . FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1
-         -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4 AXIS_D0Q3S4A0_F
-         translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S4A1 rotation detector
-         FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
-         AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S4A1_S translation detector
-         AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S5 rotation
-         detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0
-         detector_sensor . . FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1
-         -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5 AXIS_D0Q3S5A0_F
-         translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S5A1 rotation detector
-         FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
-         AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S5A1_S translation detector
-         AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S6 rotation
-         detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0
-         detector_sensor . . FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1
-         -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6 AXIS_D0Q3S6A0_F
-         translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S6A1 rotation detector
-         FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
-         AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S6A1_S translation detector
-         AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S7 rotation
-         detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0
-         detector_sensor . . FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1
-         -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7 AXIS_D0Q3S7A0_F
-         translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0
-         detector_asic . . AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F
-         0 -1 0 0 0 0.0 detector_asic . . FS_D0Q3S7A1 rotation detector
-         FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
-         AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000
-         10.120000 0.0 detector_asic . . AXIS_D0Q3S7A1_S translation detector
-         AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    -->
+
+{     /entry:NXentry
+        /instrument:NXinstrument
+         /DETECTORELEMENTNAME:NXdetector
+for AXISEQUIPMENT=="detector"}
+{     /entry:NXentry
+        /sample:NXsample
+for AXISEQUIPMENT=="goniometer"}
+{     /entry:NXentry
+for AXISEQUIPMENT=="general"}
+          /transformations:NXtransformations
+            /AXISID=[]
+              @units="mm"  if AXISTYPE=="translation" 
+              or @units="degrees"  if AXISTYPE=="rotation"
+              @transformation_type="AXISTYPE"
+              @equipment_component="AXISEQUIPCOMP"
+              @depends_on="AXISDEPENDSON"
+              @rotation_axis="AXISROTAXIS"
+              @rotation=AXISROTATION
+              @rotation_units="degrees"
+              @offset=offsetxform([O1,O2,O3])
+              @offset_inits="mm"
+              @vector=coordxform([V1,V2,V3])
 ;
-;
-            Example 5.
 
-         This example shows an excerpt from the axis specification of an FEL
-         detector provided by N. Sauter and A. Brewster.
-
-         The detector is divided into 4 quadrants, each quadrant contains 8
-         sensors and each sensor contains 2 ASICs.  We want to be able to
-         refine the placement of each of these elements, so we maintain the set
-         of vectors that places them.
-;
-;
-          loop_
-         _diffrn_detector_axis.detector_id
-         _diffrn_detector_axis.axis_id
-         CSPAD_FRONT AXIS_DETECTOR_X
-         CSPAD_FRONT AXIS_DETECTOR_Y
-         CSPAD_FRONT AXIS_DETECTOR_Z
-         CSPAD_FRONT AXIS_DETECTOR_PITCH
-
-          loop_
-         _diffrn_detector_element.id
-         _diffrn_detector_element.detector_id
-         ELE_D0Q0S0A0 CSPAD_FRONT
-         ELE_D0Q0S0A1 CSPAD_FRONT
-         ELE_D0Q0S1A0 CSPAD_FRONT
-         ELE_D0Q0S1A1 CSPAD_FRONT
-         ELE_D0Q0S2A0 CSPAD_FRONT
-         ELE_D0Q0S2A1 CSPAD_FRONT
-         ELE_D0Q0S3A0 CSPAD_FRONT
-         ELE_D0Q0S3A1 CSPAD_FRONT
-         ELE_D0Q0S4A0 CSPAD_FRONT
-         ELE_D0Q0S4A1 CSPAD_FRONT
-         ELE_D0Q0S5A0 CSPAD_FRONT
-         ELE_D0Q0S5A1 CSPAD_FRONT
-         ELE_D0Q0S6A0 CSPAD_FRONT
-         ELE_D0Q0S6A1 CSPAD_FRONT
-         ELE_D0Q0S7A0 CSPAD_FRONT
-         ELE_D0Q0S7A1 CSPAD_FRONT
-         ELE_D0Q1S0A0 CSPAD_FRONT
-         ELE_D0Q1S0A1 CSPAD_FRONT
-         ELE_D0Q1S1A0 CSPAD_FRONT
-         ELE_D0Q1S1A1 CSPAD_FRONT
-         ELE_D0Q1S2A0 CSPAD_FRONT
-         ELE_D0Q1S2A1 CSPAD_FRONT
-         ELE_D0Q1S3A0 CSPAD_FRONT
-         ELE_D0Q1S3A1 CSPAD_FRONT
-         ELE_D0Q1S4A0 CSPAD_FRONT
-         ELE_D0Q1S4A1 CSPAD_FRONT
-         ELE_D0Q1S5A0 CSPAD_FRONT
-         ELE_D0Q1S5A1 CSPAD_FRONT
-         ELE_D0Q1S6A0 CSPAD_FRONT
-         ELE_D0Q1S6A1 CSPAD_FRONT
-         ELE_D0Q1S7A0 CSPAD_FRONT
-         ELE_D0Q1S7A1 CSPAD_FRONT
-         ELE_D0Q2S0A0 CSPAD_FRONT
-         ELE_D0Q2S0A1 CSPAD_FRONT
-         ELE_D0Q2S1A0 CSPAD_FRONT
-         ELE_D0Q2S1A1 CSPAD_FRONT
-         ELE_D0Q2S2A0 CSPAD_FRONT
-         ELE_D0Q2S2A1 CSPAD_FRONT
-         ELE_D0Q2S3A0 CSPAD_FRONT
-         ELE_D0Q2S3A1 CSPAD_FRONT
-         ELE_D0Q2S4A0 CSPAD_FRONT
-         ELE_D0Q2S4A1 CSPAD_FRONT
-         ELE_D0Q2S5A0 CSPAD_FRONT
-         ELE_D0Q2S5A1 CSPAD_FRONT
-         ELE_D0Q2S6A0 CSPAD_FRONT
-         ELE_D0Q2S6A1 CSPAD_FRONT
-         ELE_D0Q2S7A0 CSPAD_FRONT
-         ELE_D0Q2S7A1 CSPAD_FRONT
-         ELE_D0Q3S0A0 CSPAD_FRONT
-         ELE_D0Q3S0A1 CSPAD_FRONT
-         ELE_D0Q3S1A0 CSPAD_FRONT
-         ELE_D0Q3S1A1 CSPAD_FRONT
-         ELE_D0Q3S2A0 CSPAD_FRONT
-         ELE_D0Q3S2A1 CSPAD_FRONT
-         ELE_D0Q3S3A0 CSPAD_FRONT
-         ELE_D0Q3S3A1 CSPAD_FRONT
-         ELE_D0Q3S4A0 CSPAD_FRONT
-         ELE_D0Q3S4A1 CSPAD_FRONT
-         ELE_D0Q3S5A0 CSPAD_FRONT
-         ELE_D0Q3S5A1 CSPAD_FRONT
-         ELE_D0Q3S6A0 CSPAD_FRONT
-         ELE_D0Q3S6A1 CSPAD_FRONT
-         ELE_D0Q3S7A0 CSPAD_FRONT
-         ELE_D0Q3S7A1 CSPAD_FRONT
-
-          loop_
-         _axis.id
-         _axis.type
-         _axis.equipment
-         _axis.depends_on
-         _axis.vector[1]
-         _axis.vector[2]
-         _axis.vector[3]
-         _axis.offset[1]
-         _axis.offset[2]
-         _axis.offset[3]
-         _axis.rotation
-         _axis.rotation_axis
-         AXIS_SOURCE general source   . 0 0 1 . . . . .
-         AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
-         AXIS_DETECTOR_Z translation detector
-                                      . 0 0 1 0 0 0 . .
-         AXIS_DETECTOR_Y translation detector
-                        AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
-         AXIS_DETECTOR_X translation detector
-                        AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
-         AXIS_DETECTOR_PITCH rotation detector
-                        AXIS_DETECTOR_X 0 1 0 0 0 0 . .
-         AXIS_DETECTOR_ROT rotation detector
-                    AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
-         AXIS_D0_ORIGIN translation detector
-                    AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
-         AXIS_D0_ROT rotation detector
-                         AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0 translation detector
-                         AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
-         AXIS_D0Q0_ROT rotation detector
-                                AXIS_D0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0 translation detector
-                                AXIS_D0 . . . -49.860765625 41.643353125 0.0
-                                           0.0 AXIS_D0Q0_ROT
-         AXIS_D0Q0S0_ROT rotation detector
-                               AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S0 translation detector
-                               AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
-                                           89.66181 AXIS_D0Q0S0_ROT
-         AXIS_D0Q0S0A0_ROT rotation detector
-                             AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S0A0 translation detector
-                             AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S0A0_ROT AXIS_D0Q0S0A0_F translation detector
-                           AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S0A0_S translation detector
-                           AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S0A1_ROT rotation detector
-                             AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S0A1 translation detector
-                             AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S0A1_ROT AXIS_D0Q0S0A1_F translation detector
-                           AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S0A1_S translation detector
-                           AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S1_ROT rotation detector
-                               AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S1 translation detector
-                               AXIS_D0Q0 . . . 34.815 -23.309825 0.0
-                                           90.00132 AXIS_D0Q0S1_ROT
-         AXIS_D0Q0S1A0_ROT rotation detector
-                             AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S1A0 translation detector
-                             AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S1A0_ROT AXIS_D0Q0S1A0_F translation detector
-                           AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S1A0_S translation detector
-                           AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S1A1_ROT rotation detector
-                             AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S1A1 translation detector
-                             AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S1A1_ROT AXIS_D0Q0S1A1_F translation detector
-                           AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S1A1_S translation detector
-                           AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S2_ROT rotation detector
-                               AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q0S2 translation detector
-                               AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
-                                          359.68548 AXIS_D0Q0S2_ROT
-         AXIS_D0Q0S2A0_ROT rotation detector
-                             AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S2A0 translation detector
-                             AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S2A0_ROT AXIS_D0Q0S2A0_F translation detector
-                             AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S2A0_S translation detector
-                             AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S2A1_ROT rotation detector
-                             AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S2A1 translation detector
-                             AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S2A1_ROT AXIS_D0Q0S2A1_F translation detector
-                             AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S2A1_S translation detector
-                             AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S3_ROT rotation detector
-                             AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S3 translation detector
-                             AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
-                                        359.96513 AXIS_D0Q0S3_ROT
-         AXIS_D0Q0S3A0_ROT rotation detector
-                             AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S3A0 translation detector
-                             AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S3A0_ROT AXIS_D0Q0S3A0_F translation detector
-                             AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S3A0_S translation detector
-                             AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S3A1_ROT rotation detector
-                             AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S3A1 translation detector
-                             AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S3A1_ROT AXIS_D0Q0S3A1_F translation detector
-                             AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S3A1_S translation detector
-                             AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S4_ROT rotation detector
-                             AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S4 translation detector
-                             AXIS_D0Q0 . . . -11.2651 24.282775 0.0
-                                        270.14738 AXIS_D0Q0S4_ROT
-         AXIS_D0Q0S4A0_ROT rotation detector
-                             AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S4A0 translation detector
-                             AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S4A0_ROT AXIS_D0Q0S4A0_F translation detector
-                             AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S4A0_S translation detector
-                             AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S4A1_ROT rotation detector
-                             AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S4A1 translation detector
-                             AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S4A1_ROT AXIS_D0Q0S4A1_F translation detector
-                             AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S4A1_S translation detector
-                             AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S5_ROT rotation detector
-                             AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S5 translation detector
-                             AXIS_D0Q0 . . . -34.7336 24.169475 0.0
-                                        270.07896 AXIS_D0Q0S5_ROT
-         AXIS_D0Q0S5A0_ROT rotation detector
-                             AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S5A0 translation detector
-                             AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S5A0_ROT AXIS_D0Q0S5A0_F translation detector
-                             AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S5A0_S translation detector
-                             AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S5A1_ROT rotation detector
-                             AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S5A1 translation detector
-                             AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S5A1_ROT AXIS_D0Q0S5A1_F translation detector
-                             AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S5A1_S translation detector
-                             AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S6_ROT rotation detector
-                             AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S6 translation detector
-                             AXIS_D0Q0 . . . 23.5488 33.320375 0.0
-                                        359.78222 AXIS_D0Q0S6_ROT
-         AXIS_D0Q0S6A0_ROT rotation detector
-                             AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S6A0 translation detector
-                             AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S6A0_ROT AXIS_D0Q0S6A0_F translation detector
-                             AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S6A0_S translation detector
-                             AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S6A1_ROT rotation detector
-                             AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S6A1 translation detector
-                             AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S6A1_ROT AXIS_D0Q0S6A1_F translation detector
-                             AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S6A1_S translation detector
-                             AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
-         AXIS_D0Q0S7_ROT rotation detector
-                             AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q0S7 translation detector
-                             AXIS_D0Q0 . . . 23.3541 9.829875 0.0
-                                        359.89604 AXIS_D0Q0S7_ROT
-         AXIS_D0Q0S7A0_ROT rotation detector
-                             AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S7A0 translation detector
-                             AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q0S7A0_ROT AXIS_D0Q0S7A0_F translation detector
-                             AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
-         AXIS_D0Q0S7A0_S translation detector
-                             AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
-         AXIS_D0Q0S7A1_ROT rotation detector
-                             AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q0S7A1 translation detector
-                             AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q0S7A1_ROT AXIS_D0Q0S7A1_F translation detector
-                             AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
-         AXIS_D0Q0S7A1_S translation detector
-                             AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1_ROT rotation detector
-                             AXIS_D0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1 translation detector
-                             AXIS_D0 . . . 41.512521875 50.149653125 0.0
-                                        0.0 AXIS_D0Q1_ROT
-         AXIS_D0Q1S0_ROT rotation detector
-                             AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q1S0 translation detector
-                             AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
-                                          0.27238 AXIS_D0Q1S0_ROT
-         AXIS_D0Q1S0A0_ROT rotation detector
-                             AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S0A0 translation detector
-                             AXIS_D0Q1S0 . . . -10.835 0.0 0.0
-                                            0.0 AXIS_D0Q1S0A0_ROT
-         AXIS_D0Q1S0A0_F translation detector
-                             AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S0A0_S translation detector
-                             AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S0A1_ROT rotation detector
-                             AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S0A1 translation detector
-                             AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S0A1_ROT AXIS_D0Q1S0A1_F translation detector
-                             AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S0A1_S translation detector
-                             AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S1_ROT rotation detector
-                             AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q1S1 translation detector
-                             AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
-                                          0.00525999986641 AXIS_D0Q1S1_ROT
-         AXIS_D0Q1S1A0_ROT rotation detector
-                             AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S1A0 translation detector
-                             AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S1A0_ROT AXIS_D0Q1S1A0_F translation detector
-                             AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S1A0_S translation detector
-                             AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S1A1_ROT rotation detector
-                             AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S1A1 translation detector
-                             AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S1A1_ROT AXIS_D0Q1S1A1_F translation detector
-                             AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S1A1_S translation detector
-                             AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S2_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S2 translation detector
-                             AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
-                                        270.02545 AXIS_D0Q1S2_ROT
-         AXIS_D0Q1S2A0_ROT rotation detector
-                             AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S2A0 translation detector
-                             AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S2A0_ROT AXIS_D0Q1S2A0_F translation detector
-                             AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S2A0_S translation detector
-                             AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S2A1_ROT rotation detector
-                             AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S2A1 translation detector
-                             AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S2A1_ROT AXIS_D0Q1S2A1_F translation detector
-                             AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S2A1_S translation detector
-                             AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S3_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S3 translation detector
-                             AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
-                                        270.03066 AXIS_D0Q1S3_ROT
-         AXIS_D0Q1S3A0_ROT rotation detector
-                             AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S3A0 translation detector
-                             AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S3A0_ROT AXIS_D0Q1S3A0_F translation detector
-                             AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S3A0_S translation detector
-                             AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S3A1_ROT rotation detector
-                             AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S3A1 translation detector
-                             AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S3A1_ROT AXIS_D0Q1S3A1_F translation detector
-                             AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S3A1_S translation detector
-                             AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S4_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S4 translation detector
-                             AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
-                                         179.96381 AXIS_D0Q1S4_ROT
-         AXIS_D0Q1S4A0_ROT rotation detector
-                             AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S4A0 translation detector
-                             AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S4A0_ROT AXIS_D0Q1S4A0_F translation detector
-                             AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S4A0_S translation detector
-                             AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S4A1_ROT rotation detector
-                             AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S4A1 translation detector
-                             AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S4A1_ROT AXIS_D0Q1S4A1_F translation detector
-                             AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S4A1_S translation detector
-                             AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S5_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S5 translation detector
-                             AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
-                                        180.02434 AXIS_D0Q1S5_ROT
-         AXIS_D0Q1S5A0_ROT rotation detector
-                             AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S5A0 translation detector
-                             AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S5A0_ROT AXIS_D0Q1S5A0_F translation detector
-                             AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S5A0_S translation detector
-                             AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S5A1_ROT rotation detector
-                             AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S5A1 translation detector
-                             AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S5A1_ROT AXIS_D0Q1S5A1_F translation detector
-                             AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S5A1_S translation detector
-                             AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S6_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S6 translation detector
-                             AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
-                                        270.08027 AXIS_D0Q1S6_ROT
-         AXIS_D0Q1S6A0_ROT rotation detector
-                             AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S6A0 translation detector
-                             AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S6A0_ROT AXIS_D0Q1S6A0_F translation detector
-                             AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S6A0_S translation detector
-                             AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S6A1_ROT rotation detector
-                             AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S6A1 translation detector
-                             AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S6A1_ROT AXIS_D0Q1S6A1_F translation detector
-                             AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S6A1_S translation detector
-                             AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
-         AXIS_D0Q1S7_ROT rotation detector
-                             AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q1S7 translation detector
-                             AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
-                                        270.15067 AXIS_D0Q1S7_ROT
-         AXIS_D0Q1S7A0_ROT rotation detector
-                             AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S7A0 translation detector
-                             AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q1S7A0_ROT AXIS_D0Q1S7A0_F translation detector
-                             AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
-         AXIS_D0Q1S7A0_S translation detector
-                             AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
-         AXIS_D0Q1S7A1_ROT rotation detector
-                             AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q1S7A1 translation detector
-                             AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q1S7A1_ROT AXIS_D0Q1S7A1_F translation detector
-                             AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
-         AXIS_D0Q1S7A1_S translation detector
-                             AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2_ROT rotation detector
-                             AXIS_D0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2 translation detector
-                             AXIS_D0 . . . 49.596146875 -41.351371875 0.0
-                                        0.0 AXIS_D0Q2_ROT
-         AXIS_D0Q2S0_ROT rotation detector
-                             AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q2S0 translation detector
-                             AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
-                                         90.04803 AXIS_D0Q2S0_ROT
-         AXIS_D0Q2S0A0_ROT rotation detector
-                             AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S0A0 translation detector
-                             AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q2S0A0_ROT AXIS_D0Q2S0A0_F translation detector
-                             AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S0A0_S translation detector
-                             AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S0A1_ROT rotation detector
-                             AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S0A1 translation detector
-                             AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S0A1_ROT AXIS_D0Q2S0A1_F translation detector
-                             AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S0A1_S translation detector
-                             AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S1_ROT rotation detector
-                             AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q2S1 translation detector
-                             AXIS_D0Q2 . . . -34.6999125 23.155 0.0
-                                         90.00592 AXIS_D0Q2S1_ROT
-         AXIS_D0Q2S1A0_ROT rotation detector
-                             AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S1A0 translation detector
-                             AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q2S1A0_ROT AXIS_D0Q2S1A0_F translation detector
-                             AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S1A0_S translation detector
-                             AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S1A1_ROT rotation detector
-                             AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S1A1 translation detector
-                             AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S1A1_ROT AXIS_D0Q2S1A1_F translation detector
-                             AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S1A1_S translation detector
-                             AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S2_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S2 translation detector
-                             AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
-                                         180.11318 AXIS_D0Q2S2_ROT
-         AXIS_D0Q2S2A0_ROT rotation detector
-                             AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S2A0 translation detector
-                             AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q2S2A0_ROT AXIS_D0Q2S2A0_F translation detector
-                             AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S2A0_S translation detector
-                             AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S2A1_ROT rotation detector
-                             AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S2A1 translation detector
-                             AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S2A1_ROT AXIS_D0Q2S2A1_F translation detector
-                             AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S2A1_S translation detector
-                             AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S3_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S3 translation detector
-                             AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
-                                        179.92104 AXIS_D0Q2S3_ROT
-         AXIS_D0Q2S3A0_ROT rotation detector
-                             AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S3A0 translation detector
-                             AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q2S3A0_ROT AXIS_D0Q2S3A0_F translation detector
-                             AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S3A0_S translation detector
-                             AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S3A1_ROT rotation detector
-                             AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S3A1 translation detector
-                             AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S3A1_ROT AXIS_D0Q2S3A1_F translation detector
-                             AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S3A1_S translation detector
-                             AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S4_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S4 translation detector
-                             AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
-                                           89.63875 AXIS_D0Q2S4_ROT
-         AXIS_D0Q2S4A0_ROT rotation detector
-                             AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S4A0 translation detector
-                             AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q2S4A0_ROT AXIS_D0Q2S4A0_F translation detector
-                             AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S4A0_S translation detector
-                             AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S4A1_ROT rotation detector
-                             AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S4A1 translation detector
-                             AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S4A1_ROT AXIS_D0Q2S4A1_F translation detector
-                             AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S4A1_S translation detector
-                             AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S5_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S5 translation detector
-                             AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
-                                         89.68154 AXIS_D0Q2S5_ROT
-         AXIS_D0Q2S5A0_ROT rotation detector
-                             AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S5A0 translation detector
-                             AXIS_D0Q2S5 . . . -10.835 0.0 0.0
-                                            0.0 AXIS_D0Q2S5A0_ROT
-         AXIS_D0Q2S5A0_F translation detector
-                             AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S5A0_S translation detector
-                             AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S5A1_ROT rotation detector
-                             AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S5A1 translation detector
-                             AXIS_D0Q2S5 . . . 10.835 0.0 0.0
-                                            0.0 AXIS_D0Q2S5A1_ROT
-         AXIS_D0Q2S5A1_F translation detector
-                             AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S5A1_S translation detector
-                             AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S6_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S6 translation detector
-                             AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
-                                        179.83473 AXIS_D0Q2S6_ROT
-         AXIS_D0Q2S6A0_ROT rotation detector
-                             AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S6A0 translation detector
-                             AXIS_D0Q2S6 . . . -10.835 0.0 0.0
-                                            0.0 AXIS_D0Q2S6A0_ROT
-         AXIS_D0Q2S6A0_F translation detector
-                             AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S6A0_S translation detector
-                             AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S6A1_ROT rotation detector
-                             AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S6A1 translation detector
-                             AXIS_D0Q2S6 . . . 10.835 0.0 0.0
-                                            0.0 AXIS_D0Q2S6A1_ROT
-         AXIS_D0Q2S6A1_F translation detector
-                             AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S6A1_S translation detector
-                             AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
-         AXIS_D0Q2S7_ROT rotation detector
-                             AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q2S7 translation detector
-                             AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
-                                        180.092 AXIS_D0Q2S7_ROT
-         AXIS_D0Q2S7A0_ROT rotation detector
-                             AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S7A0 translation detector
-                             AXIS_D0Q2S7 . . . -10.835 0.0 0.0
-                                            0.0 AXIS_D0Q2S7A0_ROT
-         AXIS_D0Q2S7A0_F translation detector
-                             AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
-         AXIS_D0Q2S7A0_S translation detector
-                             AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
-         AXIS_D0Q2S7A1_ROT rotation detector
-                             AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q2S7A1 translation detector
-                             AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q2S7A1_ROT AXIS_D0Q2S7A1_F translation detector
-                             AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
-         AXIS_D0Q2S7A1_S translation detector
-                             AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3_ROT rotation detector
-                             AXIS_D0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3 translation detector
-                             AXIS_D0 . . . -41.247903125 -50.441634375 0.0
-                                        0.0 AXIS_D0Q3_ROT
-         AXIS_D0Q3S0_ROT rotation detector
-                             AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q3S0 translation detector
-                             AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
-                                        180.12436 AXIS_D0Q3S0_ROT
-         AXIS_D0Q3S0A0_ROT rotation detector
-                             AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S0A0 translation detector
-                             AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S0A0_ROT AXIS_D0Q3S0A0_F translation detector
-                             AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S0A0_S translation detector
-                             AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S0A1_ROT rotation detector
-                             AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S0A1 translation detector
-                             AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S0A1_ROT AXIS_D0Q3S0A1_F translation detector
-                             AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S0A1_S translation detector
-                             AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S1_ROT rotation detector
-                             AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q3S1 translation detector
-                             AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
-                                        180.00263 AXIS_D0Q3S1_ROT
-         AXIS_D0Q3S1A0_ROT rotation detector
-                             AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S1A0 translation detector
-                             AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S1A0_ROT AXIS_D0Q3S1A0_F translation detector
-                             AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S1A0_S translation detector
-                             AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S1A1_ROT rotation detector
-                             AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S1A1 translation detector
-                             AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S1A1_ROT AXIS_D0Q3S1A1_F translation detector
-                             AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S1A1_S translation detector
-                             AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S2_ROT rotation detector
-                             AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q3S2 translation detector
-                             AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
-                                        269.55191 AXIS_D0Q3S2_ROT
-         AXIS_D0Q3S2A0_ROT rotation detector
-                             AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S2A0 translation detector
-                             AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S2A0_ROT AXIS_D0Q3S2A0_F translation detector
-                             AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S2A0_S translation detector
-                             AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S2A1_ROT rotation detector
-                             AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S2A1 translation detector
-                             AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S2A1_ROT AXIS_D0Q3S2A1_F translation detector
-                             AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S2A1_S translation detector
-                             AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S3_ROT rotation detector
-                             AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q3S3 translation detector
-                             AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
-                                        269.74206 AXIS_D0Q3S3_ROT
-         AXIS_D0Q3S3A0_ROT rotation detector
-                             AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S3A0 translation detector
-                             AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S3A0_ROT AXIS_D0Q3S3A0_F translation detector
-                             AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S3A0_S translation detector
-                             AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S3A1_ROT rotation detector
-                             AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S3A1 translation detector
-                             AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S3A1_ROT AXIS_D0Q3S3A1_F translation detector
-                             AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S3A1_S translation detector
-                             AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S4_ROT rotation detector
-                             AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q3S4 translation detector
-                             AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
-                                        359.81971 AXIS_D0Q3S4_ROT
-         AXIS_D0Q3S4A0_ROT rotation detector
-                             AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S4A0 translation detector
-                             AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S4A0_ROT AXIS_D0Q3S4A0_F translation detector
-                             AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S4A0_S translation detector
-                             AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S4A1_ROT rotation detector
-                             AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S4A1 translation detector
-                             AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S4A1_ROT AXIS_D0Q3S4A1_F translation detector
-                             AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S4A1_S translation detector
-                             AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S5_ROT rotation detector
-                             AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
-         AXIS_D0Q3S5 translation detector
-                             AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
-                                        359.99883 AXIS_D0Q3S5_ROT
-         AXIS_D0Q3S5A0_ROT rotation detector
-                             AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S5A0 translation detector
-                             AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S5A0_ROT AXIS_D0Q3S5A0_F translation detector
-                             AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S5A0_S translation detector
-                             AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S5A1_ROT rotation detector
-                             AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S5A1 translation detector
-                             AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S5A1_ROT AXIS_D0Q3S5A1_F translation detector
-                             AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S5A1_S translation detector
-                             AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S6_ROT rotation detector
-                             AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q3S6 translation detector
-                             AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
-                                        269.67299 AXIS_D0Q3S6_ROT
-         AXIS_D0Q3S6A0_ROT rotation detector
-                             AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S6A0 translation detector
-                             AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S6A0_ROT AXIS_D0Q3S6A0_F translation detector
-                             AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S6A0_S translation detector
-                             AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S6A1_ROT rotation detector
-                             AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S6A1 translation detector
-                             AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S6A1_ROT AXIS_D0Q3S6A1_F translation detector
-                             AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S6A1_S translation detector
-                             AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
-         AXIS_D0Q3S7_ROT rotation detector
-                             AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
-         AXIS_D0Q3S7 translation detector
-                             AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
-                                        269.67561 AXIS_D0Q3S7_ROT
-         AXIS_D0Q3S7A0_ROT rotation detector
-                             AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S7A0 translation detector
-                             AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0
-         AXIS_D0Q3S7A0_ROT AXIS_D0Q3S7A0_F translation detector
-                             AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
-         AXIS_D0Q3S7A0_S translation detector
-                             AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
-         AXIS_D0Q3S7A1_ROT rotation detector
-                             AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
-         AXIS_D0Q3S7A1 translation detector
-                             AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0
-         AXIS_D0Q3S7A1_ROT AXIS_D0Q3S7A1_F translation detector
-                             AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
-         AXIS_D0Q3S7A1_S translation detector
-                             AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
-;
-;
-            Example 6.
-
-         This example shows an excerpt from the axis specification of an FEL
-         detector provided by N. Sauter and A. Brewster, using
-         _axis.rotation_axis and _axis.rotation to organize the positional
-         dependencies.  The approach in Example 5 is now preferred.
-
-         The detector is divided into 4 quadrants, each quadrant contains 8
-         sensors and each sensor contains 2 ASICs.  We want to be able to
-         refine the placement of each of these elements, so we maintain the set
-         of vectors that places them.
-
-         To do this, the first vector of importance is an initial placement axis
-         that moves from the origin along the Z axis a distance equal to the
-         detector distance.  This is the origin for the rest of the axes and is
-         called AXIS_D0_ORIGIN.
-
-         Each subsequent movement involves a frame shift.  This is done by using
-         two imgCIF axes: a rotation axis and a translation axis.  The rotation
-         axis is listed first, and includes no offset or angle.  The actual
-         frame shift is done by using a translation axis.  An offset is used
-         first in the parent's frame, and then an angle is listed to rotate
-         around the rotation axis.
-
-         Example, sensor five of quadrant 2.  First a rotation axis is listed:
-
-         AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
-         This defines a rotation axis around the z axis in the frame of
-         quadrant 2.
-
-         Next a translation axis is listed:
-         AXIS_D0Q2S5 translation detector
-             AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
-         Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
-         then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
-
-         And so forth.
-;
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         axis_group
+         diffrn_group
 
 save_
 
@@ -5294,14 +5859,13 @@ save_axis.depends_on
 
     _definition.id                '_axis.depends_on'
     _description.text
-;
-    The value of _axis.depends_on  specifies the next outermost
-      axis upon which this axis depends, unless
-      _axis.rotation_axis  is specified, in which case,
-      _axis.rotation_axis  is next outermost and
-      _axis.depends_on  is second outermost.
+;            The value of _axis.depends_on specifies the next outermost
+              axis upon which this axis depends, unless
+              _axis.rotation_axis is specified, in which case,
+              _axis.rotation_axis is next outermost and
+              _axis.depends_on is second outermost.
 
-      This item is a pointer to _axis.id  in the same category.
+              This item is a pointer to _axis.id in the same category.
 ;
     _name.category_id             axis
     _name.object_id               depends_on
@@ -5314,10 +5878,9 @@ save_axis.equipment
 
     _definition.id                '_axis.equipment'
     _description.text
-;
-    The value of  _axis.equipment  specifies the type of
-      equipment using the axis:  'goniometer', 'detector',
-     'gravity', 'source' or 'general'.
+;            The value of  _axis.equipment specifies the type of
+              equipment using the axis:  'goniometer', 'detector',
+             'gravity', 'source' or 'general'.
 ;
     _name.category_id             axis
     _name.object_id               equipment
@@ -5345,10 +5908,10 @@ save_axis.equipment_component
 
     _definition.id                '_axis.equipment_component'
     _description.text
-;
-    The value of  _axis.equipment_component  specifies
-      an arbitrary identifier of a component of the equipment to which
-      the axis belongs, such as 'detector_arm' or 'detector_module'.
+;            The value of  _axis.equipment_component specifies
+              an arbitrary identifier of a component of the equipment to which
+              the axis belongs, such as 'detector_arm' or 'detector_module'.
+
 ;
     _name.category_id             axis
     _name.object_id               equipment_component
@@ -5365,18 +5928,17 @@ save_axis.id
 
     _definition.id                '_axis.id'
     _description.text
-;
-    The value of _axis.id  must uniquely identify
-      each axis relevant to the experiment.  Note that multiple
-      pieces of equipment may share the same axis (e.g. a twotheta
-      arm), so the category key for AXIS  also includes the
-      equipment.
+;            The value of _axis.id must uniquely identify
+              each axis relevant to the experiment.  Note that multiple
+              pieces of equipment may share the same axis (e.g. a twotheta
+              arm), so the category key for AXIS also includes the
+              equipment.
 ;
     _name.category_id             axis
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -5387,11 +5949,10 @@ save_axis.offset[1]
 
     _definition.id                '_axis.offset[1]'
     _description.text
-;
-    The [1] element of the three-element vector used to specify
-      the offset to the base of a rotation or translation axis.
+;             The [1] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
 
-      The vector is specified in millimetres.
+               The vector is specified in millimetres.
 ;
     _name.category_id             axis
     _name.object_id               'offset[1]'
@@ -5404,6 +5965,7 @@ save_axis.offset[1]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
+    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5411,11 +5973,10 @@ save_axis.offset[2]
 
     _definition.id                '_axis.offset[2]'
     _description.text
-;
-    The [2] element of the three-element vector used to specify
-      the offset to the base of a rotation or translation axis.
+;             The [2] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
 
-      The vector is specified in millimetres.
+               The vector is specified in millimetres.
 ;
     _name.category_id             axis
     _name.object_id               'offset[2]'
@@ -5428,6 +5989,7 @@ save_axis.offset[2]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
+    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5435,11 +5997,10 @@ save_axis.offset[3]
 
     _definition.id                '_axis.offset[3]'
     _description.text
-;
-    The [3] element of the three-element vector used to specify
-      the offset to the base of a rotation or translation axis.
+;             The [3] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
 
-      The vector is specified in millimetres.
+               The vector is specified in millimetres.
 ;
     _name.category_id             axis
     _name.object_id               'offset[3]'
@@ -5452,6 +6013,7 @@ save_axis.offset[3]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
+    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5459,11 +6021,10 @@ save_axis.rotation
 
     _definition.id                '_axis.rotation'
     _description.text
-;
-    The value of _axis.rotation  specifies
-      the fixed base rotation angle for _axis.rotation_axis
-      to which the value of any frame-by-frame setting, if any, should
-      be added.  Normally, only the fixed value would be given.
+;            The value of _axis.rotation specifies
+              the fixed base rotation angle for _axis.rotation_axis
+              to which the value of any frame-by-frame setting, if any, should
+              be added.  Normally, only the fixed value would be given.
 ;
     _name.category_id             axis
     _name.object_id               rotation
@@ -5483,12 +6044,11 @@ save_axis.rotation_axis
 
     _definition.id                '_axis.rotation_axis'
     _description.text
-;
-    The value of _axis.rotation_axis  specifies
-      an optional additional dependency for this axis to be applied
-      after applying _axis.depends_on.
+;            The value of _axis.rotation_axis specifies
+              an optional additional dependency for this axis to be applied
+              after applying _axis.depends_on.
 
-      This item is a pointer to _axis.id  in the same category.
+              This item is a pointer to _axis.id in the same category.
 ;
     _name.category_id             axis
     _name.object_id               rotation_axis
@@ -5505,10 +6065,9 @@ save_axis.system
 
     _definition.id                '_axis.system'
     _description.text
-;
-    The value of  _axis.system  specifies the coordinate
-      system used to define the axis: 'laboratory', 'McStas', 'direct',
-     'orthogonal', 'reciprocal' or 'abstract'.
+;            The value of  _axis.system specifies the coordinate
+              system used to define the axis: 'laboratory', 'McStas', 'direct', 
+             'orthogonal', 'reciprocal' or 'abstract'.
 ;
     _name.category_id             axis
     _name.object_id               system
@@ -5557,10 +6116,9 @@ save_axis.type
 
     _definition.id                '_axis.type'
     _description.text
-;
-    The value of _axis.type  specifies the type of
-      axis:  'rotation' or 'translation' (or 'general' when
-      the type is not relevant, as for gravity).
+;            The value of _axis.type specifies the type of
+              axis:  'rotation' or 'translation' (or 'general' when
+              the type is not relevant, as for gravity).
 ;
     _name.category_id             axis
     _name.object_id               type
@@ -5586,15 +6144,14 @@ save_axis.variant
 
     _definition.id                '_axis.variant'
     _description.text
-;
-    The value of _axis.variant  gives the variant
-      to which the given AXIS row is related.
+;            The value of _axis.variant gives the variant
+              to which the given AXIS row is related.
 
-      If this value is not given, the variant is assumed to be
-      the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-      This item is a pointer to _variant.variant  in the
-      VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             axis
     _name.object_id               variant
@@ -5613,11 +6170,10 @@ save_axis.vector[1]
 
     _definition.id                '_axis.vector[1]'
     _description.text
-;
-    The [1] element of the three-element vector used to specify
-      the direction of a rotation or translation axis.
-      The vector should be normalized to be a unit vector and
-      is dimensionless.
+;             The [1] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
 ;
     _name.category_id             axis
     _name.object_id               'vector[1]'
@@ -5628,6 +6184,8 @@ save_axis.vector[1]
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5635,11 +6193,10 @@ save_axis.vector[2]
 
     _definition.id                '_axis.vector[2]'
     _description.text
-;
-    The [2] element of the three-element vector used to specify
-      the direction of a rotation or translation axis.
-      The vector should be normalized to be a unit vector and
-      is dimensionless.
+;             The [2] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
 ;
     _name.category_id             axis
     _name.object_id               'vector[2]'
@@ -5650,6 +6207,8 @@ save_axis.vector[2]
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
 
 save_
 
@@ -5657,11 +6216,10 @@ save_axis.vector[3]
 
     _definition.id                '_axis.vector[3]'
     _description.text
-;
-    The [3] element of the three-element vector used to specify
-      the direction of a rotation or translation axis.
-      The vector should be normalized to be a unit vector and
-      is dimensionless.
+;             The [3] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
 ;
     _name.category_id             axis
     _name.object_id               'vector[3]'
@@ -5672,27 +6230,76 @@ save_axis.vector[3]
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_DIFFRN
+
+    _definition.id                diffrn
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-04
+    _description.text
+;              Data items in the DIFFRN category record details about the
+               diffraction data and their measurement.
+
+               This is a stub category for the cif_img dicionary to
+               complete the tree for tags that are aliases for tags
+               in the various diffrn_... categories in the mmCIF/PDBx
+               dictionary
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn
+    _name.ddl2_mandatory          no
+    _category_key.name            '_diffrn.id'
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn.id
+
+    _definition.id                '_diffrn.id'
+    _alias.definition_id          '_diffrn.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           5.385
+    _alias.dictionary_uri         mmcif_pdbx.dic
+    _description.text
+;              This data item uniquely identifies a set of diffraction
+               data.
+;
+    _name.category_id             diffrn
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
 save_DIFFRN_DATA_FRAME
 
-    _definition.id                DIFFRN_DATA_FRAME
+    _definition.id                diffrn_data_frame
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
-;
-    Data items in the DIFFRN_DATA_FRAME  category record
-      the details about each frame of data.
+;            Data items in the DIFFRN_DATA_FRAME category record
+              the details about each frame of data.
 
-      The items in this category were previously in a
-      DIFFRN_FRAME_DATA category, which is now deprecated.
-      The items from the old category are provided
-      as aliases but should not be used for new work.
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_DATA_FRAME
+    _name.object_id               diffrn_data_frame
     _name.ddl2_mandatory          no
 
     loop_
@@ -5700,31 +6307,93 @@ save_DIFFRN_DATA_FRAME
          '_diffrn_data_frame.id'
          '_diffrn_data_frame.detector_element_id'
          '_diffrn_data_frame.variant'
-         '_diffrn_data_frame.diffrn_id'
 
     _description_example.case
-;
-    loop_
-    _diffrn_data_frame.id
-    _diffrn_data_frame.detector_element_id
-    _diffrn_data_frame.array_id
-    _diffrn_data_frame.binary_id
-    frame_1   d1_ccd_1  array_1  1
-    frame_1   d1_ccd_2  array_1  2
-    frame_1   d1_ccd_3  array_1  3
-    frame_1   d1_ccd_4  array_1  4
+;        loop_
+        _diffrn_data_frame.id
+        _diffrn_data_frame.detector_element_id
+        _diffrn_data_frame.array_id
+        _diffrn_data_frame.binary_id
+        frame_1   d1_ccd_1  array_1  1
+        frame_1   d1_ccd_2  array_1  2
+        frame_1   d1_ccd_3  array_1  3
+        frame_1   d1_ccd_4  array_1  4
 ;
     _description_example.detail
-;
-    Example 1. a frame containing data from four frame elements.
+;     Example 1. a frame containing data from four frame elements.
 
-                      Each frame element has a common array configuration
-                      'array_1' described in ARRAY_STRUCTURE  and related
-                      categories.  The data for each detector element are
-                      stored in four groups of binary data in the
-                      ARRAY_DATA  category, linked by the array_id and
-                      binary_id.
+                       Each frame element has a common array configuration
+                       'array_1' described in ARRAY_STRUCTURE and related
+                       categories.  The data for each detector element are
+                       stored in four groups of binary data in the
+                       ARRAY_DATA category, linked by the array_id and
+                       binary_id.
 ;
+    _nx_mapping.details
+;    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.array_section_id SECTIONID
+    _diffrn_data_frame.binary_id BINID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    /entry:NXentry
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_data_frame__section_id=[SECTIONIDARRAY]
+          /CBF_diffrn_data_frame__binary_id=[BINARYIDARRAY]
+          /CBF_diffrn_data_frame__center_fast_slow=[CENTERARRAY]
+            @units="UNITS"
+          /CBF_diffrn_data_frame__details=["DETAILSARRAY"]
+
+    inserts either ARRAYID (if SECTIONID is not specified or SECTIONID
+    into the element of SECTIONIDARRY for this frame and for this detector
+    element (see below);
+
+    inserts BINID
+    into the element of BINARYIDARRAY for this frame and for this detector
+    element (see below);
+
+    inserts CENF
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the fast centre (see below);
+
+    inserts CENS
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the slow centre (see below);
+
+    only one CENTERARRY unit is provided.  If there is variation, the values in
+    CENTERARRAY should be rescaled to uniform units.
+
+    _diffrn_data_frame.detector_element_id ELEMENTID -->
+    ELEMENTID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the fast index;
+
+    FRAMEID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the slow index
+    by matching FRAMEID against _diffrn_scan_frame.frame_id and using
+    _diffrn_scan_frame.frame_number from the same row.
+
+    inserts DETAILS
+    into the element of DETAILSARRAY for this frame and for this detector
+    element (see below); 
+
+    The arrays created in the mapping have a slow index of the number of frames
+    and a fast index of the number of detector elements.  There is a middle
+    index for CENTERARRAY in the order fast and then slow.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         diffrn_group
 
 save_
 
@@ -5732,11 +6401,12 @@ save_diffrn_data_frame.array_id
 
     _definition.id                '_diffrn_data_frame.array_id'
     _alias.definition_id          '_diffrn_frame_data.array_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-      ARRAY_STRUCTURE  category.
+;            This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               array_id
@@ -5754,9 +6424,8 @@ save_diffrn_data_frame.array_section_id
 
     _definition.id                '_diffrn_data_frame.array_section_id'
     _description.text
-;
-    This item is a pointer to _array_structure_list_section.id
-      in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;            This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               array_section_id
@@ -5774,11 +6443,12 @@ save_diffrn_data_frame.binary_id
 
     _definition.id                '_diffrn_data_frame.binary_id'
     _alias.definition_id          '_diffrn_frame_data.binary_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    This item is a pointer to _array_data.binary_id  in the
-      ARRAY_DATA  category.
+;            This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               binary_id
@@ -5789,6 +6459,7 @@ save_diffrn_data_frame.binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
+    _units.code                   none
 
 save_
 
@@ -5796,12 +6467,11 @@ save_diffrn_data_frame.center_derived
 
     _definition.id                '_diffrn_data_frame.center_derived'
     _description.text
-;
-    The value of _diffrn_data_frame.center_derived
-     is assumed to be 'yes', i.e. that values of
-     _diffrn_data_frame.center_fast  and
-     _diffrn_data_frame.center_slow
-     are derived from the axis settings rather than measured.
+;             The value of _diffrn_data_frame.center_derived
+              is assumed to be 'yes', i.e. that values of
+              _diffrn_data_frame.center_fast and
+              _diffrn_data_frame.center_slow 
+              are derived from the axis settings rather than measured.               
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_derived
@@ -5819,20 +6489,20 @@ save_diffrn_data_frame.center_fast
 
     _definition.id                '_diffrn_data_frame.center_fast'
     _description.text
-;
-    The value of _diffrn_data_frame.center_fast  is
-      the fast index axis beam centre position relative to the detector
-      element face in the units specified in the data item
-      _diffrn_data_frame.center_units  along the fast
-      axis of the detector from the centre of the first pixel to
-      the point at which the Z axis (which should be collinear with the
-      beam) intersects the face of the detector, if in fact it does.
-      At the time of the measurement the current settings of
-      the detector positioner for the given frame are used.
+;            The value of _diffrn_data_frame.center_fast is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
 
-      It is important to note that for measurements in mm,
-      the sense of the axis is used, rather than the sign of the
-      pixel-to-pixel increments.
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_fast
@@ -5842,6 +6512,7 @@ save_diffrn_data_frame.center_fast
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -5849,19 +6520,18 @@ save_diffrn_data_frame.center_slow
 
     _definition.id                '_diffrn_data_frame.center_slow'
     _description.text
-;
-    The value of _diffrn_data_frame.center_slow  is
-     the slow index axis beam centre position relative to the detector
-     element face in the units specified in the data item
-     _diffrn_data_frame.center_units  along the slow
-     axis of the detector from the centre of the first pixel to
-     the point at which the Z axis (which should be collinear with the
-     beam) intersects the face of the detector, if in fact it does.
-     At the time of the measurement the current settings of
-     the detector positioner for the given frame are used.
+;             The value of _diffrn_data_frame.center_slow is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units along the slow
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
 
-     It is important to note that the sense of the axis is used,
-     rather than the sign of the pixel-to-pixel increments.
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_slow
@@ -5871,6 +6541,7 @@ save_diffrn_data_frame.center_slow
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -5878,23 +6549,22 @@ save_diffrn_data_frame.center_units
 
     _definition.id                '_diffrn_data_frame.center_units'
     _description.text
-;
-    The value of _diffrn_data_frame.center_units
-     specifies the units in which the values of
-     _diffrn_data_frame.center_fast  and
-     _diffrn_data_frame.center_slow
-     are presented.  The default is 'mm' for millimetres.  The
-     alternatives are 'pixels' and 'bins'.  In all cases the
-     centre distances are measured from the centre of the
-     first pixel, i.e. in a 2x2 binning, the measuring origin
-     is offset from the centres of the bins by one half pixel
-     towards the first pixel.
+;             The value of _diffrn_data_frame.center_units
+              specifies the units in which the values of 
+              _diffrn_data_frame.center_fast and
+              _diffrn_data_frame.center_slow
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
 
-     If 'bins' is specified, the data in
-         _array_intensities.pixel_fast_bin_size,
-         _array_intensities.pixel_slow_bin_size, and
-         _array_intensities.pixel_binning_method
-     are used to define the binning scheme.
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               center_units
@@ -5918,23 +6588,24 @@ save_diffrn_data_frame.details
 
     _definition.id                '_diffrn_data_frame.details'
     _alias.definition_id          '_diffrn_frame_data.details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.4
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    The value of _diffrn_data_frame.details  should give a
-     description of special aspects of each frame of data.
+;             The value of _diffrn_data_frame.details should give a
+              description of special aspects of each frame of data.
 
-     This is an appropriate location in which to record
-     information from vendor headers as presented in those
-     headers, but it should never be used as a substitute
-     for providing the fully parsed information within
-     the appropriate imgCIF/CBF categories.
+              This is an appropriate location in which to record
+              information from vendor headers as presented in those
+              headers, but it should never be used as a substitute
+              for providing the fully parsed information within
+              the appropriate imgCIF/CBF categories.
 
-     Normally, when a conversion from a miniCBF has been done
-     the data from _array_data.header_convention
-     should be transferred to this data item and
-     _array_data.header_convention
-     should be removed.
+              Normally, when a conversion from a miniCBF has been done
+              the data from _array_data.header_convention
+              should be transferred to this data item and 
+              _array_data.header_convention
+              should be removed.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               details
@@ -5970,10 +6641,9 @@ save_diffrn_data_frame.details
     BEAM CENTRE = 157.5 157.5;
 ;
     _description_example.detail
-;
-    Example of header information extracted from an ADSC Quantum
-     315 detector header by CBFlib_0.7.6.  Image provided by Chris
-     Nielsen of ADSC from a data collection at SSRL beamline 1-5.
+;              Example of header information extracted from an ADSC Quantum
+               315 detector header by CBFlib_0.7.6.  Image provided by Chris
+               Nielsen of ADSC from a data collection at SSRL beamline 1-5.
 ;
 
 save_
@@ -5982,11 +6652,12 @@ save_diffrn_data_frame.detector_element_id
 
     _definition.id                '_diffrn_data_frame.detector_element_id'
     _alias.definition_id          '_diffrn_frame_data.detector_element_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    This item is a pointer to _diffrn_detector_element.id
-     in the DIFFRN_DETECTOR_ELEMENT  category.
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               detector_element_id
@@ -6003,19 +6674,19 @@ save_
 save_diffrn_data_frame.diffrn_id
 
     _definition.id                '_diffrn_data_frame.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This item is a pointer to '_diffrn.id'
+              in the DIFFRN category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -6023,17 +6694,18 @@ save_diffrn_data_frame.id
 
     _definition.id                '_diffrn_data_frame.id'
     _alias.definition_id          '_diffrn_frame_data.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    The value of _diffrn_data_frame.id  must uniquely identify
-     each complete frame of data.
+;             The value of _diffrn_data_frame.id must uniquely identify
+              each complete frame of data.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6044,15 +6716,14 @@ save_diffrn_data_frame.variant
 
     _definition.id                '_diffrn_data_frame.variant'
     _description.text
-;
-    The value of _diffrn_data_frame.variant  gives the variant
-     to which the given DIFFRN_DATA_FRAME row is related.
+;             The value of _diffrn_data_frame.variant gives the variant
+              to which the given DIFFRN_DATA_FRAME row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_data_frame
     _name.object_id               variant
@@ -6069,18 +6740,18 @@ save_
 
 save_DIFFRN_DETECTOR
 
-    _definition.id                DIFFRN_DETECTOR
+    _definition.id                diffrn_detector
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2022-05-27
+    _definition.update            2025-09-04
     _description.text
 ;
-    Data items in the DIFFRN_DETECTOR  category describe the
+    Data items in the DIFFRN_DETECTOR category describe the
      detector used to measure the scattered radiation, including
      any analyser and post-sample collimation.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_DETECTOR
+    _name.object_id               diffrn_detector
     _name.ddl2_mandatory          no
 
     loop_
@@ -6090,16 +6761,44 @@ save_DIFFRN_DETECTOR
          '_diffrn_detector.variant'
 
     _description_example.case
-;
-    _diffrn_detector.diffrn_id              'd1'
-    _diffrn_detector.detector               'multiwire'
-    _diffrn_detector.type                   'Siemens'
+;    _diffrn_detector.diffrn_id             'd1'
+    _diffrn_detector.detector              'multiwire'
+    _diffrn_detector.type                  'Siemens'
 ;
     _description_example.detail
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
 ;
-    Example 1. based on PDB entry 5HVP and laboratory records for the
-                 structure corresponding to PDB entry 5HVP.
+    _nx_mapping.details
+;    _diffrn_detector.diffrn_id DIFFRNID 
+    _diffrn_detector.id DETECTORNAME 
+    _diffrn_detector.details DETAILS
+    _diffrn_detector.detector DETECTOR
+    _diffrn_detector.dtime DTIME
+    _diffrn_detector.gain_setting GAINSETTING
+    _diffrn_detector.number_of_axes NAXES
+    _diffrn_detector.type DETTYPE
+
+    --> 
+
+      /entry:NXentry
+        /CBF_scan_id="SCANID"
+        /CBF_diffrn_id="DIFFRNID"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /details="DETAILS"
+              /type="DETECTOR"
+              /deadtime=DTIME
+              /number_of_axes=NAXES
+              /description="DETTYPE"
+              /gain_setting="GAINSETTING"
 ;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -6107,10 +6806,11 @@ save_diffrn_detector.details
 
     _definition.id                '_diffrn_detector.details'
     _alias.definition_id          '_diffrn_detector_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    A description of special aspects of the radiation detector.
+;             A description of special aspects of the radiation detector.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               details
@@ -6130,13 +6830,14 @@ save_diffrn_detector.detector
 
     loop_
       _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_radiation_detector'                              cifdic.c91
-         '_diffrn_detector'                                        cif_core.dic
+         '_diffrn_radiation_detector'        .        1.0        cifdic.c91
+         '_diffrn_detector'                  .        2.0        cif_core.dic
 
     _description.text
-;
-    The general class of the radiation detector.
+;             The general class of the radiation detector.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               detector
@@ -6160,15 +6861,15 @@ save_diffrn_detector.diffrn_id
 
     _definition.id                '_diffrn_detector.diffrn_id'
     _description.text
-;
-    This data item is a pointer to _diffrn.id  in the DIFFRN
-     category.
+;             This data item is a pointer to '_diffrn.id' in the DIFFRN
+              category.
 
-     The value of _diffrn.id  uniquely defines a set of
-     diffraction data.
+              The value of _diffrn.id uniquely defines a set of
+              diffraction data.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
     _type.purpose                 Key
     _type.source                  Assigned
@@ -6184,14 +6885,15 @@ save_diffrn_detector.dtime
 
     loop_
       _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_radiation_detector_dtime'                        cifdic.c91
-         '_diffrn_detector_dtime'                                  cif_core.dic
+         '_diffrn_radiation_detector_dtime'      .      1.0      cifdic.c91
+         '_diffrn_detector_dtime'                .      2.0      cif_core.dic
 
     _description.text
-;
-    The deadtime in microseconds of the detector(s) used to
-     measure the diffraction intensities.
+;             The deadtime in microseconds of the detector(s) used to
+              measure the diffraction intensities.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               dtime
@@ -6205,23 +6907,28 @@ save_diffrn_detector.dtime
     _enumeration.range            0.0:
     _units.code                   microseconds
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
 save_
 
 save_diffrn_detector.gain_setting
 
     _definition.id                '_diffrn_detector.gain_setting'
     _description.text
-;
-    The gain setting for detector.   This is a text string usually
-     reflecting a detector setting that may have a simple or very
-     complex relationship with the value of
-     _array_intensities.gain
-     and should not be used directly for computations without
-     further information.
+;             The gain setting for detector.   This is a text string usually
+              reflecting a detector setting that may have a simple or very
+              complex relationship with the value of
+              _array_intensities.gain
+              and should not be used directly for computations without
+              further information.
 
-     This tag is provided for completeness in recording the settings
-     of an experiment using a detector with a panel-switch, jumper
-     or control command that allows a choice of gain settings.
+              This tag is provided for completeness in recording the settings
+              of an experiment using a detector with a panel-switch, jumper
+              or control command that allows a choice of gain settings.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               gain_setting
@@ -6238,19 +6945,18 @@ save_diffrn_detector.id
 
     _definition.id                '_diffrn_detector.id'
     _description.text
-;
-    The value of _diffrn_detector.id  must uniquely identify
-     each detector used to collect each diffraction data set.
+;             The value of _diffrn_detector.id must uniquely identify
+              each detector used to collect each diffraction data set.
 
-     If the value of _diffrn_detector.id  is not given, it is
-     implicitly equal to the value of
-     _diffrn_detector.diffrn_id.
+              If the value of _diffrn_detector.id is not given, it is
+              implicitly equal to the value of
+              _diffrn_detector.diffrn_id.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6261,9 +6967,8 @@ save_diffrn_detector.layer_thickness
 
     _definition.id                '_diffrn_detector.layer_thickness'
     _description.text
-;
-    The thickness in mm of the sensing layer of the detector
-     for use in angular corrections.
+;             The thickness in mm of the sensing layer of the detector
+              for use in angular corrections.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               layer_thickness
@@ -6277,28 +6982,33 @@ save_diffrn_detector.layer_thickness
     _enumeration.range            0.0:
     _units.code                   millimetres
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
 save_
 
 save_diffrn_detector.number_of_axes
 
     _definition.id                '_diffrn_detector.number_of_axes'
     _description.text
-;
-    The value of _diffrn_detector.number_of_axes  gives the
-     number of axes of the positioner for the detector identified
-     by _diffrn_detector.id.
+;             The value of _diffrn_detector.number_of_axes gives the
+              number of axes of the positioner for the detector identified
+              by _diffrn_detector.id.
 
-     The word 'positioner' is a general term used in
-     instrumentation design for devices that are used to change
-     the positions of portions of apparatus by linear
-     translation, rotation or combinations of such motions.
+              The word 'positioner' is a general term used in
+              instrumentation design for devices that are used to change
+              the positions of portions of apparatus by linear
+              translation, rotation or combinations of such motions.
 
-     Axes which are used to provide a coordinate system for the
-     face of an area detector should not be counted for this
-     data item.
+              Axes which are used to provide a coordinate system for the
+              face of an area detector should not be counted for this
+              data item.
 
-     The description of each axis should be provided by entries
-     in DIFFRN_DETECTOR_AXIS.
+              The description of each axis should be provided by entries
+              in DIFFRN_DETECTOR_AXIS.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               number_of_axes
@@ -6309,6 +7019,13 @@ save_diffrn_detector.number_of_axes
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
 
 save_
 
@@ -6316,10 +7033,11 @@ save_diffrn_detector.type
 
     _definition.id                '_diffrn_detector.type'
     _alias.definition_id          '_diffrn_detector_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The make, model or name of the detector device used.
+;             The make, model or name of the detector device used.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               type
@@ -6336,15 +7054,14 @@ save_diffrn_detector.variant
 
     _definition.id                '_diffrn_detector.variant'
     _description.text
-;
-    The value of _diffrn_detector.variant  gives the variant
-     to which the given DIFFRN_DETECTOR row is related.
+;             The value of _diffrn_detector.variant gives the variant
+              to which the given DIFFRN_DETECTOR row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               variant
@@ -6361,17 +7078,16 @@ save_
 
 save_DIFFRN_DETECTOR_AXIS
 
-    _definition.id                DIFFRN_DETECTOR_AXIS
+    _definition.id                diffrn_detector_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_DETECTOR_AXIS  category associate
+    Data items in the DIFFRN_DETECTOR_AXIS category associate
      axes with detectors.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_DETECTOR_AXIS
+    _name.object_id               diffrn_detector_axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -6379,7 +7095,24 @@ save_DIFFRN_DETECTOR_AXIS
          '_diffrn_detector_axis.detector_id'
          '_diffrn_detector_axis.axis_id'
          '_diffrn_detector_axis.variant'
-         '_diffrn_detector_axis.diffrn_id'
+
+    _nx_mapping.details
+;    _diffrn_detector_axis.axis_id AXISID --> 
+    _diffrn_detector_axis.detector_id DETECTORNAME -->
+        /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+            /transformations:NXtransformations
+              /AXISID=[]
+
+This information normally will duplicate information obtained from 
+the ARRAY_STRUCTURE_LIST_AXIS.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -6387,9 +7120,8 @@ save_diffrn_detector_axis.axis_id
 
     _definition.id                '_diffrn_detector_axis.axis_id'
     _description.text
-;
-    This data item is a pointer to _axis.id  in
-      the AXIS category.
+;             This data item is a pointer to _axis.id in
+               the AXIS category.
 ;
     _name.category_id             diffrn_detector_axis
     _name.object_id               axis_id
@@ -6407,15 +7139,16 @@ save_diffrn_detector_axis.detector_id
 
     _definition.id                '_diffrn_detector_axis.detector_id'
     _alias.definition_id          '_diffrn_detector_axis.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    This data item is a pointer to _diffrn_detector.id  in
-     the DIFFRN_DETECTOR  category.
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
 
-     This item was previously named _diffrn_detector_axis.id
-     which is now a deprecated name.  The old name is
-     provided as an alias but should not be used for new work.
+              This item was previously named _diffrn_detector_axis.id
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
 ;
     _name.category_id             diffrn_detector_axis
     _name.object_id               detector_id
@@ -6432,19 +7165,19 @@ save_
 save_diffrn_detector_axis.diffrn_id
 
     _definition.id                '_diffrn_detector_axis.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -6452,11 +7185,10 @@ save_diffrn_detector_axis.id
 
     _definition.id                '_diffrn_detector_axis.id'
     _description.text
-;
-    This data item is a pointer to _diffrn_detector.id  in
-     the DIFFRN_DETECTOR  category.
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_detector_axis
     _name.object_id               id
@@ -6473,15 +7205,14 @@ save_diffrn_detector_axis.variant
 
     _definition.id                '_diffrn_detector_axis.variant'
     _description.text
-;
-    The value of _diffrn_detector_axis.variant  gives the variant
-     to which the given DIFFRN_DETECTOR_AXIS row is related.
+;            The value of _diffrn_detector_axis.variant gives the variant
+             to which the given DIFFRN_DETECTOR_AXIS row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+             If this value is not given, the variant is assumed to be
+             the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
 ;
     _name.category_id             diffrn_detector_axis
     _name.object_id               variant
@@ -6498,13 +7229,12 @@ save_
 
 save_DIFFRN_DETECTOR_ELEMENT
 
-    _definition.id                DIFFRN_DETECTOR_ELEMENT
+    _definition.id                diffrn_detector_element
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_DETECTOR_ELEMENT  category record
+    Data items in the DIFFRN_DETECTOR_ELEMENT category record
      the details about spatial layout and other characteristics
      of each element of a detector which may have multiple elements.
 
@@ -6514,7 +7244,7 @@ save_DIFFRN_DETECTOR_ELEMENT
      detector element.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_DETECTOR_ELEMENT
+    _name.object_id               diffrn_detector_element
     _name.ddl2_mandatory          no
 
     loop_
@@ -6522,38 +7252,69 @@ save_DIFFRN_DETECTOR_ELEMENT
          '_diffrn_detector_element.id'
          '_diffrn_detector_element.detector_id'
          '_diffrn_detector_element.variant'
-         '_diffrn_detector_element.diffrn_id'
 
     _description_example.case
-;
-    loop_
-    _diffrn_detector_element.detector_id
-    _diffrn_detector_element.id
-    _diffrn_detector_element.reference_center_fast
-    _diffrn_detector_element.reference_center_slow
-    _diffrn_detector_element.reference_center_units
-    d1     d1_ccd_1  201.5 201.5  mm
-    d1     d1_ccd_2  -1.8  201.5  mm
-    d1     d1_ccd_3  201.6  -1.4  mm
-    d1     d1_ccd_4  -1.7   -1.5  mm
+;        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        d1     d1_ccd_1  201.5 201.5  mm
+        d1     d1_ccd_2  -1.8  201.5  mm
+        d1     d1_ccd_3  201.6  -1.4  mm
+        d1     d1_ccd_4  -1.7   -1.5  mm
 ;
     _description_example.detail
-;
-    Example 1. Detector d1 is composed of four CCD detector elements,
-      each 200 mm by 200 mm, arranged in a square, in the pattern
+;      Example 1. Detector d1 is composed of four CCD detector elements,
+        each 200 mm by 200 mm, arranged in a square, in the pattern
 
-                 1     2
-                    *
-                 3     4
+                   1     2
+                      *
+                   3     4
 
-      Note that the beam centre is slightly displaced from each of the
-      detector elements, just beyond the lower right corner of 1,
-      the lower left corner of 2, the upper right corner of 3 and
-      the upper left corner of 4.  For each element, the detector
-      face coordinate system is assumed to have the fast axis
-      running from left to right and the slow axis running from
-      top to bottom with the origin at the top left corner.
+        Note that the beam centre is slightly displaced from each of the
+        detector elements, just beyond the lower right corner of 1,
+        the lower left corner of 2, the upper right corner of 3 and
+        the upper left corner of 4.  For each element, the detector
+        face coordinate system is assumed to have the fast axis
+        running from left to right and the slow axis running from
+        top to bottom with the origin at the top left corner.
 ;
+    _nx_mapping.details
+;    _diffrn_detector_element.id ELEMENTID
+    _diffrn_detector_element.detector_id DETECTORNAME
+    _diffrn_detector_element.reference_center_fast RCF
+    _diffrn_detector_element.reference_center_slow RCS
+    _diffrn_detector_element.reference_center_units UNITS
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /beam_center_x=[RCS]  (converted from UNITS as needed)
+            @units=mm
+          /beam_center_y=[RCF]  (converted from UNITS as needed)
+            @units=mm
+          /CBF_diffrn_detector_element__id="ELEMENTID1:ELEMENTID2:..."
+          /CBF_diffrn_detector_element__reference_center_fast=[RCF1,RCF2,...]
+          /CBF_diffrn_detector_element__reference_center_slow=[RCS1,RCS2,...]
+          /CBF_diffrn_detector_element__id="UNITS1:UNITS2:..."
+     inserts ELEMENTID into the colon-separated list of element IDs
+     inserts RCF into the array of reference centres
+     inserts RCS into the array of reference centres
+     inserts ELEMENTID into the colon-separated list of units
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         diffrn_group
 
 save_
 
@@ -6561,24 +7322,24 @@ save_diffrn_detector_element.center[1]
 
     _definition.id                '_diffrn_detector_element.center[1]'
     _description.text
-;
-    The value of _diffrn_detector_element.center[1] is the X
-     component of the distortion-corrected beam centre in
-     millimetres from the (0, 0) (lower-left) corner of the
-     detector element viewed from the sample side.
+;             The value of _diffrn_detector_element.center[1] is the X
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
 
-     The X and Y axes are the laboratory coordinate system
-     coordinates defined in the AXIS category  measured
-     when all positioning axes for the detector are at their zero
-     settings.  If the resulting X or Y axis is then orthogonal to the
-     detector, the Z axis is used instead of the orthogonal axis.
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
 
-     Because of ambiguity about the setting used to determine this
-     centre, use of this data item is deprecated.  The data item
-     _diffrn_data_frame.center_fast
-     which is referenced to the detector coordinate system and not
-     directly to the laboratory coordinate system should be used
-     instead.
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated.  The data item
+              _diffrn_data_frame.center_fast
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               'center[1]'
@@ -6591,6 +7352,9 @@ save_diffrn_detector_element.center[1]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+    _ddl2_item_related.related_name '_diffrn_data_frame.center_fast'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -6598,24 +7362,24 @@ save_diffrn_detector_element.center[2]
 
     _definition.id                '_diffrn_detector_element.center[2]'
     _description.text
-;
-    The value of _diffrn_detector_element.center[2] is the Y
-     component of the distortion-corrected beam centre in
-     millimetres from the (0, 0) (lower-left) corner of the
-     detector element viewed from the sample side.
+;             The value of _diffrn_detector_element.center[2] is the Y
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
 
-     The X and Y axes are the laboratory coordinate system
-     coordinates defined in the AXIS category  measured
-     when all positioning axes for the detector are at their zero
-     settings.  If the resulting X or Y axis is then orthogonal to the
-     detector, the Z axis is used instead of the orthogonal axis.
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
 
-     Because of ambiguity about the setting used to determine this
-     centre, use of this data item is deprecated. The data item
-     _diffrn_data_frame.center_slow
-     which is referenced to the detector coordinate system and not
-     directly to the laboratory coordinate system should be used
-     instead.
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated. The data item
+              _diffrn_data_frame.center_slow
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               'center[2]'
@@ -6628,6 +7392,9 @@ save_diffrn_detector_element.center[2]
     _type.ddl2_units              millimetres
     _enumeration.default          0.0
     _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+    _ddl2_item_related.related_name '_diffrn_data_frame.center_slow'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -6635,9 +7402,8 @@ save_diffrn_detector_element.detector_id
 
     _definition.id                '_diffrn_detector_element.detector_id'
     _description.text
-;
-    This item is a pointer to _diffrn_detector.id
-     in the DIFFRN_DETECTOR  category.
+;             This item is a pointer to _diffrn_detector.id
+              in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               detector_id
@@ -6653,19 +7419,19 @@ save_
 save_diffrn_detector_element.diffrn_id
 
     _definition.id                '_diffrn_detector_element.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This item is a pointer to _diffrn.id
+              in the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -6673,15 +7439,14 @@ save_diffrn_detector_element.id
 
     _definition.id                '_diffrn_detector_element.id'
     _description.text
-;
-    The value of _diffrn_detector_element.id  must uniquely
-     identify each element of a detector.
+;            The value of _diffrn_detector_element.id must uniquely
+             identify each element of a detector.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -6693,23 +7458,23 @@ save_diffrn_detector_element.reference_center_fast
     _definition.id
         '_diffrn_detector_element.reference_center_fast'
     _description.text
-;
-    The value of _diffrn_detector_element.reference_center_fast  is
-     the fast index axis beam centre position relative to the detector
-     element face in the units specified in the data item
-     _diffrn_detector_element.reference_center_units  along the fast
-     axis of the detector from the centre of the first pixel to
-     the point at which the Z-axis (which should be collinear with the
-     beam) intersects the face of the detector, if in fact it does.
-     At the time of the measurement all settings of the detector
-     positioner should be at their reference settings.  If more than
-     one reference setting has been used the value given should be
-     representative of the beam centre as determined from the ensemble
-     of settings.
+;             The value of _diffrn_detector_element.reference_center_fast is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the 
+              beam) intersects the face of the detector, if in fact it does.   
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than 
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble 
+              of settings.
 
-     It is important to note that for measurements in mm,
-     the sense of the axis is used, rather than the sign of the
-     pixel-to-pixel increments.
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_fast
@@ -6719,6 +7484,7 @@ save_diffrn_detector_element.reference_center_fast
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -6727,22 +7493,21 @@ save_diffrn_detector_element.reference_center_slow
     _definition.id
         '_diffrn_detector_element.reference_center_slow'
     _description.text
-;
-    The value of _diffrn_detector_element.reference_center_slow  is
-     the slow index axis beam centre position relative to the detector
-     element face in the units specified in the data item
-     _diffrn_detector_element.reference_center_units  along the slow
-     axis of the detector from the centre of the first pixel to
-     the point at which the Z-axis (which should be collinear with the
-     beam) intersects the face of the detector, if in fact it does.
-     At the time of the measurement all settings of the detector
-     positioner should be at their reference settings.  If more than
-     one reference setting has been used the value given should be
-     representative of the beam centre as determined from the ensemble
-     of settings.
+;             The value of _diffrn_detector_element.reference_center_slow is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units along the slow
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble
+              of settings.
 
-     It is important to note that the sense of the axis is used,
-     rather than the sign of the pixel-to-pixel increments.
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_slow
@@ -6752,6 +7517,7 @@ save_diffrn_detector_element.reference_center_slow
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -6760,23 +7526,22 @@ save_diffrn_detector_element.reference_center_units
     _definition.id
         '_diffrn_detector_element.reference_center_units'
     _description.text
-;
-    The value of _diffrn_detector_element.reference_center_units
-     specifies the units in which the values of
-     _diffrn_detector_element.reference_center_fast  and
-     _diffrn_detector_element.reference_center_slow
-     are presented.  The default is 'mm' for millimetres.  The
-     alternatives are 'pixels' and 'bins'.  In all cases the
-     centre distances are measured from the centre of the
-     first pixel, i.e. in a 2x2 binning, the measuring origin
-     is offset from the centres of the bins by one half pixel
-     towards the first pixel.
+;             The value of _diffrn_detector_element.reference_center_units
+              specifies the units in which the values of 
+              _diffrn_detector_element.reference_center_fast and
+              _diffrn_detector_element.reference_center_slow
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
 
-     If 'bins' is specified, the data in
-         _array_intensities.pixel_fast_bin_size,
-         _array_intensities.pixel_slow_bin_size, and
-         _array_intensities.pixel_binning_method
-     are used to define the binning scheme.
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               reference_center_units
@@ -6800,15 +7565,14 @@ save_diffrn_detector_element.variant
 
     _definition.id                '_diffrn_detector_element.variant'
     _description.text
-;
-    The value of _diffrn_detector_element.variant  gives the variant
-     to which the given DIFFRN_DETECTOR_ELEMENT row is related.
+;             The value of _diffrn_detector_element.variant gives the variant
+              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-      VARIANT  category.
+              This item is a pointer to _variant.variant in the
+               VARIANT category.
 ;
     _name.category_id             diffrn_detector_element
     _name.object_id               variant
@@ -6825,17 +7589,17 @@ save_
 
 save_DIFFRN_FRAME_DATA
 
-    _definition.id                DIFFRN_FRAME_DATA
+    _definition.id                diffrn_frame_data
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
+    _definition.update            2025-09-04
     _description.text
 ;
     Data items in the DIFFRN_FRAME_DATA category record
      the details about each frame of data.
 
      The items in this category are now in the
-     DIFFRN_DATA_FRAME  category.
+     DIFFRN_DATA_FRAME category.
 
      The items in the DIFFRN_FRAME_DATA category
      are now deprecated.  The items from this category
@@ -6854,7 +7618,7 @@ save_DIFFRN_FRAME_DATA
      All _item.mandatory_code values have been changed to 'no'.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_FRAME_DATA
+    _name.object_id               diffrn_frame_data
     _name.ddl2_mandatory          no
 
     loop_
@@ -6872,17 +7636,21 @@ save_DIFFRN_FRAME_DATA
     THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
 ;
 
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
 save_
 
 save_diffrn_frame_data.array_id
 
     _definition.id                '_diffrn_frame_data.array_id'
     _description.text
-;
-    This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE category.
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               array_id
@@ -6892,6 +7660,8 @@ save_diffrn_frame_data.array_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.array_id'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -6899,11 +7669,10 @@ save_diffrn_frame_data.binary_id
 
     _definition.id                '_diffrn_frame_data.binary_id'
     _description.text
-;
-    This item is a pointer to _array_data.binary_id  in the
-     ARRAY_STRUCTURE category.
+;             This item is a pointer to _array_data.binary_id in the
+              ARRAY_STRUCTURE category.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               binary_id
@@ -6913,6 +7682,9 @@ save_diffrn_frame_data.binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
+    _units.code                   none
+    _ddl2_item_related.related_name '_diffrn_data_frame.binary_id'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -6920,11 +7692,10 @@ save_diffrn_frame_data.details
 
     _definition.id                '_diffrn_frame_data.details'
     _description.text
-;
-    The value of _diffrn_frame_data.details  should give a
-     description of special aspects of each frame of data.
+;             The value of _diffrn_frame_data.details should give a
+              description of special aspects of each frame of data.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               details
@@ -6934,6 +7705,8 @@ save_diffrn_frame_data.details
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
+    _ddl2_item_related.related_name '_diffrn_data_frame.details'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -6941,11 +7714,10 @@ save_diffrn_frame_data.detector_element_id
 
     _definition.id                '_diffrn_frame_data.detector_element_id'
     _description.text
-;
-    This item is a pointer to _diffrn_detector_element.id
-     in the DIFFRN_DETECTOR_ELEMENT category.
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT category.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               detector_element_id
@@ -6955,17 +7727,19 @@ save_diffrn_frame_data.detector_element_id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.detector_element_id'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
 save_diffrn_frame_data.diffrn_id
 
     _definition.id                '_diffrn_frame_data.diffrn_id'
-    _definition.update            2022-05-27
+    _definition.update            2025-09-04
     _description.text
 ;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+    Identifier for data collection conditions. Values of this item are drawn
+    from values of _diffrn.id.
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               diffrn_id
@@ -6981,11 +7755,10 @@ save_diffrn_frame_data.id
 
     _definition.id                '_diffrn_frame_data.id'
     _description.text
-;
-    The value of _diffrn_frame_data.id  must uniquely identify
-     each complete frame of data.
+;             The value of _diffrn_frame_data.id must uniquely identify
+              each complete frame of data.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_frame_data
     _name.object_id               id
@@ -6995,24 +7768,26 @@ save_diffrn_frame_data.id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.id'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
 save_DIFFRN_MEASUREMENT
 
-    _definition.id                DIFFRN_MEASUREMENT
+    _definition.id                diffrn_measurement
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2022-05-27
+    _definition.update            2025-09-04
     _description.text
 ;
-    Data items in the DIFFRN_MEASUREMENT  category record details
+    Data items in the DIFFRN_MEASUREMENT category record details
      about the device used to orient and/or position the crystal
      during data measurement and the manner in which the
      diffraction data were measured.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_MEASUREMENT
+    _name.object_id               diffrn_measurement
     _name.ddl2_mandatory          no
 
     loop_
@@ -7026,29 +7801,68 @@ save_DIFFRN_MEASUREMENT
       _description_example.case
       _description_example.detail
 ;
-         _diffrn_measurement.diffrn_id           'd1'
-         _diffrn_measurement.device              '3-circle camera'
-         _diffrn_measurement.device_type        'Supper model X'
-         _diffrn_measurement.device_details      'none'
-         _diffrn_measurement.method              'omega scan'
-         _diffrn_measurement.details
-         ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm,
-           detector angle 22.5 degrees
-         ;
+    _diffrn_measurement.diffrn_id          'd1'
+    _diffrn_measurement.device             '3-circle camera'
+    _diffrn_measurement.device_type        'Supper model X'
+    _diffrn_measurement.device_details     'none'
+    _diffrn_measurement.method             'omega scan'
+    _diffrn_measurement.details
+    ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm, 
+      detector angle 22.5 degrees
+    ;
+;
+;    Example 1. based on PDB entry 5HVP and laboratory records for the
+                 structure corresponding to PDB entry 5HVP
 ;
 ;
-         Example 1. based on PDB entry 5HVP and laboratory records for the
-                      structure corresponding to PDB entry 5HVP
+    _diffrn_measurement.diffrn_id       's1'
+    _diffrn_measurement.device_type     'Philips PW1100/20 diffractometer'
+    _diffrn_measurement.method          'theta/2theta (\q/2\q)'
 ;
+;     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                  [Acta Cryst. (1991), C47, 2276-2277].
 ;
-         _diffrn_measurement.diffrn_id        's1'
-         _diffrn_measurement.device_type      'Philips PW1100/20 diffractometer'
-         _diffrn_measurement.method           'theta/2theta (\q/2\q)'
+
+    _nx_mapping.details
+;    _diffrn_measurement.diffrn_id DIFFRNID
+    _diffrn_measurement.details DETAILS
+    _diffrn_measurement.device DEVICE
+    _diffrn_measurement.device_details DEVDETAILS
+    _diffrn_measurement.device_type DEVTYPE
+    _diffrn_measurement.id GONIOMETER
+    _diffrn_measurement.method METHOD
+    _diffrn_measurement.number_of_axes NUMBER
+    _diffrn_measurement.sample_detector_distance DIST
+    _diffrn_measurement.sample_detector_distance_derived DISTDERIVED
+    _diffrn_measurement.sample_detector_voffset VOFST
+    _diffrn_measurement.specimen_support SPECSPRT
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+      /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+        /details="DETAILS"
+        /local_name="DEVICE"
+        /description="DEVDETAILS"
+        /type="DEVTYPE"
+        /CBF_diffrn_measurement__method="METHOD"
+          /number_of_axes=NUMBER
+        /CBF_diffrn_measurement__specimen_support="SPECSPRT"
+      /CBF_diffrn_detector__DETECTORNAME:NXdetector
+        /distance=DIST
+          @units="mm"
+        /distance_derived=DISTDERIVED
+        /CBF_diffrn_measurement__sample_detector_voffset=VOFST
+          @units="mm"    
 ;
-;
-         Example 2. based on data set TOZ of Willis, Beckwith & Tozer
-                      [Acta Cryst. (1991), C47, 2276-2277].
-;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -7056,11 +7870,12 @@ save_diffrn_measurement.details
 
     _definition.id                '_diffrn_measurement.details'
     _alias.definition_id          '_diffrn_measurement_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    A description of special aspects of the intensity
-     measurement.
+;             A description of special aspects of the intensity
+              measurement.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               details
@@ -7071,9 +7886,8 @@ save_diffrn_measurement.details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;
-    440 frames, 0.20 degrees, 150 sec, detector
-     distance 12 cm, detector angle 22.5 degrees
+;                                 440 frames, 0.20 degrees, 150 sec, detector
+                                  distance 12 cm, detector angle 22.5 degrees
 ;
 
 save_
@@ -7082,27 +7896,28 @@ save_diffrn_measurement.device
 
     _definition.id                '_diffrn_measurement.device'
     _alias.definition_id          '_diffrn_measurement_device'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The general class of goniometer or device used to support
-     and orient the specimen.
+;             The general class of goniometer or device used to support
+              and orient the specimen.
 
-     If the value of _diffrn_measurement.device  is not given,
-     it is implicitly equal to the value of
-     _diffrn_measurement.diffrn_id.
+              If the value of _diffrn_measurement.device is not given,
+              it is implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
 
-     Either _diffrn_measurement.device  or
-     _diffrn_measurement.id  may be used to link to other
-     categories.  If the experimental setup admits multiple
-     devices, then _diffrn_measurement.id  is used to provide
-     a unique link.
+              Either _diffrn_measurement.device or
+              _diffrn_measurement.id may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id is used to provide
+              a unique link.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
@@ -7121,11 +7936,12 @@ save_diffrn_measurement.device_details
 
     _definition.id                '_diffrn_measurement.device_details'
     _alias.definition_id          '_diffrn_measurement_device_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    A description of special aspects of the device used to
-     measure the diffraction intensities.
+;             A description of special aspects of the device used to
+              measure the diffraction intensities.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device_details
@@ -7136,9 +7952,8 @@ save_diffrn_measurement.device_details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;
-    commercial goniometer modified locally to
-     allow for 90\% \t arc
+;                                 commercial goniometer modified locally to
+                                  allow for 90\% \t arc
 ;
 
 save_
@@ -7147,11 +7962,12 @@ save_diffrn_measurement.device_type
 
     _definition.id                '_diffrn_measurement.device_type'
     _alias.definition_id          '_diffrn_measurement_device_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The make, model or name of the measurement device
-     (goniometer) used.
+;             The make, model or name of the measurement device
+              (goniometer) used.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               device_type
@@ -7175,12 +7991,12 @@ save_diffrn_measurement.diffrn_id
 
     _definition.id                '_diffrn_measurement.diffrn_id'
     _description.text
-;
-    This data item is a pointer to _diffrn.id  in the DIFFRN
-     category.
+;             This data item is a pointer to _diffrn.id in the DIFFRN
+              category.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
     _type.purpose                 Key
     _type.source                  Assigned
@@ -7194,27 +8010,26 @@ save_diffrn_measurement.id
 
     _definition.id                '_diffrn_measurement.id'
     _description.text
-;
-    The value of _diffrn_measurement.id  must uniquely identify
-     the set of mechanical characteristics of the device used to
-     orient and/or position the sample used during the collection
-     of each diffraction data set.
+;             The value of _diffrn_measurement.id must uniquely identify
+              the set of mechanical characteristics of the device used to
+              orient and/or position the sample used during the collection
+              of each diffraction data set.
 
-     If the value of _diffrn_measurement.id  is not given, it is
-     implicitly equal to the value of
-     _diffrn_measurement.diffrn_id.
+              If the value of _diffrn_measurement.id is not given, it is
+              implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
 
-     Either _diffrn_measurement.device  or
-     _diffrn_measurement.id  may be used to link to other
-     categories.  If the experimental setup admits multiple
-     devices, then _diffrn_measurement.id  is used to provide
-     a unique link.
+              Either _diffrn_measurement.device or
+              _diffrn_measurement.id may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id is used to provide
+              a unique link.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               id
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -7225,10 +8040,11 @@ save_diffrn_measurement.method
 
     _definition.id                '_diffrn_measurement.method'
     _alias.definition_id          '_diffrn_measurement_method'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    Method used to measure intensities.
+;             Method used to measure intensities.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               method
@@ -7247,14 +8063,13 @@ save_diffrn_measurement.number_of_axes
 
     _definition.id                '_diffrn_measurement.number_of_axes'
     _description.text
-;
-    The value of _diffrn_measurement.number_of_axes  gives the
-     number of axes of the positioner for the goniometer or
-     other sample orientation or positioning device identified
-     by _diffrn_measurement.id.
+;             The value of _diffrn_measurement.number_of_axes gives the
+              number of axes of the positioner for the goniometer or
+              other sample orientation or positioning device identified
+              by _diffrn_measurement.id.
 
-     The description of the axes should be provided by entries in
-     DIFFRN_MEASUREMENT_AXIS.
+              The description of the axes should be provided by entries in
+              DIFFRN_MEASUREMENT_AXIS.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               number_of_axes
@@ -7265,6 +8080,13 @@ save_diffrn_measurement.number_of_axes
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
 
 save_
 
@@ -7272,11 +8094,10 @@ save_diffrn_measurement.sample_detector_distance
 
     _definition.id                '_diffrn_measurement.sample_detector_distance'
     _description.text
-;
-    The value of _diffrn_measurement.sample_detector_distance  gives
-     the unsigned distance in millimetres from the sample to the
-     detector along the beam.  Normally this distance is derived
-     from the axis settings.
+;             The value of _diffrn_measurement.sample_detector_distance gives
+              the unsigned distance in millimetres from the sample to the 
+              detector along the beam.  Normally this distance is derived
+              from the axis settings.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_distance
@@ -7288,6 +8109,8 @@ save_diffrn_measurement.sample_detector_distance
     _type.ddl2_code               float
     _type.ddl2_units              millimetres
     _units.code                   millimetres
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -7296,11 +8119,10 @@ save_diffrn_measurement.sample_detector_distance_derived
     _definition.id
         '_diffrn_measurement.sample_detector_distance_derived'
     _description.text
-;
-    The value of _diffrn_measurement.sample_detector_distance_derived
-     is assumed to be 'yes', i.e. that value of
-     _diffrn_measurement.sample_detector_distance
-     is derived from the axis settings rather than measured.
+;             The value of _diffrn_measurement.sample_detector_distance_derived
+              is assumed to be 'yes', i.e. that value of 
+              _diffrn_measurement.sample_detector_distance
+              is derived from the axis settings rather than measured.               
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_distance_derived
@@ -7318,11 +8140,10 @@ save_diffrn_measurement.sample_detector_voffset
 
     _definition.id                '_diffrn_measurement.sample_detector_voffset'
     _description.text
-;
-    The value of _diffrn_measurement.sample_detector_voffset  gives
-     the signed distance in millimetres in the vertical
-     direction (positive for up) from the centre of
-     the beam to the centre of the detector.
+;             The value of _diffrn_measurement.sample_detector_voffset gives
+              the signed distance in millimetres in the vertical
+              direction (positive for up) from the centre of
+              the beam to the centre of the detector. 
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               sample_detector_voffset
@@ -7335,6 +8156,8 @@ save_diffrn_measurement.sample_detector_voffset
     _type.ddl2_units              millimetres
     _enumeration.range            :
     _units.code                   millimetres
+    _ddl2_enumeration_range.minimum .
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -7342,11 +8165,12 @@ save_diffrn_measurement.specimen_support
 
     _definition.id                '_diffrn_measurement.specimen_support'
     _alias.definition_id          '_diffrn_measurement_specimen_support'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The physical device used to support the crystal during data
-     collection.
+;             The physical device used to support the crystal during data
+              collection.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               specimen_support
@@ -7370,15 +8194,14 @@ save_diffrn_measurement.variant
 
     _definition.id                '_diffrn_measurement.variant'
     _description.text
-;
-    The value of _diffrn_measurement.variant  gives the variant
-     to which the given DIFFRN_MEASUREMENT row is related.
+;            The value of _diffrn_measurement.variant gives the variant
+             to which the given DIFFRN_MEASUREMENT row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+             If this value is not given, the variant is assumed to be
+             the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               variant
@@ -7395,17 +8218,16 @@ save_
 
 save_DIFFRN_MEASUREMENT_AXIS
 
-    _definition.id                DIFFRN_MEASUREMENT_AXIS
+    _definition.id                diffrn_measurement_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_MEASUREMENT_AXIS  category associate
+    Data items in the DIFFRN_MEASUREMENT_AXIS category associate
      axes with goniometers.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_MEASUREMENT_AXIS
+    _name.object_id               diffrn_measurement_axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -7414,7 +8236,29 @@ save_DIFFRN_MEASUREMENT_AXIS
          '_diffrn_measurement_axis.measurement_id'
          '_diffrn_measurement_axis.axis_id'
          '_diffrn_measurement_axis.variant'
-         '_diffrn_measurement_axis.diffrn_id'
+
+    _nx_mapping.details
+;    _diffrn_measurement_axis.axis_id AXISID
+    _diffrn_measurement_axis.measurement_device DEVICE
+    _diffrn_measurement_axis.measurement_id GONIOMETER
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /sample:NXsample
+        /transformations:NXtransformations      
+          /AXISID=[]      
+      /instrument:NXinstrument
+        /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+          /CBF_diffrn_measurement__device="DEVICE"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -7422,9 +8266,8 @@ save_diffrn_measurement_axis.axis_id
 
     _definition.id                '_diffrn_measurement_axis.axis_id'
     _description.text
-;
-    This data item is a pointer to _axis.id  in
-     the AXIS  category.
+;             This data item is a pointer to _axis.id in
+              the AXIS category.
 ;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               axis_id
@@ -7441,19 +8284,10 @@ save_
 save_diffrn_measurement_axis.diffrn_id
 
     _definition.id                '_diffrn_measurement_axis.diffrn_id'
-    _definition.update            2022-05-27
-    _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
-;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
+    _name.ddl2_mandatory          implicit
 
 save_
 
@@ -7461,11 +8295,10 @@ save_diffrn_measurement_axis.id
 
     _definition.id                '_diffrn_measurement_axis.id'
     _description.text
-;
-    This data item is a pointer to _diffrn_measurement.id  in
-     the DIFFRN_MEASUREMENT  category.
+;             This data item is a pointer to _diffrn_measurement.id in
+              the DIFFRN_MEASUREMENT category.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               id
@@ -7475,6 +8308,8 @@ save_diffrn_measurement_axis.id
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_measurement_axis.measurement_id'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -7482,9 +8317,8 @@ save_diffrn_measurement_axis.measurement_device
 
     _definition.id                '_diffrn_measurement_axis.measurement_device'
     _description.text
-;
-    This data item is a pointer to _diffrn_measurement.device
-     in the DIFFRN_MEASUREMENT  category.
+;             This data item is a pointer to _diffrn_measurement.device
+              in the DIFFRN_MEASUREMENT category.
 ;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               measurement_device
@@ -7502,15 +8336,16 @@ save_diffrn_measurement_axis.measurement_id
 
     _definition.id                '_diffrn_measurement_axis.measurement_id'
     _alias.definition_id          '_diffrn_measurement_axis.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    This data item is a pointer to _diffrn_measurement.id  in
-     the DIFFRN_MEASUREMENT  category.
+;             This data item is a pointer to _diffrn_measurement.id in
+              the DIFFRN_MEASUREMENT category.
 
-     This item was previously named _diffrn_measurement_axis.id,
-     which is now a deprecated name.  The old name is
-     provided as an alias but should not be used for new work.
+              This item was previously named _diffrn_measurement_axis.id,
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
 ;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               measurement_id
@@ -7528,15 +8363,14 @@ save_diffrn_measurement_axis.variant
 
     _definition.id                '_diffrn_measurement_axis.variant'
     _description.text
-;
-    The value of _diffrn_measurement_axis.variant  gives the variant
-     to which the given DIFFRN_MEASUREMENT_AXIS row is related.
+;             The value of _diffrn_measurement_axis.variant gives the variant
+              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_measurement_axis
     _name.object_id               variant
@@ -7553,21 +8387,20 @@ save_
 
 save_DIFFRN_RADIATION
 
-    _definition.id                DIFFRN_RADIATION
+    _definition.id                diffrn_radiation
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2022-05-27
+    _definition.update            2025-09-04
     _description.text
-;
-    Data items in the DIFFRN_RADIATION  category describe
-     the radiation used for measuring diffraction intensities,
-     its collimation and monochromatization before the sample.
+;             Data items in the DIFFRN_RADIATION category describe
+              the radiation used for measuring diffraction intensities,
+              its collimation and monochromatization before the sample.
 
-     Post-sample treatment of the beam is described by data
-     items in the DIFFRN_DETECTOR  category.
+              Post-sample treatment of the beam is described by data
+              items in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_RADIATION
+    _name.object_id               diffrn_radiation
     _name.ddl2_mandatory          no
 
     loop_
@@ -7579,26 +8412,119 @@ save_DIFFRN_RADIATION
       _description_example.case
       _description_example.detail
 ;
-         _diffrn_radiation.diffrn_id             'set1'
+    _diffrn_radiation.diffrn_id            'set1'
 
-         _diffrn_radiation.collimation           '0.3 mm double pinhole'
-         _diffrn_radiation.monochromator         'graphite'
-         _diffrn_radiation.type                  'Cu K\a'
-         _diffrn_radiation.wavelength_id          1
+    _diffrn_radiation.collimation          '0.3 mm double pinhole'
+    _diffrn_radiation.monochromator        'graphite'
+    _diffrn_radiation.type                 'Cu K\a'
+    _diffrn_radiation.wavelength_id         1
+;
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP
 ;
 ;
-         Example 1. based on PDB entry 5HVP and laboratory records for the
-                      structure corresponding to PDB entry 5HVP
+    _diffrn_radiation.wavelength_id    1
+    _diffrn_radiation.type             'Cu K\a'
+    _diffrn_radiation.monochromator    'graphite'
 ;
+;    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
 ;
-         _diffrn_radiation.wavelength_id     1
-         _diffrn_radiation.type              'Cu K\a'
-         _diffrn_radiation.monochromator     'graphite'
+
+    _nx_mapping.details
+;    _diffrn_radiation.collimation    COLLIMATION
+    _diffrn_radiation.diffrn_id      DIFFRNID
+    _diffrn_radiation.div_x_source   DIVX
+    _diffrn_radiation.div_y_source   DIVY
+    _diffrn_radiation.div_x_y_source DIVXY
+    _diffrn_radiation.filter_edge'   ABSEDGE
+    _diffrn_radiation.inhomogeneity  HWIDTH
+    _diffrn_radiation.monochromator  MONOCHROMATOR
+    _diffrn_radiation.polarisn_norm  POLNANG
+    _diffrn_radiation.polarisn_ratio POLRAT
+    _diffrn_radiation.polarizn_source_norm   POLSNANG
+    _diffrn_radiation.polarizn_source_ratio  POLSRAT
+    _diffrn_radiation.polarizn_Stokes_I  SVECI
+    _diffrn_radiation.polarizn_Stokes_Q  SVECQ
+    _diffrn_radiation.polarizn_Stokes_U  SVECU
+    _diffrn_radiation.polarizn_Stokes_V  SVECV
+    _diffrn_radiation.polarisn_norm_esd  POLNANGESD
+    _diffrn_radiation.polarisn_ratio_esd POLRATESD
+    _diffrn_radiation.polarizn_source_norm_esd   POLSNANGESD
+    _diffrn_radiation.polarizn_source_ratio_esd  POLSRATESD
+    _diffrn_radiation.polarizn_Stokes_I_esd  SVECIESD
+    _diffrn_radiation.polarizn_Stokes_Q_esd  SVECQESD
+    _diffrn_radiation.polarizn_Stokes_U_esd  SVECUESD
+    _diffrn_radiation.polarizn_Stokes_V_esd  SVECVESD
+    _diffrn_radiation.probe          RADIATION
+    _diffrn_radiation.type           SIEGBAHNTYPE
+    _diffrn_radiation.xray_symbol    IUPACXRAYSYMB
+    _diffrn_radiation.wavelength_id  ID
+    _diffrn_radiation_wavelength.id  ID
+    _diffrn_radiation_wavelength.wavelength    WAVELENGTH
+    _diffrn_radiation_wavelength.wt            WEIGHT
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.polarizn_Stokes_I_esd STOKESIESD
+    _diffrn_scan_frame.polarizn_Stokes_Q_esd STOKESQESD
+    _diffrn_scan_frame.polarizn_Stokes_U_esd STOKESUESD
+    _diffrn_scan_frame.polarizn_Stokes_V_esd STOKESVESD
+    _diffrn_scan_frame.frame_number FRAMENO
+
+    -->
+
+       /entry:NXentry
+         /CBF_scan_id="SCANID"
+         /sample:NXsample
+           /beam:NXbeam
+             /incident_divergence_x=DIVX
+               @units="degrees"
+             /incident_divergence_y=DIVY
+               @units="degrees"
+             /incident_divergence_xy=DIXXY
+               @units="degrees^2"
+             /CBF_diffrn_radiation_wavelength__wavelength_id=[WAVELENGTH_ID]
+             /incident_wavelength=[WAVELENGTH]
+               @units="A"
+             /weight=[WEIGHT]
+             /incident_polarisation_stokes_average=[SVECI,SVECQ,SVECU,SVECV]
+             /incident_polarisation_stokes_average_uncertainty=[SVECIESD,SVECQESD,SVECUESD,SVECVESD]
+             /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             /incident_polarisation_stokes_uncertainty=[STOKESIESD,STOKESQESD,STOKESUESD,STOKESVESD]
+               @units="Watts/meter^2"
+             /CBF_diffrn_radiation__polarisn_norm=POLNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio=POLRAT
+             /CBF_diffrn_radiation__polarisn_norm_uncertainty=POLNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio_uncertainty=POLRATESD
+             /CBF_diffrn_radiation__polarisn_source_norm=POLSNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio=POLSRAT
+             /CBF_diffrn_radiation__polarisn_source_norm_uncertainty=POLSNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio_uncertainty=POLSRATESD
+             /CBF_diffrn_radiation__filter_edge=ABSEDGE
+                @units="angstroms"
+             /CBF_diffrn_radiation__inhomogeneity=HWIDTH
+                @units="mm"
+         /instrument:NXinstrument
+           /monochromator:NXmonochromator
+             /description="MONOCHROMATOR"
+           /source:NXsource
+             /probe="RADIATION"
+             /CBF_diffrn_radiation__type="SIEGBAHNTYPE"
+             /CBF_diffrn_radiation__xray_symbol="IUPACXRAYSYMB"
+
+         With the incident_polarisation_stokes array indexed by FRAMENO
 ;
-;
-         Example 2. based on data set TOZ of Willis, Beckwith & Tozer
-                     [Acta Cryst. (1991), C47, 2276-2277].
-;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -7606,8 +8532,11 @@ save_diffrn_radiation.beam_flux
 
     _definition.id                '_diffrn_radiation.beam_flux'
     _description.text
-;
-    The average flux integrated over the beam incident on the sample.
+;             The instantaneous flux spacially integrated over the portion
+              of the beam available to be incident on a sample (e.g. after 
+              collimation).  If the flux varies over the course of the 
+              experiment, the average over the time of the experiment should 
+              be reported.  This is sometimes referred to as total flux. 
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux
@@ -7617,8 +8546,138 @@ save_diffrn_radiation.beam_flux
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
-    _type.ddl2_units              'photons per second'
-    _units.code                   'photons per second'
+    _type.ddl2_units              photons_per_second'
+    _units.code                   photons_per_second'
+
+save_
+
+save_diffrn_radiation.beam_flux_density
+
+    _definition.id                '_diffrn_radiation.beam_flux_density'
+    _description.text
+;             The instantaneous flux per unit area orhtogonal to the beam.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_density
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_second_per_micrometre_squared
+    _units.code                   photons_per_second_per_micrometre_squared
+
+save_
+
+save_diffrn_radiation.beam_flux_density_integrated
+
+    _definition.id
+        '_diffrn_radiation.beam_flux_density_integrated'
+    _description.text
+;             The time integral of the flux density.  The time over 
+              which the beam flux density is integrated is given in 
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_density_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_micrometre_squared
+    _units.code                   photons_per_micrometre_squared
+
+save_
+
+save_diffrn_radiation.beam_flux_integrated
+
+    _definition.id                '_diffrn_radiation.beam_flux_integrated'
+    _description.text
+;             The time integral of the flux spacially integrated over the 
+              portion of the beam available to be incident on a sample 
+              (e.g. after collimation).  The time over which the beam flux
+              is integrated is given in 
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons
+    _units.code                   photons
+
+save_
+
+save_diffrn_radiation.beam_flux_integration_time
+
+    _definition.id                '_diffrn_radiation.beam_flux_integration_time'
+    _description.text
+;             The time interval over which beam flux, beam incident flux
+              beam density is integrated.  
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_integration_time
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+
+save_
+
+save_diffrn_radiation.beam_incident_flux
+
+    _definition.id                '_diffrn_radiation.beam_incident_flux'
+    _description.text
+;             The instantaneous flux spacially integrated over the portion of 
+              the beam actually incident on the sample.  If the incident flux 
+              varies over the course of the experiment, the average over the 
+              time of the experiment should be reported.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_incident_flux
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_second
+    _units.code                   photons_per_second
+
+save_
+
+save_diffrn_radiation.beam_incident_flux_integrated
+
+    _definition.id
+        '_diffrn_radiation.beam_incident_flux_integrated'
+    _description.text
+;             The time integral of the flux spacially integrated over the
+              portion of the beam actually incident on the sample.  The 
+              time over which the beam flux is integrated is given in
+
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_incident_flux_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons
+    _units.code                   photons
 
 save_
 
@@ -7626,9 +8685,8 @@ save_diffrn_radiation.beam_width
 
     _definition.id                '_diffrn_radiation.beam_width'
     _description.text
-;
-    Full width at half maximum of the beam incident on the sample
-     in the plane of polarization (or horizontally if unpolarized).
+;             Full width at half maximum of the beam incident on the sample
+              in the plane of polarization (or horizontally if unpolarized).
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_width
@@ -7647,10 +8705,11 @@ save_diffrn_radiation.collimation
 
     _definition.id                '_diffrn_radiation.collimation'
     _alias.definition_id          '_diffrn_radiation_collimation'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The collimation or focusing applied to the radiation.
+;             The collimation or focusing applied to the radiation.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               collimation
@@ -7673,12 +8732,12 @@ save_diffrn_radiation.diffrn_id
 
     _definition.id                '_diffrn_radiation.diffrn_id'
     _description.text
-;
-    This data item is a pointer to _diffrn.id  in the DIFFRN
-     category.
+;             This data item is a pointer to _diffrn.id in the DIFFRN
+              category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
     _type.purpose                 Key
     _type.source                  Assigned
@@ -7692,22 +8751,21 @@ save_diffrn_radiation.div_x_source
 
     _definition.id                '_diffrn_radiation.div_x_source'
     _description.text
-;
-    Beam crossfire in degrees parallel to the laboratory X axis
-     (see AXIS  category).
+;             Beam crossfire in degrees parallel to the laboratory X axis
+              (see AXIS category).
 
-     This is a characteristic of the X-ray beam as it illuminates
-     the sample (or specimen) after all monochromation and
-     collimation.
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
 
-     This is the standard uncertainty (estimated standard
-     deviation, e.s.d.)  of the directions of photons in
-     the XZ plane around the mean source beam direction.
+              This is the standard uncertainty (estimated standard
+              deviation, e.s.d.)  of the directions of photons in 
+              the XZ plane around the mean source beam direction.
 
-     Note that for some synchrotrons this value is specified
-     in milliradians, in which case a conversion is needed.
-     To convert a value in milliradians to a value in degrees,
-     multiply by 0.180 and divide by \p.
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_x_source
@@ -7726,25 +8784,24 @@ save_diffrn_radiation.div_x_y_source
 
     _definition.id                '_diffrn_radiation.div_x_y_source'
     _description.text
-;
-    Beam crossfire correlation in degrees squared between the
-     crossfire laboratory X-axis component and the crossfire
-     laboratory Y-axis component (see AXIS category).
+;             Beam crossfire correlation in degrees squared between the
+              crossfire laboratory X-axis component and the crossfire
+              laboratory Y-axis component (see AXIS category).
 
-     This is a characteristic of the X-ray beam as it illuminates
-     the sample (or specimen) after all monochromation and
-     collimation.
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
 
-     This is the mean of the products of the deviations of the
-     direction of each photon in XZ plane times the deviations
-     of the direction of the same photon in the YZ plane
-     around the mean source beam direction.  This will be zero
-     for uncorrelated crossfire.
+              This is the mean of the products of the deviations of the
+              direction of each photon in XZ plane times the deviations
+              of the direction of the same photon in the YZ plane
+              around the mean source beam direction.  This will be zero
+              for uncorrelated crossfire.
 
-     Note that for some synchrotrons, this value is specified in
-     milliradians squared, in which case a conversion is
-     needed. To convert a value in milliradians squared to a value
-     in degrees squared, multiply by 0.180^2^ and divide by \p^2^.
+              Note that for some synchrotrons, this value is specified in
+              milliradians squared, in which case a conversion is
+              needed. To convert a value in milliradians squared to a value
+              in degrees squared, multiply by 0.180^2^ and divide by \p^2^.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_x_y_source
@@ -7764,22 +8821,21 @@ save_diffrn_radiation.div_y_source
 
     _definition.id                '_diffrn_radiation.div_y_source'
     _description.text
-;
-    Beam crossfire in degrees parallel to the laboratory Y axis
-     (see AXIS  category).
+;             Beam crossfire in degrees parallel to the laboratory Y axis
+              (see AXIS category).
 
-     This is a characteristic of the X-ray beam as it illuminates
-     the sample (or specimen) after all monochromation and
-     collimation.
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
 
-     This is the standard uncertainty (estimated standard deviation,
-     e.s.d.) of the directions of photons in the YZ plane around
-     the mean source beam direction.
+              This is the standard uncertainty (estimated standard deviation,
+              e.s.d.) of the directions of photons in the YZ plane around 
+              the mean source beam direction.
 
-     Note that for some synchrotrons this value is specified
-     in milliradians, in which case a conversion is needed.
-     To convert a value in milliradians to a value in degrees,
-     multiply by 0.180 and divide by \p.
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               div_y_source
@@ -7799,10 +8855,11 @@ save_diffrn_radiation.filter_edge
 
     _definition.id                '_diffrn_radiation.filter_edge'
     _alias.definition_id          '_diffrn_radiation_filter_edge'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    Absorption edge in \%angstr\"oms of the radiation filter used.
+;              Absorption edge in \%angstr\"oms of the radiation filter used.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               filter_edge
@@ -7816,17 +8873,24 @@ save_diffrn_radiation.filter_edge
     _enumeration.range            0.0:
     _units.code                   angstroms
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
 save_
 
 save_diffrn_radiation.inhomogeneity
 
     _definition.id                '_diffrn_radiation.inhomogeneity'
     _alias.definition_id          '_diffrn_radiation_inhomogeneity'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    Half-width in millimetres of the incident beam in the
-     direction perpendicular to the diffraction plane.
+;             Half-width in millimetres of the incident beam in the
+              direction perpendicular to the diffraction plane.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               inhomogeneity
@@ -7840,18 +8904,25 @@ save_diffrn_radiation.inhomogeneity
     _enumeration.range            0.0:
     _units.code                   millimetres
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
 save_
 
 save_diffrn_radiation.monochromator
 
     _definition.id                '_diffrn_radiation.monochromator'
     _alias.definition_id          '_diffrn_radiation_monochromator'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The method used to obtain monochromatic radiation. If a
-     monochromator crystal is used, the material and the
-     indices of the Bragg reflection are specified.
+;             The method used to obtain monochromatic radiation. If a
+              monochromator crystal is used, the material and the
+              indices of the Bragg reflection are specified.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               monochromator
@@ -7875,12 +8946,13 @@ save_diffrn_radiation.polarisn_norm
 
     _definition.id                '_diffrn_radiation.polarisn_norm'
     _alias.definition_id          '_diffrn_radiation_polarisn_norm'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The angle in degrees, as viewed from the specimen, between the
-     perpendicular component of the polarization and the diffraction
-     plane. See _diffrn_radiation_polarisn_ratio.
+;             The angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_norm
@@ -7894,18 +8966,24 @@ save_diffrn_radiation.polarisn_norm
     _enumeration.range            -90.0:90.0
     _units.code                   degrees
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         90.0                     90.0
+         -90.0                    90.0
+         -90.0                    -90.0
+
 save_
 
 save_diffrn_radiation.polarisn_norm_esd
 
     _definition.id                '_diffrn_radiation.polarisn_norm_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.) of
-     _diffrn_radiation.polarisn_norm,
-     the angle in degrees, as viewed from the specimen, between the
-     perpendicular component of the polarization and the diffraction
-     plane. See _diffrn_radiation_polarisn_ratio.
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_norm,
+              the angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_norm_esd
@@ -7919,22 +8997,32 @@ save_diffrn_radiation.polarisn_norm_esd
     _enumeration.range            0.0:
     _units.code                   degrees
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_norm'
+    _ddl2_item_related.function_code associated_value
+
 save_
 
 save_diffrn_radiation.polarisn_ratio
 
     _definition.id                '_diffrn_radiation.polarisn_ratio'
     _alias.definition_id          '_diffrn_radiation_polarisn_ratio'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    Polarization ratio of the diffraction beam incident on the
-     crystal. This is the ratio of the perpendicularly polarized to
-     the parallel polarized component of the radiation. The
-     perpendicular component forms an angle of
-     _diffrn_radiation.polarisn_norm  to the normal to the
-     diffraction plane of the sample (i.e. the plane containing
-     the incident and reflected beams).
+;             Polarization ratio of the diffraction beam incident on the
+              crystal. This is the ratio of the perpendicularly polarized to
+              the parallel polarized component of the radiation. The
+              perpendicular component forms an angle of
+              _diffrn_radiation.polarisn_norm to the normal to the
+              diffraction plane of the sample (i.e. the plane containing
+              the incident and reflected beams).
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_ratio
@@ -7945,6 +9033,13 @@ save_diffrn_radiation.polarisn_ratio
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
 
 save_
 
@@ -7952,11 +9047,10 @@ save_diffrn_radiation.polarisn_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarisn_ratio_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.) of
-     _diffrn_radiation.polarisn_ratio,
-     the polarization ratio of the diffraction beam incident on the
-     crystal.
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_ratio,
+              the polarization ratio of the diffraction beam incident on the
+              crystal. 
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarisn_ratio_esd
@@ -7967,6 +9061,16 @@ save_diffrn_radiation.polarisn_ratio_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_ratio'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -7974,27 +9078,26 @@ save_diffrn_radiation.polarizn_source_norm
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm'
     _description.text
-;
-    The angle in degrees, as viewed from the specimen, between
-     the normal to the polarization plane and the laboratory
-     Y-axis as defined in the AXIS category.
+;             The angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
 
-     Note that this is the angle of polarization of the source
-     photons, either directly from a synchrotron beamline or
-     from a monochromator.
+              Note that this is the angle of polarization of the source
+              photons, either directly from a synchrotron beamline or
+              from a monochromator.
 
-     This differs from the value of
-     _diffrn_radiation.polarisn_norm
-     in that _diffrn_radiation.polarisn_norm  refers to
-     polarization relative to the diffraction plane rather than
-     to the laboratory axis system.
+              This differs from the value of
+              _diffrn_radiation.polarisn_norm
+              in that _diffrn_radiation.polarisn_norm refers to
+              polarization relative to the diffraction plane rather than
+              to the laboratory axis system.
 
-     In the case of an unpolarized beam, or a beam with true
-     circular polarization, in which no single plane of
-     polarization can be determined, the plane should be taken
-     as the XZ plane and the angle as 0.
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane should be taken
+              as the XZ plane and the angle as 0.
 
-     See _diffrn_radiation.polarizn_source_ratio.
+              See _diffrn_radiation.polarizn_source_ratio.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_norm
@@ -8009,18 +9112,24 @@ save_diffrn_radiation.polarizn_source_norm
     _enumeration.default          0.0
     _units.code                   degrees
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         90.0                     90.0
+         -90.0                    90.0
+         -90.0                    -90.0
+
 save_
 
 save_diffrn_radiation.polarizn_source_norm_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_source_norm,
-     the angle in degrees, as viewed from the specimen, between
-     the normal to the polarization plane and the laboratory
-     Y-axis as defined in the AXIS category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_norm,
+              the angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_norm_esd
@@ -8034,50 +9143,58 @@ save_diffrn_radiation.polarizn_source_norm_esd
     _enumeration.range            0.0:
     _units.code                   degrees
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_norm'
+    _ddl2_item_related.function_code associated_value
+
 save_
 
 save_diffrn_radiation.polarizn_source_ratio
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio'
     _description.text
-;
-    The quantity (Ip-In)/(Ip+In), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared)
-     of the electric vector in the plane of the normal to the
-     plane of polarization.
+;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
 
-     In the case of an unpolarized beam, or a beam with true
-     circular polarization, in which no single plane of
-     polarization can be determined, the plane is to be taken
-     as the XZ plane and the normal is parallel to the Y axis.
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane is to be taken
+              as the XZ plane and the normal is parallel to the Y axis.
 
-     Thus, if there was complete polarization in the plane of
-     polarization, the value of
-     _diffrn_radiation.polarizn_source_ratio  would be 1, and
-     for an unpolarized beam
-     _diffrn_radiation.polarizn_source_ratio  would have a
-     value of 0.
+              Thus, if there was complete polarization in the plane of
+              polarization, the value of
+              _diffrn_radiation.polarizn_source_ratio would be 1, and
+              for an unpolarized beam
+              _diffrn_radiation.polarizn_source_ratio would have a
+              value of 0.
 
-     If the X axis has been chosen to lie in the plane of
-     polarization, this definition will agree with the definition
-     of 'MONOCHROMATOR' in the Denzo glossary, and values of near
-     1 should be expected for a bending-magnet source.  However,
-     if the X-axis were perpendicular to the polarization plane
-     (not a common choice), then the Denzo value would be the
-     negative of _diffrn_radiation.polarizn_source_ratio.
+              If the X axis has been chosen to lie in the plane of
+              polarization, this definition will agree with the definition
+              of 'MONOCHROMATOR' in the Denzo glossary, and values of near
+              1 should be expected for a bending-magnet source.  However,
+              if the X-axis were perpendicular to the polarization plane
+              (not a common choice), then the Denzo value would be the
+              negative of _diffrn_radiation.polarizn_source_ratio.
 
-     See http://www.hkl-xray.com for information on Denzo and
-     Otwinowski & Minor (1997).
+              See http://www.hkl-xray.com for information on Denzo and
+              Otwinowski & Minor (1997).
 
-     This differs both in the choice of ratio and choice of
-     orientation from _diffrn_radiation.polarisn_ratio, which,
-     unlike _diffrn_radiation.polarizn_source_ratio, is
-     unbounded.
+              This differs both in the choice of ratio and choice of
+              orientation from _diffrn_radiation.polarisn_ratio, which,
+              unlike _diffrn_radiation.polarizn_source_ratio, is
+              unbounded.
 
-     Reference: Otwinowski, Z. & Minor, W. (1997). 'Processing of
-     X-ray diffraction data collected in oscillation mode.' Methods
-     Enzymol. 276, 307-326.
+              Reference: Otwinowski, Z. & Minor, W. (1997). 'Processing of
+              X-ray diffraction data collected in oscillation mode.' Methods
+              Enzymol. 276, 307-326.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_ratio
@@ -8088,6 +9205,14 @@ save_diffrn_radiation.polarizn_source_ratio
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            -1.0:1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1.0                      1.0
+         -1.0                     1.0
+         -1.0                     -1.0
 
 save_
 
@@ -8095,14 +9220,13 @@ save_diffrn_radiation.polarizn_source_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_source_ratio,
-     (Ip-In)/(Ip+In), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared)
-     of the electric vector in the plane of the normal to the
-     plane of polarization.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_ratio,
+              (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_source_ratio_esd
@@ -8113,6 +9237,16 @@ save_diffrn_radiation.polarizn_source_ratio_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_ratio'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -8120,33 +9254,32 @@ save_diffrn_radiation.polarizn_stokes_i
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I'
     _description.text
-;
-    The quantity Ip+In+Inp, where Ip is the intensity (amplitude
-     squared) of the electric vector in the plane of polarization,
-     In is the intensity (amplitude squared) of the electric vector
-     in the plane of the normal to the plane of polarization,
-     and Inp is the intensity (amplitude squared) of the
-     non-polarized (incoherent) electric vector.
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
 
-     This is an average or other representative sample of the
-     scan.
+              This is an average or other representative sample of the
+              scan.
 
-     This is the first of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Note that, if the polarized intensity Ip+In is required,
-     (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200 -- 3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_I
@@ -8158,6 +9291,13 @@ save_diffrn_radiation.polarizn_stokes_i
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _enumeration.default          1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
 
 save_
 
@@ -8165,15 +9305,14 @@ save_diffrn_radiation.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_Stokes_I,
-     Ip+In+Inp, where Ip is the intensity (amplitude squared)
-     of the electric vector in the plane of polarization,
-     In is the intensity (amplitude squared) of the electric vector
-     in the plane of the normal to the plane of polarization,
-     and Inp is the intensity (amplitude squared) of the
-     non-polarized (incoherent) electric vector.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_I_esd
@@ -8184,6 +9323,16 @@ save_diffrn_radiation.polarizn_stokes_i_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_I'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -8191,32 +9340,31 @@ save_diffrn_radiation.polarizn_stokes_q
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q'
     _description.text
-;
-    The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     scan.
+              This is an average or other representative sample of the
+              scan.
 
-     This is the second of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200 -- 3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_Q
@@ -8226,6 +9374,7 @@ save_diffrn_radiation.polarizn_stokes_q
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -8233,17 +9382,16 @@ save_diffrn_radiation.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_Stokes_Q,
-     (Ip-In)*cos(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y-axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_Q_esd
@@ -8254,6 +9402,16 @@ save_diffrn_radiation.polarizn_stokes_q_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_Q'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -8261,32 +9419,31 @@ save_diffrn_radiation.polarizn_stokes_u
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U'
     _description.text
-;
-    The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     scan.
+              This is an average or other representative sample of the
+              scan.
 
-     This is the third of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry at al. (1977)].
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry at al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200 -- 3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_U
@@ -8296,6 +9453,7 @@ save_diffrn_radiation.polarizn_stokes_u
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -8303,17 +9461,16 @@ save_diffrn_radiation.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_Stokes_U,
-     (Ip-In)*sin(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y-axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_U_esd
@@ -8324,6 +9481,16 @@ save_diffrn_radiation.polarizn_stokes_u_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_U'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -8331,33 +9498,32 @@ save_diffrn_radiation.polarizn_stokes_v
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V'
     _description.text
-;
-    The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
-     circular polarization, where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     scan.
+              This is an average or other representative sample of the
+              scan.
 
-     This is the fourth of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200 -- 3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_V
@@ -8367,6 +9533,7 @@ save_diffrn_radiation.polarizn_stokes_v
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -8374,18 +9541,17 @@ save_diffrn_radiation.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_radiation.polarizn_Stokes_V,
-     +/-2*sqrt(IpIn), with a + sign for right-handed circular
-     polarization, where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               polarizn_Stokes_V_esd
@@ -8396,6 +9562,16 @@ save_diffrn_radiation.polarizn_stokes_v_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_V'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -8403,12 +9579,13 @@ save_diffrn_radiation.probe
 
     _definition.id                '_diffrn_radiation.probe'
     _alias.definition_id          '_diffrn_radiation_probe'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    Name of the type of radiation used. It is strongly
-     recommended that this be given so that the
-     probe radiation is clearly specified.
+;             Name of the type of radiation used. It is strongly
+              recommended that this be given so that the
+              probe radiation is clearly specified.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               probe
@@ -8432,11 +9609,12 @@ save_diffrn_radiation.type
 
     _definition.id                '_diffrn_radiation.type'
     _alias.definition_id          '_diffrn_radiation_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The nature of the radiation. This is typically a description
-     of the X-ray wavelength in Siegbahn notation.
+;             The nature of the radiation. This is typically a description
+              of the X-ray wavelength in Siegbahn notation.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               type
@@ -8460,15 +9638,14 @@ save_diffrn_radiation.variant
 
     _definition.id                '_diffrn_radiation.variant'
     _description.text
-;
-    The value of _diffrn_radiation.variant  gives the variant
-     to which the given DIFFRN_RADIATION row is related.
+;             The value of _diffrn_radiation.variant gives the variant
+              to which the given DIFFRN_RADIATION row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               variant
@@ -8487,10 +9664,9 @@ save_diffrn_radiation.wavelength_id
 
     _definition.id                '_diffrn_radiation.wavelength_id'
     _description.text
-;
-    This data item is a pointer to
-     _diffrn_radiation_wavelength.id  in the
-     DIFFRN_RADIATION_WAVELENGTH category.
+;             This data item is a pointer to
+              _diffrn_radiation_wavelength.id in the
+              DIFFRN_RADIATION_WAVELENGTH category.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               wavelength_id
@@ -8507,11 +9683,12 @@ save_diffrn_radiation.xray_symbol
 
     _definition.id                '_diffrn_radiation.xray_symbol'
     _alias.definition_id          '_diffrn_radiation_xray_symbol'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
     _alias.dictionary_uri         cif_core.dic
     _description.text
-;
-    The IUPAC symbol for the X-ray wavelength for the probe
-     radiation.
+;             The IUPAC symbol for the X-ray wavelength for the probe
+              radiation.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               xray_symbol
@@ -8534,13 +9711,13 @@ save_
 
 save_DIFFRN_REFLN
 
-    _definition.id                DIFFRN_REFLN
+    _definition.id                diffrn_refln
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
     This category redefinition has been added to extend the key of
-     the standard DIFFRN_REFLN  category.
+     the standard DIFFRN_REFLN category.
 
      Data items in the DIFFRN_REFLN category record details about
      the intensities in the diffraction data set
@@ -8555,7 +9732,7 @@ save_DIFFRN_REFLN
      _diffrn_refln.frame_id
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_REFLN
+    _name.object_id               diffrn_refln
     _name.ddl2_mandatory          no
 
     loop_
@@ -8565,18 +9742,28 @@ save_DIFFRN_REFLN
          '_diffrn_refln.frame_id'
          '_diffrn_refln.variant'
 
+    _nx_mapping.details
+;
+    This category will be addressed at a future date.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
 save_
 
 save_diffrn_refln.diffrn_id
 
     _definition.id                '_diffrn_refln.diffrn_id'
     _description.text
-;
-    This item is a placeholder for the definition in the
-     PDBx/mmCIF dictionary
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary
 ;
     _name.category_id             diffrn_refln
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          yes
     _type.purpose                 Key
     _type.source                  Assigned
@@ -8590,9 +9777,8 @@ save_diffrn_refln.frame_id
 
     _definition.id                '_diffrn_refln.frame_id'
     _description.text
-;
-    This item is a pointer to _diffrn_data_frame.id
-     in the DIFFRN_DATA_FRAME  category.
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_refln
     _name.object_id               frame_id
@@ -8610,9 +9796,8 @@ save_diffrn_refln.id
 
     _definition.id                '_diffrn_refln.id'
     _description.text
-;
-    This item is a placeholder for the definition in the
-     PDBx/mmCIF dictionary.
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary.
 ;
     _name.category_id             diffrn_refln
     _name.object_id               id
@@ -8629,15 +9814,14 @@ save_diffrn_refln.variant
 
     _definition.id                '_diffrn_refln.variant'
     _description.text
-;
-    The value of _diffrn_refln.variant  gives the variant
-     to which the given DIFFRN_REFLN row is related.
+;             The value of _diffrn_refln.variant gives the variant
+              to which the given DIFFRN_REFLN row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_refln
     _name.object_id               variant
@@ -8652,73 +9836,81 @@ save_diffrn_refln.variant
 
 save_
 
+save_diffrn_reflns.diffrn_id
+
+    _definition.id                '_diffrn_reflns.diffrn_id'
+    _name.category_id             diffrn_reflns
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+
+save_
+
 save_DIFFRN_SCAN
 
-    _definition.id                DIFFRN_SCAN
+    _definition.id                diffrn_scan
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN  category describe the parameters of one
+    Data items in the DIFFRN_SCAN category describe the parameters of one
      or more scans, relating axis positions to frames.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN
+    _name.object_id               diffrn_scan
     _name.ddl2_mandatory          no
 
     loop_
       _category_key.name
          '_diffrn_scan.id'
          '_diffrn_scan.variant'
-         '_diffrn_scan.diffrn_id'
 
     loop_
       _description_example.case
       _description_example.detail
 ;
-          _diffrn_scan.id                    1
-          _diffrn_scan.date_start          '2001-11-18T03:26:42'
-          _diffrn_scan.date_end_estimated  '2001-11-18T03:36:45'
-          _diffrn_scan.date_end            '2001-11-18T03:36:45'
-          _diffrn_scan.integration_time     3.0
-          _diffrn_scan.frame_id_start       mad_L2_000
-          _diffrn_scan.frame_id_end         mad_L2_200
-          _diffrn_scan.frames               201
+      _diffrn_scan.id                   1
+      _diffrn_scan.date_start         '2001-11-18T03:26:42'
+      _diffrn_scan.date_end_estimated '2001-11-18T03:36:45'
+      _diffrn_scan.date_end           '2001-11-18T03:36:45'
+      _diffrn_scan.integration_time    3.0
+      _diffrn_scan.frame_id_start      mad_L2_000
+      _diffrn_scan.frame_id_end        mad_L2_200
+      _diffrn_scan.frames              201
 
-         loop_
-          _diffrn_scan_axis.scan_id
-          _diffrn_scan_axis.axis_id
-          _diffrn_scan_axis.angle_start
-          _diffrn_scan_axis.angle_range
-          _diffrn_scan_axis.angle_increment
-          _diffrn_scan_axis.displacement_start
-          _diffrn_scan_axis.displacement_range
-          _diffrn_scan_axis.displacement_increment
+     loop_
+      _diffrn_scan_axis.scan_id
+      _diffrn_scan_axis.axis_id
+      _diffrn_scan_axis.angle_start
+      _diffrn_scan_axis.angle_range
+      _diffrn_scan_axis.angle_increment
+      _diffrn_scan_axis.displacement_start
+      _diffrn_scan_axis.displacement_range
+      _diffrn_scan_axis.displacement_increment
 
-           1 omega 200.0 20.0 0.1 . . .
-           1 kappa -40.0  0.0 0.0 . . .
-           1 phi   127.5  0.0 0.0 . . .
-           1 tranz  . . .   2.3 0.0 0.0
+       1 omega 200.0 20.1 0.1 . . .
+       1 kappa -40.0  0.0 0.0 . . .
+       1 phi   127.5  0.0 0.0 . . .
+       1 tranz  . . .   2.3 0.0 0.0
 
-          _diffrn_scan_frame.scan_id                    1
-          _diffrn_scan_frame.date                '2001-11-18T03:27:33'
-          _diffrn_scan_frame.integration_time     3.0
-          _diffrn_scan_frame.frame_id             mad_L2_018
-          _diffrn_scan_frame.frame_number         18
+      _diffrn_scan_frame.scan_id                   1
+      _diffrn_scan_frame.date               '2001-11-18T03:27:33'
+      _diffrn_scan_frame.integration_time    3.0
+      _diffrn_scan_frame.frame_id            mad_L2_018
+      _diffrn_scan_frame.frame_number        18
 
-         loop_
-          _diffrn_scan_frame_axis.frame_id
-          _diffrn_scan_frame_axis.axis_id
-          _diffrn_scan_frame_axis.angle
-          _diffrn_scan_frame_axis.angle_increment
-          _diffrn_scan_frame_axis.displacement
-          _diffrn_scan_frame_axis.displacement_increment
+     loop_
+      _diffrn_scan_frame_axis.frame_id
+      _diffrn_scan_frame_axis.axis_id
+      _diffrn_scan_frame_axis.angle
+      _diffrn_scan_frame_axis.angle_increment
+      _diffrn_scan_frame_axis.displacement
+      _diffrn_scan_frame_axis.displacement_increment
 
-           mad_L2_018 omega 201.8  0.1 ..
-           mad_L2_018 kappa -40.0  0.0 ..
-           mad_L2_018 phi   127.5  0.0 ..
-           mad_L2_018 tranz  .     .  2.3 0.0
+       mad_L2_018 omega 201.8  0.1 . .
+       mad_L2_018 kappa -40.0  0.0 . .
+       mad_L2_018 phi   127.5  0.0 . .
+       mad_L2_018 tranz  .     .  2.3 0.0
 ;
 ;
          Example 1. derived from a suggestion by R. M. Sweet.
@@ -8732,7 +9924,7 @@ save_DIFFRN_SCAN
          reason why more axes could not have been specified to step. Range
          information has been specified, but note that it can be calculated from
          the  number of frames and the increment, so the data item
-         _diffrn_scan_axis.angle_range  could be dropped.
+         _diffrn_scan_axis.angle_range could be dropped.
 
          Both the sweep data and the data for a single frame are specified.
 
@@ -8740,8 +9932,8 @@ save_DIFFRN_SCAN
          once in terms of the overall averages in the value of
          _diffrn_scan.integration_time and the values for DIFFRN_SCAN_AXIS,
          and precisely for the given frame in the value for
-         _diffrn_scan_frame.integration_time  and the values for
-         DIFFRN_SCAN_FRAME_AXIS .  If dose-related adjustments are made to
+         _diffrn_scan_frame.integration_time and the values for
+         DIFFRN_SCAN_FRAME_AXIS.  If dose-related adjustments are made to
          scan times and nonlinear stepping is done, these values may differ.
          Therefore, in interpreting the data for a particular frame it is
          important to use the frame-specific data.
@@ -8752,230 +9944,229 @@ save_DIFFRN_SCAN
          is data that can be estimated at the same time, and *.date_end which
          can only be logged exactly if the data collection completes normally.
 ;
-;
-                  ###CBF: VERSION 1.1
+;    ###CBF: VERSION 1.1
 
-                   data_image_1
+     data_image_1
 
-                   # category DIFFRN
-                  _diffrn.id P6MB
-                  _diffrn.crystal_id P6MB_CRYSTAL7
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
 
-                   # category DIFFRN_SOURCE
-                   loop_
-                  _diffrn_source.diffrn_id
-                  _diffrn_source.source
-                  _diffrn_source.type
-                    P6MB synchrotron 'SSRL beamline 9-1'
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
 
-                   # category DIFFRN_RADIATION
-                   loop_
-                   _diffrn_radiation.diffrn_id
-                   _diffrn_radiation.wavelength_id
-                   _diffrn_radiation.monochromator
-                   _diffrn_radiation.polarizn_source_ratio
-                   _diffrn_radiation.polarizn_source_norm
-                   _diffrn_radiation.div_x_source
-                   _diffrn_radiation.div_y_source
-                   _diffrn_radiation.div_x_y_source
-                    P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+     # category DIFFRN_RADIATION
+     loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
 
-                   # category DIFFRN_RADIATION_WAVELENGTH
-                   loop_
-                  _diffrn_radiation_wavelength.id
-                  _diffrn_radiation_wavelength.wavelength
-                  _diffrn_radiation_wavelength.wt
-                    WAVELENGTH1 0.98 1.0
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
 
-                   # category DIFFRN_DETECTOR
-                   loop_
-                   _diffrn_detector.diffrn_id
-                   _diffrn_detector.id
-                   _diffrn_detector.type
-                   _diffrn_detector.number_of_axes
-                    P6MB MAR345-SN26 'MAR 345' 4
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
 
-                   # category DIFFRN_DETECTOR_AXIS
-                   loop_
-                   _diffrn_detector_axis.detector_id
-                   _diffrn_detector_axis.axis_id
-                    MAR345-SN26 DETECTOR_X
-                    MAR345-SN26 DETECTOR_Y
-                    MAR345-SN26 DETECTOR_Z
-                    MAR345-SN26 DETECTOR_PITCH
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
 
-                   # category DIFFRN_DETECTOR_ELEMENT
-                   loop_
-                   _diffrn_detector_element.id
-                   _diffrn_detector_element.detector_id
-                    ELEMENT1 MAR345-SN26
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
 
-                   # category DIFFRN_DATA_FRAME
-                   loop_
-                   _diffrn_data_frame.id
-                   _diffrn_data_frame.detector_element_id
-                   _diffrn_data_frame.array_id
-                   _diffrn_data_frame.binary_id
-                    FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
 
-                   # category DIFFRN_MEASUREMENT
-                   loop_
-                   _diffrn_measurement.diffrn_id
-                   _diffrn_measurement.id
-                   _diffrn_measurement.number_of_axes
-                   _diffrn_measurement.method
-                    P6MB GONIOMETER 3 rotation
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
 
-                   # category DIFFRN_MEASUREMENT_AXIS
-                   loop_
-                   _diffrn_measurement_axis.measurement_id
-                   _diffrn_measurement_axis.axis_id
-                    GONIOMETER GONIOMETER_PHI
-                    GONIOMETER GONIOMETER_KAPPA
-                    GONIOMETER GONIOMETER_OMEGA
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
 
-                   # category DIFFRN_SCAN
-                   loop_
-                   _diffrn_scan.id
-                   _diffrn_scan.frame_id_start
-                   _diffrn_scan.frame_id_end
-                   _diffrn_scan.frames
-                    SCAN1 FRAME1 FRAME1 1
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
 
-                   # category DIFFRN_SCAN_AXIS
-                   loop_
-                   _diffrn_scan_axis.scan_id
-                   _diffrn_scan_axis.axis_id
-                   _diffrn_scan_axis.angle_start
-                   _diffrn_scan_axis.angle_range
-                   _diffrn_scan_axis.angle_increment
-                   _diffrn_scan_axis.displacement_start
-                   _diffrn_scan_axis.displacement_range
-                   _diffrn_scan_axis.displacement_increment
-                    SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
-                    SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
-                    SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
-                    SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
-                    SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
-                    SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
-                    SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
 
-                   # category DIFFRN_SCAN_FRAME
-                   loop_
-                   _diffrn_scan_frame.frame_id
-                   _diffrn_scan_frame.frame_number
-                   _diffrn_scan_frame.integration_time
-                   _diffrn_scan_frame.scan_id
-                   _diffrn_scan_frame.date
-                    FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
 
-                   # category DIFFRN_SCAN_FRAME_AXIS
-                   loop_
-                   _diffrn_scan_frame_axis.frame_id
-                   _diffrn_scan_frame_axis.axis_id
-                   _diffrn_scan_frame_axis.angle
-                   _diffrn_scan_frame_axis.displacement
-                    FRAME1 GONIOMETER_OMEGA 12.0 0.0
-                    FRAME1 GONIOMETER_KAPPA 23.3 0.0
-                    FRAME1 GONIOMETER_PHI -165.8 0.0
-                    FRAME1 DETECTOR_Z 0.0 -240.0
-                    FRAME1 DETECTOR_Y 0.0 0.6
-                    FRAME1 DETECTOR_X 0.0 -0.5
-                    FRAME1 DETECTOR_PITCH 0.0 0.0
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
 
-                   # category AXIS
-                   loop_
-                   _axis.id
-                   _axis.type
-                   _axis.equipment
-                   _axis.depends_on
-                   _axis.vector[1] _axis.vector[2] _axis.vector[3]
-                   _axis.offset[1] _axis.offset[2] _axis.offset[3]
-                    GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
-                    GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA
-         0.64279            0 0.76604 . . .
-                    GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
-                   . . .
-                    SOURCE           general source . 0 0 1 . . .
-                    GRAVITY          general gravity . 0 -1 0 . . .
-                    DETECTOR_Z       translation detector . 0 0 1 0 0 0
-                    DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
-                    DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
-                    DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
-                    ELEMENT_X        translation detector DETECTOR_PITCH
-                   1 0 0 172.43 -172.43 0
-                    ELEMENT_Y        translation detector ELEMENT_X
-                   0 1 0 0 0 0
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
 
-                   # category ARRAY_STRUCTURE_LIST
-                   loop_
-                   _array_structure_list.array_id
-                   _array_structure_list.index
-                   _array_structure_list.dimension
-                   _array_structure_list.precedence
-                   _array_structure_list.direction
-                   _array_structure_list.axis_set_id
-                    ARRAY1 1 2300 1 increasing ELEMENT_X
-                    ARRAY1 2 2300 2 increasing ELEMENT_Y
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 2300 1 increasing ELEMENT_X
+      ARRAY1 2 2300 2 increasing ELEMENT_Y
 
-                   # category ARRAY_STRUCTURE_LIST_AXIS
-                   loop_
-                   _array_structure_list_axis.axis_set_id
-                   _array_structure_list_axis.axis_id
-                   _array_structure_list_axis.displacement
-                   _array_structure_list_axis.displacement_increment
-                    ELEMENT_X ELEMENT_X 0.075 0.150
-                    ELEMENT_Y ELEMENT_Y 0.075 0.150
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.displacement_increment
+      ELEMENT_X ELEMENT_X 0.075 0.150
+      ELEMENT_Y ELEMENT_Y 0.075 0.150
 
-                   # category ARRAY_ELEMENT_SIZE
-                   loop_
-                   _array_element_size.array_id
-                   _array_element_size.index
-                   _array_element_size.size
-                    ARRAY1 1 150e-6
-                    ARRAY1 2 150e-6
+     # category ARRAY_ELEMENT_SIZE
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+      ARRAY1 2 150e-6
 
-                   # category ARRAY_INTENSITIES
-                   loop_
-                   _array_intensities.array_id
-                   _array_intensities.binary_id
-                   _array_intensities.linearity
-                   _array_intensities.gain
-                   _array_intensities.gain_esd
-                   _array_intensities.overload
-                   _array_intensities.undefined_value
-                    ARRAY1 1 linear 1.15 0.2 240000 0
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
 
-                    # category ARRAY_STRUCTURE
-                   loop_
-                    _array_structure.id
-                    _array_structure.encoding_type
-                    _array_structure.compression_type
-                    _array_structure.byte_order
-                    ARRAY1 "signed 32-bit integer" packed little_endian
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
 
-                   # category ARRAY_DATA
-                   loop_
-                   _array_data.array_id
-                   _array_data.binary_id
-                   _array_data.data
-                    ARRAY1 1
-                   ;
-                   --CIF-BINARY-FORMAT-SECTION--
-                   Content-Type: application/octet-stream;
-                       conversions="X-CBF_PACKED"
-                   Content-Transfer-Encoding: BASE64
-                   X-Binary-Size: 3801324
-                   X-Binary-ID: 1
-                   X-Binary-Element-Type: "signed 32-bit integer"
-                   Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
 
-AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
-                   ...
-8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
 
-                   --CIF-BINARY-FORMAT-SECTION----
-                   ;
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
 ;
 ;
          Example 2. a more extensive example (R. M. Sweet, P. J. Ellis &
@@ -9005,231 +10196,229 @@ AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
           are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
           0.075) in this coordinate system.
 ;
-;
-                  ###CBF: VERSION 1.1
+;    ###CBF: VERSION 1.1
 
-                   data_image_1
+     data_image_1
 
-                   # category DIFFRN
-                  _diffrn.id P6MB
-                  _diffrn.crystal_id P6MB_CRYSTAL7
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
 
-                   # category DIFFRN_SOURCE
-                   loop_
-                  _diffrn_source.diffrn_id
-                  _diffrn_source.source
-                  _diffrn_source.type
-                    P6MB synchrotron 'SSRL beamline 9-1'
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
 
-                   # category DIFFRN_RADIATION
-                        loop_
-                   _diffrn_radiation.diffrn_id
-                   _diffrn_radiation.wavelength_id
-                   _diffrn_radiation.monochromator
-                   _diffrn_radiation.polarizn_source_ratio
-                   _diffrn_radiation.polarizn_source_norm
-                   _diffrn_radiation.div_x_source
-                   _diffrn_radiation.div_y_source
-                   _diffrn_radiation.div_x_y_source
-                    P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+     # category DIFFRN_RADIATION
+          loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
 
-                   # category DIFFRN_RADIATION_WAVELENGTH
-                   loop_
-                  _diffrn_radiation_wavelength.id
-                  _diffrn_radiation_wavelength.wavelength
-                  _diffrn_radiation_wavelength.wt
-                    WAVELENGTH1 0.98 1.0
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
 
-                   # category DIFFRN_DETECTOR
-                   loop_
-                   _diffrn_detector.diffrn_id
-                   _diffrn_detector.id
-                   _diffrn_detector.type
-                   _diffrn_detector.number_of_axes
-                    P6MB MAR345-SN26 'MAR 345' 4
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
 
-                   # category DIFFRN_DETECTOR_AXIS
-                   loop_
-                   _diffrn_detector_axis.detector_id
-                   _diffrn_detector_axis.axis_id
-                    MAR345-SN26 DETECTOR_X
-                    MAR345-SN26 DETECTOR_Y
-                    MAR345-SN26 DETECTOR_Z
-                    MAR345-SN26 DETECTOR_PITCH
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
 
-                   # category DIFFRN_DETECTOR_ELEMENT
-                   loop_
-                   _diffrn_detector_element.id
-                   _diffrn_detector_element.detector_id
-                    ELEMENT1 MAR345-SN26
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
 
-                   # category DIFFRN_DATA_FRAME
-                   loop_
-                   _diffrn_data_frame.id
-                   _diffrn_data_frame.detector_element_id
-                   _diffrn_data_frame.array_id
-                   _diffrn_data_frame.binary_id
-                    FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
 
-                   # category DIFFRN_MEASUREMENT
-                   loop_
-                   _diffrn_measurement.diffrn_id
-                   _diffrn_measurement.id
-                   _diffrn_measurement.number_of_axes
-                   _diffrn_measurement.method
-                    P6MB GONIOMETER 3 rotation
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
 
-                   # category DIFFRN_MEASUREMENT_AXIS
-                   loop_
-                   _diffrn_measurement_axis.measurement_id
-                   _diffrn_measurement_axis.axis_id
-                    GONIOMETER GONIOMETER_PHI
-                    GONIOMETER GONIOMETER_KAPPA
-                    GONIOMETER GONIOMETER_OMEGA
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
 
-                   # category DIFFRN_SCAN
-                   loop_
-                   _diffrn_scan.id
-                   _diffrn_scan.frame_id_start
-                   _diffrn_scan.frame_id_end
-                   _diffrn_scan.frames
-                    SCAN1 FRAME1 FRAME1 1
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
 
-                   # category DIFFRN_SCAN_AXIS
-                   loop_
-                   _diffrn_scan_axis.scan_id
-                   _diffrn_scan_axis.axis_id
-                   _diffrn_scan_axis.angle_start
-                   _diffrn_scan_axis.angle_range
-                   _diffrn_scan_axis.angle_increment
-                   _diffrn_scan_axis.displacement_start
-                   _diffrn_scan_axis.displacement_range
-                   _diffrn_scan_axis.displacement_increment
-                    SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
-                    SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
-                    SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
-                    SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
-                    SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
-                    SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
-                    SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
 
-                   # category DIFFRN_SCAN_FRAME
-                   loop_
-                   _diffrn_scan_frame.frame_id
-                   _diffrn_scan_frame.frame_number
-                   _diffrn_scan_frame.integration_time
-                   _diffrn_scan_frame.scan_id
-                   _diffrn_scan_frame.date
-                    FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
 
-                   # category DIFFRN_SCAN_FRAME_AXIS
-                   loop_
-                   _diffrn_scan_frame_axis.frame_id
-                   _diffrn_scan_frame_axis.axis_id
-                   _diffrn_scan_frame_axis.angle
-                   _diffrn_scan_frame_axis.displacement
-                    FRAME1 GONIOMETER_OMEGA 12.0 0.0
-                    FRAME1 GONIOMETER_KAPPA 23.3 0.0
-                    FRAME1 GONIOMETER_PHI -165.8 0.0
-                    FRAME1 DETECTOR_Z 0.0 -240.0
-                    FRAME1 DETECTOR_Y 0.0 0.6
-                    FRAME1 DETECTOR_X 0.0 -0.5
-                    FRAME1 DETECTOR_PITCH 0.0 0.0
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
 
-                   # category AXIS
-                   loop_
-                   _axis.id
-                   _axis.type
-                   _axis.equipment
-                   _axis.depends_on
-                   _axis.vector[1] _axis.vector[2] _axis.vector[3]
-                   _axis.offset[1] _axis.offset[2] _axis.offset[3]
-                    GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
-                    GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA
-         0.64279            0 0.76604 . . .
-                    GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
-                   . . .
-                    SOURCE           general source . 0 0 1 . . .
-                    GRAVITY          general gravity . 0 -1 0 . . .
-                    DETECTOR_Z       translation detector . 0 0 1 0 0 0
-                    DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
-                    DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
-                    DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
-                    ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1
-         0 0 0            ELEMENT_RAD      translation detector ELEMENT_ROT 0 1
-         0 0 0 0
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1 0 0 0
+      ELEMENT_RAD      translation detector ELEMENT_ROT 0 1 0 0 0 0
 
-                   # category ARRAY_STRUCTURE_LIST
-                   loop_
-                   _array_structure_list.array_id
-                   _array_structure_list.index
-                   _array_structure_list.dimension
-                   _array_structure_list.precedence
-                   _array_structure_list.direction
-                   _array_structure_list.axis_set_id
-                    ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
 
-                   # category ARRAY_STRUCTURE_LIST_AXIS
-                   loop_
-                   _array_structure_list_axis.axis_set_id
-                   _array_structure_list_axis.axis_id
-                   _array_structure_list_axis.angle
-                   _array_structure_list_axis.displacement
-                   _array_structure_list_axis.angular_pitch
-                   _array_structure_list_axis.radial_pitch
-                    ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075  .
-                    ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.angle
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.angular_pitch
+     _array_structure_list_axis.radial_pitch
+      ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075   .
+      ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
 
-                   # category ARRAY_ELEMENT_SIZE
-                   # the actual pixels are 0.075 by 0.150 mm
-                   # We give the coarser dimension here.
-                   loop_
-                   _array_element_size.array_id
-                   _array_element_size.index
-                   _array_element_size.size
-                    ARRAY1 1 150e-6
+     # category ARRAY_ELEMENT_SIZE
+     # the actual pixels are 0.075 by 0.150 mm
+     # We give the coarser dimension here.
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
 
-                   # category ARRAY_INTENSITIES
-                   loop_
-                   _array_intensities.array_id
-                   _array_intensities.binary_id
-                   _array_intensities.linearity
-                   _array_intensities.gain
-                   _array_intensities.gain_esd
-                   _array_intensities.overload
-                   _array_intensities.undefined_value
-                    ARRAY1 1 linear 1.15 0.2 240000 0
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
 
-                    # category ARRAY_STRUCTURE
-                   loop_
-                    _array_structure.id
-                    _array_structure.encoding_type
-                    _array_structure.compression_type
-                    _array_structure.byte_order
-                    ARRAY1 "signed 32-bit integer" packed little_endian
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
 
-                   # category ARRAY_DATA
-                   loop_
-                   _array_data.array_id
-                   _array_data.binary_id
-                   _array_data.data
-                    ARRAY1 1
-                   ;
-                   --CIF-BINARY-FORMAT-SECTION--
-                   Content-Type: application/octet-stream;
-                       conversions="X-CBF_PACKED"
-                   Content-Transfer-Encoding: BASE64
-                   X-Binary-Size: 3801324
-                   X-Binary-ID: 1
-                   X-Binary-Element-Type: "signed 32-bit integer"
-                   Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
 
-AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
-                   ...
-8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
 
-                   --CIF-BINARY-FORMAT-SECTION----
-                   ;
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
 ;
 ;
          Example 3. Example 2 revised for a spiral scan (R. M. Sweet,
@@ -9261,17 +10450,58 @@ AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
          The two axes are coupled to form an axis set ELEMENT_SPIRAL.
 ;
 
+    _nx_mapping.details
+;    _diffrn_scan.id SCANID
+    _diffrn_scan.date_end ENDDATETIME
+    _diffrn_scan.date_end_estimated ENDDATETIMEEST
+    _diffrn_scan.date_start STARTDATETIME
+    _diffrn_scan.integration_time AVGCOUNTTIME
+    _diffrn_scan.frame_id_start FRAMESTARTID
+    _diffrn_scan.frame_id_end FRAMEENDID
+    _diffrn_scan.frames FRAMES
+    _diffrn_scan.time_period TIMEPER
+    _diffrn_scan.time_rstrt_incr RSTRTTIME
+
+    -->
+
+        /entry:NXentry
+          /CBF_scan_id="SCANID"
+          /end_time=ENDDATETIME
+          /end_time_estimated=ENDDATETIMEEST
+          /start_time=STARTDATETIME
+          /average_count_time=AVGCOUNTTIME
+            @units="sec"
+          /average_frame_time=TIMEPER
+            @units="sec"
+          /average_frame_restart_time=RSTRTTIME
+            @units="sec"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /frame_start_number=FRAMESTARTNO
+              /frame_end_number=FRAMEENDNO
+
+    FRAMESTARTNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMESTARTID
+    FRAMEENDNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMEENDID   
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
 save_
 
 save_diffrn_scan.date_end
 
     _definition.id                '_diffrn_scan.date_end'
     _description.text
-;
-    The date and time of the end of the scan.  Note that this
-     may be an estimate generated during the scan, before the
-     precise time of the end of the scan is known, in which
-     case _diffrn_scan.date_end_estimated  should be used instead.
+;             The date and time of the end of the scan.  Note that this
+              may be an estimate generated during the scan, before the
+              precise time of the end of the scan is known, in which
+              case _diffrn_scan.date_end_estimated should be used instead.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_end
@@ -9288,10 +10518,9 @@ save_diffrn_scan.date_end_estimated
 
     _definition.id                '_diffrn_scan.date_end_estimated'
     _description.text
-;
-    The estimated date and time of the end of the scan.  Note
-     that this may be generated at the start or during the scan,
-     before the precise time of the end of the scan is known.
+;             The estimated date and time of the end of the scan.  Note 
+              that this may be generated at the start or during the scan,
+              before the precise time of the end of the scan is known.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_end_estimated
@@ -9308,8 +10537,7 @@ save_diffrn_scan.date_start
 
     _definition.id                '_diffrn_scan.date_start'
     _description.text
-;
-    The date and time of the start of the scan.
+;             The date and time of the start of the scan.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_start
@@ -9325,19 +10553,10 @@ save_
 save_diffrn_scan.diffrn_id
 
     _definition.id                '_diffrn_scan.diffrn_id'
-    _definition.update            2022-05-27
-    _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
-;
     _name.category_id             diffrn_scan
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
+    _name.ddl2_mandatory          implicit
 
 save_
 
@@ -9345,12 +10564,11 @@ save_diffrn_scan.frame_id_end
 
     _definition.id                '_diffrn_scan.frame_id_end'
     _description.text
-;
-    The value of this data item is the identifier of the
-     last frame in the scan.
+;             The value of this data item is the identifier of the
+              last frame in the scan.
 
-     This item is a pointer to _diffrn_data_frame.id  in the
-     DIFFRN_DATA_FRAME  category.
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               frame_id_end
@@ -9368,12 +10586,11 @@ save_diffrn_scan.frame_id_start
 
     _definition.id                '_diffrn_scan.frame_id_start'
     _description.text
-;
-    The value of this data item is the identifier of the
-     first frame in the scan.
+;             The value of this data item is the identifier of the
+              first frame in the scan.
 
-     This item is a pointer to _diffrn_data_frame.id  in the
-     DIFFRN_DATA_FRAME  category.
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               frame_id_start
@@ -9391,9 +10608,8 @@ save_diffrn_scan.frames
 
     _definition.id                '_diffrn_scan.frames'
     _description.text
-;
-    The value of this data item is the number of frames in
-     the scan.
+;             The value of this data item is the number of frames in
+              the scan.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               frames
@@ -9404,6 +10620,13 @@ save_diffrn_scan.frames
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
 
 save_
 
@@ -9411,16 +10634,15 @@ save_diffrn_scan.id
 
     _definition.id                '_diffrn_scan.id'
     _description.text
-;
-    The value of _diffrn_scan.id  uniquely identifies each
-     scan.  The identifier is used to tie together all the
-     information about the scan.
+;             The value of _diffrn_scan.id uniquely identifies each
+              scan.  The identifier is used to tie together all the
+              information about the scan.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -9431,12 +10653,11 @@ save_diffrn_scan.integration_time
 
     _definition.id                '_diffrn_scan.integration_time'
     _description.text
-;
-    Approximate average time in seconds to integrate each
-     step of the scan.  The precise time for integration
-     of each particular step must be provided in
-     _diffrn_scan_frame.integration_time, even
-     if all steps have the same integration time.
+;             Approximate average time in seconds to integrate each
+              step of the scan.  The precise time for integration
+              of each particular step must be provided in
+              _diffrn_scan_frame.integration_time, even
+              if all steps have the same integration time.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               integration_time
@@ -9448,6 +10669,8 @@ save_diffrn_scan.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -9455,11 +10678,10 @@ save_diffrn_scan.time_period
 
     _definition.id                '_diffrn_scan.time_period'
     _description.text
-;
-    Approximate average time in seconds between the start
-     of each step of the scan.  The precise start-to-start
-     time increment of each particular step may be provided in
-     _diffrn_scan_frame.time_period.
+;             Approximate average time in seconds between the start
+              of each step of the scan.  The precise start-to-start
+              time increment of each particular step may be provided in
+              _diffrn_scan_frame.time_period.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               time_period
@@ -9471,6 +10693,8 @@ save_diffrn_scan.time_period
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -9478,23 +10702,22 @@ save_diffrn_scan.time_rstrt_incr
 
     _definition.id                '_diffrn_scan.time_rstrt_incr'
     _description.text
-;
-    Approximate average time in seconds between the end
-     of integration of each step of the scan and the start
-     of integration of the next step.
+;             Approximate average time in seconds between the end
+              of integration of each step of the scan and the start
+              of integration of the next step.
 
-     In general, this will agree with
-     _diffrn_scan_frame.time_rstrt_incr .  The
-     sum of the values of _diffrn_scan_frame.integration_time
-     and  _diffrn_scan_frame.time_rstrt_incr  is the
-     time from the start of integration of one frame and the start of
-     integration for the next frame and should equal the value of
-     _diffrn_scan_frame.time_period  for this
-     frame.   If the individual frame values vary, then the value of
-     _diffrn_scan.time_rstrt_incr  will be
-     representative of the ensemble of values of
-     _diffrn_scan_frame.time_rstrt_incr  (e.g.
-     the mean).
+              In general, this will agree with
+              _diffrn_scan_frame.time_rstrt_incr.  The
+              sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period for this
+              frame.   If the individual frame values vary, then the value of
+              _diffrn_scan.time_rstrt_incr will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr (e.g.
+              the mean).
 ;
     _name.category_id             diffrn_scan
     _name.object_id               time_rstrt_incr
@@ -9506,6 +10729,8 @@ save_diffrn_scan.time_rstrt_incr
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -9513,15 +10738,14 @@ save_diffrn_scan.variant
 
     _definition.id                '_diffrn_scan.variant'
     _description.text
-;
-    The value of _diffrn_scan.variant  gives the variant
-     to which the given DIFFRN_SCAN row is related.
+;             The value of _diffrn_scan.variant gives the variant
+              to which the given DIFFRN_SCAN row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               variant
@@ -9538,18 +10762,17 @@ save_
 
 save_DIFFRN_SCAN_AXIS
 
-    _definition.id                DIFFRN_SCAN_AXIS
+    _definition.id                diffrn_scan_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN_AXIS  category describe the settings of
+    Data items in the DIFFRN_SCAN_AXIS category describe the settings of
      axes for particular scans.  Unspecified axes are assumed to be at
      their zero points.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN_AXIS
+    _name.object_id               diffrn_scan_axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -9557,7 +10780,53 @@ save_DIFFRN_SCAN_AXIS
          '_diffrn_scan_axis.scan_id'
          '_diffrn_scan_axis.axis_id'
          '_diffrn_scan_axis.variant'
-         '_diffrn_scan_axis.diffrn_id'
+
+    _nx_mapping.details
+;    _diffrn_scan_axis.axis_id AXISID-->
+    _diffrn_scan_axis.angle_start ANGSTART
+    _diffrn_scan_axis.angle_range ANGRANGE 
+    _diffrn_scan_axis.angle_increment ANGINC 
+    _diffrn_scan_axis.angle_rstrt_incr ANGRSTRT 
+    _diffrn_scan_axis.displacement_start DISPSTART 
+    _diffrn_scan_axis.displacement_range DISPRANGE 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_rstrt_incr DISPRSTRT 
+    _diffrn_scan_axis.reference_angle ANG 
+    _diffrn_scan_axis.reference_displacement DISP 
+    _diffrn_scan_axis.scan_id SCANID
+
+    -->
+
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_axis__angle_start=ANGSTART
+             @diffrn_scan_axis__angle_range=ANGRANGE
+             @diffrn_scan_axis__angle_increment=ANGINC
+             @diffrn_scan_axis__angle_rstrt_incr=ANGRSTRT
+             @diffrn_scan_axis__displacement_start=DISPSTART
+             @diffrn_scan_axis__displacement_range=DISPRANGE
+             @diffrn_scan_axis__displacement_increment=DISPINC
+             @diffrn_scan_axis__displacement_rstrt_incr=DISPRSTRT
+             @diffrn_scan_axis__reference_angle=ANG
+             @diffrn_scan_axis__reference_displacement=DISP
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -9565,20 +10834,19 @@ save_diffrn_scan_axis.angle_increment
 
     _definition.id                '_diffrn_scan_axis.angle_increment'
     _description.text
-;
-    The increment for each step for the specified axis
-     in degrees.  In general, this will agree with
-     _diffrn_scan_frame_axis.angle_increment . The
-     sum of the values of _diffrn_scan_frame_axis.angle  and
-     _diffrn_scan_frame_axis.angle_increment  is the
-     angular setting of the axis at the end of the integration
-     time for a given frame.  If the individual frame values
-     vary, then the value of
-     _diffrn_scan_axis.angle_increment  will be
-     representative
-     of the ensemble of values of
-     _diffrn_scan_frame_axis.angle_increment  (e.g.
-     the mean).
+;             The increment for each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_increment. The
+              sum of the values of _diffrn_scan_frame_axis.angle and
+              _diffrn_scan_frame_axis.angle_increment is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_increment will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_increment (e.g.
+              the mean).
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_increment
@@ -9598,9 +10866,8 @@ save_diffrn_scan_axis.angle_range
 
     _definition.id                '_diffrn_scan_axis.angle_range'
     _description.text
-;
-    The range from the starting position for the specified axis
-     in degrees.
+;             The total range covered during the scan from the starting position 
+              to the end of the final step for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_range
@@ -9620,23 +10887,22 @@ save_diffrn_scan_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.angle_rstrt_incr'
     _description.text
-;
-    The increment after each step for the specified axis
-     in degrees.  In general, this will agree with
-     _diffrn_scan_frame_axis.angle_rstrt_incr .  The
-     sum of the values of _diffrn_scan_frame_axis.angle,
-     _diffrn_scan_frame_axis.angle_increment
-     and  _diffrn_scan_frame_axis.angle_rstrt_incr  is the
-     angular setting of the axis at the start of the integration
-     time for the next frame relative to a given frame and
-     should equal _diffrn_scan_frame_axis.angle  for this
-     next frame.   If the individual frame values
-     vary, then the value of
-     _diffrn_scan_axis.angle_rstrt_incr  will be
-     representative
-     of the ensemble of values of
-     _diffrn_scan_frame_axis.angle_rstrt_incr  (e.g.
-     the mean).
+;             The increment after each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_rstrt_incr.  The
+              sum of the values of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment
+              and  _diffrn_scan_frame_axis.angle_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.angle for this
+              next frame.   If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_rstrt_incr will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_rstrt_incr (e.g.
+              the mean).
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_rstrt_incr
@@ -9656,8 +10922,7 @@ save_diffrn_scan_axis.angle_start
 
     _definition.id                '_diffrn_scan_axis.angle_start'
     _description.text
-;
-    The starting position for the specified axis in degrees.
+;             The starting position for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_start
@@ -9677,15 +10942,14 @@ save_diffrn_scan_axis.axis_id
 
     _definition.id                '_diffrn_scan_axis.axis_id'
     _description.text
-;
-    The value of this data item is the identifier of one of
-     the axes for the scan for which settings are being specified.
+;             The value of this data item is the identifier of one of
+              the axes for the scan for which settings are being specified.
 
-     Multiple axes may be specified for the same value of
-     _diffrn_scan.id.
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
 
-     This item is a pointer to _axis.id  in the
-     AXIS category.
+              This item is a pointer to _axis.id in the
+              AXIS category.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               axis_id
@@ -9702,19 +10966,18 @@ save_
 save_diffrn_scan_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_axis.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -9722,20 +10985,19 @@ save_diffrn_scan_axis.displacement_increment
 
     _definition.id                '_diffrn_scan_axis.displacement_increment'
     _description.text
-;
-    The increment for each step for the specified axis
-     in millimetres.  In general, this will agree with
-     _diffrn_scan_frame_axis.displacement_increment.
-     The sum of the values of
-     _diffrn_scan_frame_axis.displacement  and
-     _diffrn_scan_frame_axis.displacement_increment  is the
-     angular setting of the axis at the end of the integration
-     time for a given frame.  If the individual frame values
-     vary, then the value of
-      _diffrn_scan_axis.displacement_increment  will be
-     representative of the ensemble of values of
-      _diffrn_scan_frame_axis.displacement_increment  (e.g.
-      the mean).
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_increment.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement and
+              _diffrn_scan_frame_axis.displacement_increment is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+               _diffrn_scan_axis.displacement_increment will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_increment (e.g.
+               the mean).
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_increment
@@ -9755,9 +11017,8 @@ save_diffrn_scan_axis.displacement_range
 
     _definition.id                '_diffrn_scan_axis.displacement_range'
     _description.text
-;
-    The range from the starting position for the specified axis
-     in millimetres.
+;             The range from the starting position for the specified axis
+              in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_range
@@ -9777,23 +11038,22 @@ save_diffrn_scan_axis.displacement_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.displacement_rstrt_incr'
     _description.text
-;
-    The increment for each step for the specified axis
-     in millimetres.  In general, this will agree with
-     _diffrn_scan_frame_axis.displacement_rstrt_incr.
-     The sum of the values of
-     _diffrn_scan_frame_axis.displacement,
-     _diffrn_scan_frame_axis.displacement_increment  and
-     _diffrn_scan_frame_axis.displacement_rstrt_incr  is the
-     angular setting of the axis at the start of the integration
-     time for the next frame relative to a given frame and
-     should equal _diffrn_scan_frame_axis.displacement
-     for this next frame.  If the individual frame values
-     vary, then the value of
-     _diffrn_scan_axis.displacement_rstrt_incr  will be
-     representative of the ensemble of values of
-      _diffrn_scan_frame_axis.displacement_rstrt_incr  (e.g.
-      the mean).
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_rstrt_incr.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.displacement
+              for this next frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.displacement_rstrt_incr will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_rstrt_incr (e.g.
+               the mean).
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_rstrt_incr
@@ -9813,8 +11073,7 @@ save_diffrn_scan_axis.displacement_start
 
     _definition.id                '_diffrn_scan_axis.displacement_start'
     _description.text
-;
-    The starting position for the specified axis in millimetres.
+;             The starting position for the specified axis in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_start
@@ -9834,21 +11093,20 @@ save_diffrn_scan_axis.reference_angle
 
     _definition.id                '_diffrn_scan_axis.reference_angle'
     _description.text
-;
-    The setting of the specified axis in degrees
-     against which measurements of the reference beam centre
-     and reference detector distance should be made.
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
 
-     In general, this will agree with
-     _diffrn_scan_frame_axis.reference_angle.
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_angle.
 
-     If the individual frame values vary, then the value of
-     _diffrn_scan_axis.reference_angle  will be
-     representative of the ensemble of values of
-     _diffrn_scan_frame_axis.reference_angle  (e.g.
-     the mean).
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_angle will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_angle (e.g.
+              the mean).
 
-     If not specified, the value defaults to zero.
+              If not specified, the value defaults to zero.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               reference_angle
@@ -9868,19 +11126,19 @@ save_diffrn_scan_axis.reference_displacement
 
     _definition.id                '_diffrn_scan_axis.reference_displacement'
     _description.text
-;
-    The setting of the specified axis in millimetres
-     against which measurements of the reference beam centre
-     and reference detector distance should be made.
+;             The setting of the specified axis in millimetres
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
 
-     In general, this will agree with
-     _diffrn_scan_frame_axis.reference_displacement.
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_displacement.
 
-     If the individual frame values vary, then the value of
-     _diffrn_scan_axis.reference_displacement  will be
-     representative of the ensemble of values of
-     _diffrn_scan_frame_axis.reference_displacement  (e.g.
-     the mean).
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_displacement will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_displacement (e.g.
+              the mean).
+
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               reference_displacement
@@ -9899,15 +11157,14 @@ save_diffrn_scan_axis.scan_id
 
     _definition.id                '_diffrn_scan_axis.scan_id'
     _description.text
-;
-    The value of this data item is the identifier of the
-     scan for which axis settings are being specified.
+;             The value of this data item is the identifier of the
+              scan for which axis settings are being specified.
 
-     Multiple axes may be specified for the same value of
-     _diffrn_scan.id.
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
 
-     This item is a pointer to _diffrn_scan.id  in the
-     DIFFRN_SCAN  category.
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               scan_id
@@ -9925,15 +11182,14 @@ save_diffrn_scan_axis.variant
 
     _definition.id                '_diffrn_scan_axis.variant'
     _description.text
-;
-    The value of _diffrn_scan_axis.variant  gives the variant
-     to which the given DIFFRN_SCAN_AXIS row is related.
+;             The value of _diffrn_scan_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_AXIS row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               variant
@@ -9950,41 +11206,58 @@ save_
 
 save_DIFFRN_SCAN_COLLECTION
 
-    _definition.id                DIFFRN_SCAN_COLLECTION
+    _definition.id                diffrn_scan_collection
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN_COLLECTION  category describe
+    Data items in the DIFFRN_SCAN_COLLECTION category describe
      the collection strategy for each scan.
 
      This category is a preliminary version being developed as
      synchrotron and XFEL collection strategies evolve.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN_COLLECTION
+    _name.object_id               diffrn_scan_collection
     _name.ddl2_mandatory          no
 
     loop_
       _category_key.name
          '_diffrn_scan_collection.scan_id'
          '_diffrn_scan_collection.variant'
-         '_diffrn_scan_collection.diffrn_id'
 
     _description_example.case
         'Example 1 - Describing a multi-wedge raster scan.'
     _description_example.detail
-;
-        loop_
+;        loop_
         _diffrn_scan_collection.scan_id
         _diffrn_scan_collection.details
-
+       
         multi_wedge
     ;   scan 20 micrometre beam in 100 micrometre steps on 31
-        by 46 alternating raster of 20 degree wedges
+        by 46 alternating raster of 20 degree wedges 
     ;
 ;
+    _nx_mapping.details
+;    _diffrn_scan_collection.type  COLLECTIONTYPE
+    _diffrn_scan_collection.translation_width TRANSLATION_WIDTH
+
+    --> 
+
+    /entry:NXentry
+      /CBF_cbf:NXpdb
+        /image1:NXpdb
+          @NXpdb="CBF_cbfdb"
+          /diffrn_scan_collection:NXpdb
+            @NXpdb="CBF_cbfcat"
+              /type=["COLLECTIONTYP"]
+              /translation_width=["TRANSLATION_WIDTH"]
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -9992,9 +11265,8 @@ save_diffrn_scan_collection.details
 
     _definition.id                '_diffrn_scan_collection.details'
     _description.text
-;
-    The value of _diffrn_scan_collection.details  should give a
-     description of special aspects of each collection strategy.
+;             The value of _diffrn_scan_collection.details should give a
+              description of special aspects of each collection strategy.
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               details
@@ -10010,19 +11282,19 @@ save_
 save_diffrn_scan_collection.diffrn_id
 
     _definition.id                '_diffrn_scan_collection.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -10030,14 +11302,13 @@ save_diffrn_scan_collection.scan_id
 
     _definition.id                '_diffrn_scan_collection.scan_id'
     _description.text
-;
-    The value of _diffrn_scan_collection.scan_id  identifies the scan
-     containing this frame.
+;             The value of _diffrn_scan_collection.scan_id identifies the scan
+              containing this frame.
 
-     This item is a pointer to _diffrn_scan.id  in the
-     DIFFRN_SCAN  category.
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
 
-     In the case of a single-scan dataset, the value is implicit.
+              In the case of a single-scan dataset, the value is implicit.
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               scan_id
@@ -10054,11 +11325,10 @@ save_diffrn_scan_collection.translation_width
 
     _definition.id                '_diffrn_scan_collection.translation_width'
     _description.text
-;
-    The value of _diffrn_scan_collection.translation_width
-     gives the average single step translation in micrometres
-     in collection strategies for which this information is
-      appropriate, e.g. 'vector'.
+;             The value of _diffrn_scan_collection.translation_width
+              gives the average single step translation in micrometres
+              in collection strategies for which this information is
+               appropriate, e.g. 'vector'.
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               translation_width
@@ -10078,12 +11348,11 @@ save_diffrn_scan_collection.type
 
     _definition.id                '_diffrn_scan_collection.type'
     _description.text
-;
-    The value of _diffrn_scan_collection.type  identifies
-     the strategy used in this scan, e.g. `rotation', 'raster',
-     'vector', 'still', etc.
+;             The value of _diffrn_scan_collection.type identifies
+              the strategy used in this scan, e.g. `rotation', 'raster',
+              'vector', 'still', etc.
 
-     The default is 'rotation'.
+              The default is 'rotation'. 
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               type
@@ -10101,15 +11370,14 @@ save_diffrn_scan_collection.variant
 
     _definition.id                '_diffrn_scan_collection.variant'
     _description.text
-;
-    The value of _diffrn_scan_collection.variant  gives the variant
-     to which the given DIFFRN_SCAN_COLLECTION row is related.
+;             The value of _diffrn_scan_collection.variant gives the variant
+              to which the given DIFFRN_SCAN_COLLECTION row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan_collection
     _name.object_id               variant
@@ -10126,17 +11394,16 @@ save_
 
 save_DIFFRN_SCAN_FRAME
 
-    _definition.id                DIFFRN_SCAN_FRAME
+    _definition.id                diffrn_scan_frame
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN_FRAME  category describe
+    Data items in the DIFFRN_SCAN_FRAME category describe
      the relationships of particular frames to scans.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME
+    _name.object_id               diffrn_scan_frame
     _name.ddl2_mandatory          no
 
     loop_
@@ -10144,7 +11411,43 @@ save_DIFFRN_SCAN_FRAME
          '_diffrn_scan_frame.scan_id'
          '_diffrn_scan_frame.frame_id'
          '_diffrn_scan_frame.variant'
-         '_diffrn_scan_frame.diffrn_id'
+
+    _nx_mapping.details
+;    _diffrn_scan_frame.date  DATETIME
+    _diffrn_scan_frame.frame_id ID
+    _diffrn_scan_frame.frame_number FRAMENUMBER
+    _diffrn_scan_frame.integration_time COUNTTIME
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.scan_id SCANID
+    _diffrn_scan_frame.time_period FRAMETIME
+    _diffrn_scan_frame.time_rstrt_incr RSTRTTIME
+
+    --> 
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_scan_frame__date=["DATETIME"]
+          /CBF_diffrn_scan_frame__frame_id=["ID"]
+          /count_time=[COUNTIME]
+          /frame_time=[FRAMETIME]
+          /frame_restart_time=[RSTRTTIME]
+      /sample:NXsample
+        /beam:NXbeam
+          /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             @units="Watts/meter^2"
+     where each array element is inserted at index FRAMENUMBER          
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -10152,8 +11455,7 @@ save_diffrn_scan_frame.date
 
     _definition.id                '_diffrn_scan_frame.date'
     _description.text
-;
-    The date and time of the start of the frame being scanned.
+;             The date and time of the start of the frame being scanned.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               date
@@ -10169,19 +11471,19 @@ save_
 save_diffrn_scan_frame.diffrn_id
 
     _definition.id                '_diffrn_scan_frame.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -10189,12 +11491,11 @@ save_diffrn_scan_frame.frame_id
 
     _definition.id                '_diffrn_scan_frame.frame_id'
     _description.text
-;
-    The value of this data item is the identifier of the
-     frame being examined.
+;             The value of this data item is the identifier of the
+              frame being examined.
 
-     This item is a pointer to _diffrn_data_frame.id  in the
-     DIFFRN_DATA_FRAME  category.
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               frame_id
@@ -10212,11 +11513,11 @@ save_diffrn_scan_frame.frame_number
 
     _definition.id                '_diffrn_scan_frame.frame_number'
     _description.text
-;
-    The value of this data item is the number of the frame
-     within the scan, starting with 1.  It is not necessarily
-     the same as the value of _diffrn_scan_frame.frame_id,
-     but it may be.
+;             The value of this data item is the number of the frame
+              within the scan, starting with 1.  It is not necessarily
+              the same as the value of _diffrn_scan_frame.frame_id,
+              but it may be.
+
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               frame_number
@@ -10227,6 +11528,13 @@ save_diffrn_scan_frame.frame_number
     _type.contents                Integer
     _type.ddl2_code               int
     _enumeration.range            0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0                        .
+         0                        0
 
 save_
 
@@ -10234,12 +11542,11 @@ save_diffrn_scan_frame.integration_time
 
     _definition.id                '_diffrn_scan_frame.integration_time'
     _description.text
-;
-    The time in seconds to integrate this step of the scan.
-     This should be the precise time of integration of each
-     particular frame.  The value of this data item should
-     be given explicitly for each frame and not inferred
-     from the value of _diffrn_scan.integration_time.
+;             The time in seconds to integrate this step of the scan.
+              This should be the precise time of integration of each
+              particular frame.  The value of this data item should
+              be given explicitly for each frame and not inferred
+              from the value of _diffrn_scan.integration_time.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               integration_time
@@ -10251,6 +11558,8 @@ save_diffrn_scan_frame.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10258,33 +11567,32 @@ save_diffrn_scan_frame.polarizn_stokes_i
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I'
     _description.text
-;
-    The quantity Ip+In+Inp, where Ip is the intensity (amplitude
-     squared) of the electric vector in the plane of polarization,
-     In is the intensity (amplitude squared) of the electric vector
-     in the plane of the normal to the plane of polarization,
-     and Inp is the intensity (amplitude squared) of the
-     non-polarized (incoherent) electric vector.
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
 
-     This is an average or other representative sample of the
-     frame.
+              This is an average or other representative sample of the
+              frame.
 
-     This is the first of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Note that, if the polarized intensity Ip+In is required,
-     (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200--3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_I
@@ -10296,6 +11604,13 @@ save_diffrn_scan_frame.polarizn_stokes_i
     _type.ddl2_code               float
     _enumeration.range            0.0:
     _enumeration.default          1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
 
 save_
 
@@ -10303,15 +11618,14 @@ save_diffrn_scan_frame.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_scan_frame.polarizn_Stokes_I,
-     Ip+In+Inp, where Ip is the intensity (amplitude squared)
-     of the electric vector in the plane of polarization,
-     In is the intensity (amplitude squared) of the electric vector
-     in the plane of the normal to the plane of polarization,
-     and Inp is the intensity (amplitude squared) of the
-     non-polarized (incoherent) electric vector.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_I_esd
@@ -10322,6 +11636,16 @@ save_diffrn_scan_frame.polarizn_stokes_i_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_I'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -10329,32 +11653,31 @@ save_diffrn_scan_frame.polarizn_stokes_q
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q'
     _description.text
-;
-    The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     frame.
+              This is an average or other representative sample of the
+              frame.
 
-     This is the second of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200--3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_Q
@@ -10364,6 +11687,7 @@ save_diffrn_scan_frame.polarizn_stokes_q
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -10371,17 +11695,16 @@ save_diffrn_scan_frame.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_scan_frame.polarizn_Stokes_Q,
-     (Ip-In)*cos(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y-axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_Q_esd
@@ -10392,6 +11715,16 @@ save_diffrn_scan_frame.polarizn_stokes_q_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_Q'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -10399,32 +11732,31 @@ save_diffrn_scan_frame.polarizn_stokes_u
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U'
     _description.text
-;
-    The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     frame.
+              This is an average or other representative sample of the
+              frame.
 
-     This is the third of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)]
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)]
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200--3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_U
@@ -10434,6 +11766,7 @@ save_diffrn_scan_frame.polarizn_stokes_u
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -10441,17 +11774,16 @@ save_diffrn_scan_frame.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_scan_frame.polarizn_Stokes_U,
-     (Ip-In)*sin(2*theta), where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization, In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y-axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_U_esd
@@ -10462,6 +11794,16 @@ save_diffrn_scan_frame.polarizn_stokes_u_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_U'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -10469,33 +11811,32 @@ save_diffrn_scan_frame.polarizn_stokes_v
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V'
     _description.text
-;
-    The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
-     circular polarization, where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y axis as defined in the
-     AXIS  category.
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
 
-     This is an average or other representative sample of the
-     frame.
+              This is an average or other representative sample of the
+              frame.
 
-     This is the fourth of the Stokes polarization parameters,
-     I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
 
-     If the absolute intensity is not known, the value 1.0
-     is assumed for I, and all four Stokes parameters are
-     dimensionless.  When the absolute intensity is known,
-     all four Stokes parameters are in units of watts per
-     square metre.
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
 
-     Reference:
-     Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
-     'Measurement of the Stokes parameters of light',
-     Appl. Optics, 16:12, 3200--3205.
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_V
@@ -10505,6 +11846,7 @@ save_diffrn_scan_frame.polarizn_stokes_v
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
 
 save_
 
@@ -10512,18 +11854,17 @@ save_diffrn_scan_frame.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V_esd'
     _description.text
-;
-    The standard uncertainty (estimated standard deviation, e.s.d.)
-     of _diffrn_scan_frame.polarizn_Stokes_V,
-     +/-2*sqrt(IpIn), with a + sign for right-handed circular
-     polarization, where Ip is the intensity
-     (amplitude squared) of the electric vector in the plane of
-     polarization and In is the intensity (amplitude squared) of
-     the electric vector in the plane of the normal to the
-     plane of polarization, and theta is the angle as viewed
-     from the specimen, between the normal to the polarization
-     plane and the laboratory Y-axis as defined in the
-     AXIS  category.
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               polarizn_Stokes_V_esd
@@ -10534,6 +11875,16 @@ save_diffrn_scan_frame.polarizn_stokes_v_esd
     _type.contents                Real
     _type.ddl2_code               float
     _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_V'
+    _ddl2_item_related.function_code associated_value
 
 save_
 
@@ -10541,12 +11892,11 @@ save_diffrn_scan_frame.scan_id
 
     _definition.id                '_diffrn_scan_frame.scan_id'
     _description.text
-;
-    The value of _diffrn_scan_frame.scan_id  identifies the scan
-     containing this frame.
+;             The value of _diffrn_scan_frame.scan_id identifies the scan
+              containing this frame.
 
-     This item is a pointer to _diffrn_scan.id  in the
-     DIFFRN_SCAN  category.
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               scan_id
@@ -10564,10 +11914,9 @@ save_diffrn_scan_frame.time_period
 
     _definition.id                '_diffrn_scan_frame.time_period'
     _description.text
-;
-    The time in seconds between the start of this frame and the
-     start of the next frame, if any.  If there is no next frame,
-     a null value should be given.
+;             The time in seconds between the start of this frame and the
+              start of the next frame, if any.  If there is no next frame,
+              a null value should be given.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               time_period
@@ -10579,6 +11928,8 @@ save_diffrn_scan_frame.time_period
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10586,21 +11937,20 @@ save_diffrn_scan_frame.time_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame.time_rstrt_incr'
     _description.text
-;
-    The time in seconds between the end of integration of this step of the scan
-     and the start of integration of the next step.
+;             The time in seconds between the end of integration of this step of the scan
+              and the start of integration of the next step.
 
-     The sum of the values of _diffrn_scan_frame.integration_time
-     and  _diffrn_scan_frame.time_rstrt_incr  is the
-     time from the start of integration of one frame and the start of
-     integration for the next frame and should equal the value of
-     _diffrn_scan_frame.time_period  for this
-     frame.   The value of _diffrn_scan.time_rstrt_incr  will be
-     representative of the ensemble of values of
-     _diffrn_scan_frame.time_rstrt_incr  (e.g.
-     the mean).
+              The sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period for this
+              frame.   The value of _diffrn_scan.time_rstrt_incr will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr (e.g.
+              the mean).
 
-     If there is no next frame, a null value should be given.
+              If there is no next frame, a null value should be given.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               time_rstrt_incr
@@ -10612,6 +11962,8 @@ save_diffrn_scan_frame.time_rstrt_incr
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -10619,15 +11971,14 @@ save_diffrn_scan_frame.variant
 
     _definition.id                '_diffrn_scan_frame.variant'
     _description.text
-;
-    The value of _diffrn_scan_frame.variant  gives the variant
-     to which the given DIFFRN_SCAN_FRAME row is related.
+;             The value of _diffrn_scan_frame.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               variant
@@ -10644,13 +11995,12 @@ save_
 
 save_DIFFRN_SCAN_FRAME_AXIS
 
-    _definition.id                DIFFRN_SCAN_FRAME_AXIS
+    _definition.id                diffrn_scan_frame_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN_FRAME_AXIS  category describe the
+    Data items in the DIFFRN_SCAN_FRAME_AXIS category describe the
      settings of axes for particular frames.  Unspecified axes are
      assumed to be at their zero points.  If, for any given frame,
      nonzero values apply for any of the data items in this category,
@@ -10658,7 +12008,7 @@ save_DIFFRN_SCAN_FRAME_AXIS
      simply inferred from values in DIFFRN_SCAN_AXIS.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME_AXIS
+    _name.object_id               diffrn_scan_frame_axis
     _name.ddl2_mandatory          no
 
     loop_
@@ -10666,7 +12016,58 @@ save_DIFFRN_SCAN_FRAME_AXIS
          '_diffrn_scan_frame_axis.frame_id'
          '_diffrn_scan_frame_axis.axis_id'
          '_diffrn_scan_frame_axis.variant'
-         '_diffrn_scan_frame_axis.diffrn_id'
+
+    _nx_mapping.details
+;    _diffrn_scan_frame_axis.axis_id AXISID
+    _diffrn_scan_frame_axis.angle ANGLE
+    _diffrn_scan_frame_axis.angle_increment ANGLEINCREMENT
+    _diffrn_scan_frame_axis.angle_rstrt_incr ANGLERSTRTINCREMENT
+    _diffrn_scan_frame_axis.displacement DISP 
+    _diffrn_scan_frame_axis.displacement_increment DISPINCREMENT
+    _diffrn_scan_frame_axis.displacement_rstrt_incr DISPRSTRTINCREMENT
+    _diffrn_scan_frame_axis.reference_angle REFANGLE
+    _diffrn_scan_frame_axis.reference_displacement REFDISP
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /entry:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /entry:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_frame_axis__angle_start=[ANGSTART]
+             @diffrn_scan_frame_axis__angle_range=[ANGRANGE]
+             @diffrn_scan_frame_axis__angle_increment=[ANGINC]
+             @diffrn_scan_frame_axis__angle_rstrt_incr=[ANGRSTRT]
+             @diffrn_scan_frame_axis__displacement_start=[DISPSTART]
+             @diffrn_scan_frame_axis__displacement_range=[DISPRANGE]
+             @diffrn_scan_frame_axis__displacement_increment=[DISPINC]
+             @diffrn_scan_frame_axis__displacement_rstrt_incr=[DISPRSTRT]
+             @diffrn_scan_frame_axis__reference_angle=[ANG]
+             @diffrn_scan_frame_axis__reference_displacement=[DISP]
+    note that @units="mm" or @units="deg" should also be specified.
+
+    The dimensions of the array depend on np (the number of frames = the
+    value of _diffrn_scan.frames)
+
+    either DISP OR ANGLE is inserted as the i-th element
+    counting from 1 in AXISID where i is the value of
+    _diffrn_scan_frame.frame_number for which the value
+    of _diffrn_scan_frame.frame_id agrees with the
+    value of _diffrn_scan_frame_axis.frame_id
+
+    The remaining tags similarly populate the attribute arrays
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -10674,9 +12075,8 @@ save_diffrn_scan_frame_axis.angle
 
     _definition.id                '_diffrn_scan_frame_axis.angle'
     _description.text
-;
-    The setting of the specified axis in degrees for this frame.
-     This is the setting at the start of the integration time.
+;             The setting of the specified axis in degrees for this frame.
+              This is the setting at the start of the integration time.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle
@@ -10696,13 +12096,12 @@ save_diffrn_scan_frame_axis.angle_increment
 
     _definition.id                '_diffrn_scan_frame_axis.angle_increment'
     _description.text
-;
-    The increment for this frame for the angular setting of
-     the specified axis in degrees.  The sum of the values
-     of _diffrn_scan_frame_axis.angle  and
-     _diffrn_scan_frame_axis.angle_increment  is the
-     angular setting of the axis at the end of the integration
-     time for this frame.
+;             The increment for this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle and
+              _diffrn_scan_frame_axis.angle_increment is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle_increment
@@ -10722,15 +12121,14 @@ save_diffrn_scan_frame_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame_axis.angle_rstrt_incr'
     _description.text
-;
-    The increment after this frame for the angular setting of
-     the specified axis in degrees.  The sum of the values
-     of _diffrn_scan_frame_axis.angle,
-     _diffrn_scan_frame_axis.angle_increment  and
-     _diffrn_scan_frame_axis.angle_rstrt_incr  is the
-     angular setting of the axis at the start of the integration
-     time for the next frame and should equal
-     _diffrn_scan_frame_axis.angle  for this next frame.
+;             The increment after this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment and
+              _diffrn_scan_frame_axis.angle_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.angle for this next frame.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               angle_rstrt_incr
@@ -10750,15 +12148,14 @@ save_diffrn_scan_frame_axis.axis_id
 
     _definition.id                '_diffrn_scan_frame_axis.axis_id'
     _description.text
-;
-    The value of this data item is the identifier of one of
-     the axes for the frame for which settings are being specified.
+;             The value of this data item is the identifier of one of
+              the axes for the frame for which settings are being specified.
 
-     Multiple axes may be specified for the same value of
-     _diffrn_scan_frame.frame_id.
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
 
-     This item is a pointer to _axis.id  in the
-     AXIS  category.
+              This item is a pointer to _axis.id in the
+              AXIS category.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               axis_id
@@ -10775,19 +12172,19 @@ save_
 save_diffrn_scan_frame_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_axis.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -10795,10 +12192,9 @@ save_diffrn_scan_frame_axis.displacement
 
     _definition.id                '_diffrn_scan_frame_axis.displacement'
     _description.text
-;
-    The setting of the specified axis in millimetres for this
-     frame.  This is the setting at the start of the integration
-     time.
+;             The setting of the specified axis in millimetres for this
+              frame.  This is the setting at the start of the integration
+              time.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement
@@ -10819,13 +12215,12 @@ save_diffrn_scan_frame_axis.displacement_increment
     _definition.id
         '_diffrn_scan_frame_axis.displacement_increment'
     _description.text
-;
-    The increment for this frame for the displacement setting of
-     the specified axis in millimetres.  The sum of the values
-     of _diffrn_scan_frame_axis.displacement  and
-     _diffrn_scan_frame_axis.displacement_increment  is the
-     angular setting of the axis at the end of the integration
-     time for this frame.
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement and
+              _diffrn_scan_frame_axis.displacement_increment is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement_increment
@@ -10846,15 +12241,14 @@ save_diffrn_scan_frame_axis.displacement_rstrt_incr
     _definition.id
         '_diffrn_scan_frame_axis.displacement_rstrt_incr'
     _description.text
-;
-    The increment for this frame for the displacement setting of
-     the specified axis in millimetres.  The sum of the values
-     of _diffrn_scan_frame_axis.displacement,
-     _diffrn_scan_frame_axis.displacement_increment  and
-     _diffrn_scan_frame_axis.displacement_rstrt_incr  is the
-     angular setting of the axis at the start of the integration
-     time for the next frame and should equal
-     _diffrn_scan_frame_axis.displacement  for this next frame.
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.displacement for this next frame.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               displacement_rstrt_incr
@@ -10874,15 +12268,14 @@ save_diffrn_scan_frame_axis.frame_id
 
     _definition.id                '_diffrn_scan_frame_axis.frame_id'
     _description.text
-;
-    The value of this data item is the identifier of the
-     frame for which axis settings are being specified.
+;             The value of this data item is the identifier of the
+              frame for which axis settings are being specified.
 
-     Multiple axes may be specified for the same value of
-     _diffrn_scan_frame.frame_id.
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
 
-     This item is a pointer to _diffrn_data_frame.id  in the
-     DIFFRN_DATA_FRAME  category.
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               frame_id
@@ -10900,16 +12293,15 @@ save_diffrn_scan_frame_axis.reference_angle
 
     _definition.id                '_diffrn_scan_frame_axis.reference_angle'
     _description.text
-;
-    The setting of the specified axis in degrees
-     against which measurements of the reference beam centre
-     and reference detector distance should be made.
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
 
-     This is normally the same for all frames, but the
-     option is provided here of making changes when
-     needed.
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
 
-     If not provided, it is assumed to be zero.
+              If not provided, it is assumed to be zero.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               reference_angle
@@ -10930,17 +12322,16 @@ save_diffrn_scan_frame_axis.reference_displacement
     _definition.id
         '_diffrn_scan_frame_axis.reference_displacement'
     _description.text
-;
-    The setting of the specified axis in millimetres for this
-     frame against which measurements of the reference beam centre
-     and reference detector distance should be made.
+;             The setting of the specified axis in millimetres for this
+              frame against which measurements of the reference beam centre
+              and reference detector distance should be made.
 
-     This is normally the same for all frames, but the
-     option is provided here of making changes when
-     needed.
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
 
-     If not provided, it is assumed to be equal to
-     _diffrn_scan_frame_axis.displacement.
+              If not provided, it is assumed to be equal to
+              _diffrn_scan_frame_axis.displacement.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               reference_displacement
@@ -10959,15 +12350,14 @@ save_diffrn_scan_frame_axis.variant
 
     _definition.id                '_diffrn_scan_frame_axis.variant'
     _description.text
-;
-    The value of _diffrn_scan_frame_axis.variant  gives the variant
-     to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
+;             The value of _diffrn_scan_frame_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan_frame_axis
     _name.object_id               variant
@@ -10984,13 +12374,12 @@ save_
 
 save_DIFFRN_SCAN_FRAME_MONITOR
 
-    _definition.id                DIFFRN_SCAN_FRAME_MONITOR
+    _definition.id                diffrn_scan_frame_monitor
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2022-05-27
     _description.text
 ;
-    Data items in the DIFFRN_SCAN_FRAME_MONITOR  category record
+    Data items in the DIFFRN_SCAN_FRAME_MONITOR category record
      the values and details about each monitor for each frame of data
      during a scan.
 
@@ -11002,7 +12391,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      and a 1-based ordinal given by _diffrn_scan_frame_monitor.id.
 
      If there is only one frame for the scan, the value of
-     _diffrn_scan_frame_monitor.frame_id  may be omitted.
+     _diffrn_scan_frame_monitor.frame_id may be omitted.
 
      A single frame may have more than one monitor value, and each
      monitor value may be the result of integration over the entire
@@ -11012,11 +12401,11 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      by the value of _diffrn_scan_frame_monitor.integration_time.  If
      only one monitor value for a given monitor is collected during
      the integration time of the frame, the value of
-     _diffrn_scan_frame_monitor.id  may be
+     _diffrn_scan_frame_monitor.id may be
      omitted.
 ;
     _name.category_id             HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME_MONITOR
+    _name.object_id               diffrn_scan_frame_monitor
     _name.ddl2_mandatory          no
 
     loop_
@@ -11026,131 +12415,127 @@ save_DIFFRN_SCAN_FRAME_MONITOR
          '_diffrn_scan_frame_monitor.scan_id'
          '_diffrn_scan_frame_monitor.frame_id'
          '_diffrn_scan_frame_monitor.variant'
-         '_diffrn_scan_frame_monitor.diffrn_id'
 
     _description_example.case
-;
-    # category DIFFRN_DETECTOR
-    loop_
-    _diffrn_detector.diffrn_id
-    _diffrn_detector.id
-    _diffrn_detector.type
-    _diffrn_detector.number_of_axes
-     P6MB MAR345-SN26 'MAR 345' 4
-     P6MB BSM01 'metal foil and PIN diode' 1
+;     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+      P6MB BSM01 'metal foil and PIN diode' 1
 
-    # category DIFFRN_DETECTOR_AXIS
-    loop_
-    _diffrn_detector_axis.detector_id
-    _diffrn_detector_axis.axis_id
-     MAR345-SN26 DETECTOR_X
-     MAR345-SN26 DETECTOR_Y
-     MAR345-SN26 DETECTOR_Z
-     MAR345-SN26 DETECTOR_PITCH
-     BSM01 MONITOR_Z
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+      BSM01 MONITOR_Z
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
 
-    # category DIFFRN_DATA_FRAME
-    loop_
-    _diffrn_data_frame.id
-    _diffrn_data_frame.detector_element_id
-    _diffrn_data_frame.array_id
-    _diffrn_data_frame.binary_id
-     FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+      SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
 
-    # category DIFFRN_SCAN
-    loop_
-    _diffrn_scan.id
-    _diffrn_scan.frame_id_start
-    _diffrn_scan.frame_id_end
-    _diffrn_scan.frames
-     SCAN1 FRAME1 FRAME1 1
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
 
-    # category DIFFRN_SCAN_AXIS
-    loop_
-    _diffrn_scan_axis.scan_id
-    _diffrn_scan_axis.axis_id
-    _diffrn_scan_axis.angle_start
-    _diffrn_scan_axis.angle_range
-    _diffrn_scan_axis.angle_increment
-    _diffrn_scan_axis.displacement_start
-    _diffrn_scan_axis.displacement_range
-    _diffrn_scan_axis.displacement_increment
-     SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
-     SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
-     SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
-     SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
-     SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
-     SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
-     SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
-     SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
+     # category DIFFRN_SCAN_FRAME_MONITOR
+     loop_
+     _diffrn_scan_frame_monitor.id
+     _diffrn_scan_frame_monitor.detector_id
+     _diffrn_scan_frame_monitor.scan_id
+     _diffrn_scan_frame_monitor.frame_id
+     _diffrn_scan_frame_monitor.integration_time
+     _diffrn_scan_frame_monitor.monitor_value
+      1  BSM01 SCAN1 FRAME1 2.0 23838345642
+      2  BSM01 SCAN1 FRAME1 2.0 23843170669
+      3  BSM01 SCAN1 FRAME1 2.0 23839478690
+      4  BSM01 SCAN1 FRAME1 2.0 23856642085
+      5  BSM01 SCAN1 FRAME1 2.0 23781717656
+      6  BSM01 SCAN1 FRAME1 2.0 23788850775
+      7  BSM01 SCAN1 FRAME1 2.0 23815576677
+      8  BSM01 SCAN1 FRAME1 2.0 23789299964
+      9  BSM01 SCAN1 FRAME1 2.0 23830195536
+      10 BSM01 SCAN1 FRAME1 2.0 23673082270
 
-    # category DIFFRN_SCAN_FRAME
-    loop_
-    _diffrn_scan_frame.frame_id
-    _diffrn_scan_frame.frame_number
-    _diffrn_scan_frame.integration_time
-    _diffrn_scan_frame.scan_id
-    _diffrn_scan_frame.date
-     FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+      FRAME1 MONITOR_Z 0.0 -220.0
 
-    # category DIFFRN_SCAN_FRAME_MONITOR
-    loop_
-    _diffrn_scan_frame_monitor.id
-    _diffrn_scan_frame_monitor.detector_id
-    _diffrn_scan_frame_monitor.scan_id
-    _diffrn_scan_frame_monitor.frame_id
-    _diffrn_scan_frame_monitor.integration_time
-    _diffrn_scan_frame_monitor.monitor_value
-     1  BSM01 SCAN1 FRAME1 2.0 23838345642
-     2  BSM01 SCAN1 FRAME1 2.0 23843170669
-     3  BSM01 SCAN1 FRAME1 2.0 23839478690
-     4  BSM01 SCAN1 FRAME1 2.0 23856642085
-     5  BSM01 SCAN1 FRAME1 2.0 23781717656
-     6  BSM01 SCAN1 FRAME1 2.0 23788850775
-     7  BSM01 SCAN1 FRAME1 2.0 23815576677
-     8  BSM01 SCAN1 FRAME1 2.0 23789299964
-     9  BSM01 SCAN1 FRAME1 2.0 23830195536
-     10 BSM01 SCAN1 FRAME1 2.0 23673082270
-
-    # category DIFFRN_SCAN_FRAME_AXIS
-    loop_
-    _diffrn_scan_frame_axis.frame_id
-    _diffrn_scan_frame_axis.axis_id
-    _diffrn_scan_frame_axis.angle
-    _diffrn_scan_frame_axis.displacement
-     FRAME1 GONIOMETER_OMEGA 12.0 0.0
-     FRAME1 GONIOMETER_KAPPA 23.3 0.0
-     FRAME1 GONIOMETER_PHI -165.8 0.0
-     FRAME1 DETECTOR_Z 0.0 -240.0
-     FRAME1 DETECTOR_Y 0.0 0.6
-     FRAME1 DETECTOR_X 0.0 -0.5
-     FRAME1 DETECTOR_PITCH 0.0 0.0
-     FRAME1 MONITOR_Z 0.0 -220.0
-
-    # category AXIS
-    loop_
-    _axis.id
-    _axis.type
-    _axis.equipment
-    _axis.depends_on
-    _axis.vector[1] _axis.vector[2] _axis.vector[3]
-    _axis.offset[1] _axis.offset[2] _axis.offset[3]
-     GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
-     GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
-     0 0.76604 . . .
-     GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
-    . . .
-     SOURCE           general source . 0 0 1 . . .
-     GRAVITY          general gravity . 0 -1 0 . . .
-     DETECTOR_Z       translation detector . 0 0 1 0 0 0
-     DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
-     DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
-     DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
-     ELEMENT_X        translation detector DETECTOR_PITCH
-    1 0 0 172.43 -172.43 0
-     ELEMENT_Y        translation detector ELEMENT_X
-    0 1 0 0 0 0
-     MONITOR_Z        translation detector . 0 0 1 0 0 0
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+      MONITOR_Z        translation detector . 0 0 1 0 0 0
 ;
     _description_example.detail
 ;
@@ -11159,6 +12544,30 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      a PIN diode, located 20 mm in front of a MAR345 detector and being
      sampled every 2 seconds in a 20 second scan.
 ;
+    _nx_mapping.details
+;    _diffrn_scan_frame_monitor.id MONID -->
+    _diffrn_scan_frame_monitor.detector_id DETECTORNAME -->
+    _diffrn_scan_frame_monitor.scan_id SCANID -->
+    _diffrn_scan_frame_monitor.frame_id FRAMEID -->
+    _diffrn_scan_frame_monitor.integration_time INTEGRATIONTIME -->
+    _diffrn_scan_frame_monitor.monitor_value MONITORVALUE -->
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+        /instrument:NXinstrument
+          /CBF_diffrn_scan_frame_monitor__DETECTORNAME_MONID:NXmonitor
+            @CBF_detector_id="DETECTORNAME"
+            @CBF_diffrn_scan_frame_monitor__id="MONID"
+            /data=[MONITORVALUE]  
+            /count_time=[INTEGRATIONTIME] 
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
 
 save_
 
@@ -11166,9 +12575,9 @@ save_diffrn_scan_frame_monitor.detector_id
 
     _definition.id                '_diffrn_scan_frame_monitor.detector_id'
     _description.text
-;
-    This data item is a pointer to _diffrn_detector.id  in
-     the DIFFRN_DETECTOR  category.
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
+
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               detector_id
@@ -11185,19 +12594,19 @@ save_
 save_diffrn_scan_frame_monitor.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_monitor.diffrn_id'
-    _definition.update            2022-05-27
     _description.text
-;
-    Identifier for data collection. Values of this item are drawn from values
-    of _diffrn.id.
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
+    _type.ddl2_code               code
 
 save_
 
@@ -11205,9 +12614,8 @@ save_diffrn_scan_frame_monitor.frame_id
 
     _definition.id                '_diffrn_scan_frame_monitor.frame_id'
     _description.text
-;
-    This item is a pointer to _diffrn_data_frame.id
-     in the DIFFRN_DATA_FRAME  category.
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               frame_id
@@ -11225,15 +12633,14 @@ save_diffrn_scan_frame_monitor.id
 
     _definition.id                '_diffrn_scan_frame_monitor.id'
     _description.text
-;
-    This item is an integer identifier which, along with
-     _diffrn_scan_frame_monitor.detector_id,
-     _diffrn_scan_frame_monitor.scan_id, and
-     _diffrn_scan_frame_monitor.frame_id
-     should uniquely identify the monitor value being recorded.
+;             This item is an integer identifier which, along with
+              _diffrn_scan_frame_monitor.detector_id,
+              _diffrn_scan_frame_monitor.scan_id, and
+              _diffrn_scan_frame_monitor.frame_id
+              should uniquely identify the monitor value being recorded.
 
-     If _array_data.binary_id  is not explicitly given,
-     it defaults to 1.
+              If _array_data.binary_id is not explicitly given,
+              it defaults to 1.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               id
@@ -11246,16 +12653,21 @@ save_diffrn_scan_frame_monitor.id
     _enumeration.range            1:
     _enumeration.default          1
 
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
 save_
 
 save_diffrn_scan_frame_monitor.integration_time
 
     _definition.id                '_diffrn_scan_frame_monitor.integration_time'
     _description.text
-;
-    The precise time for integration of the monitor value given in
-     _diffrn_scan_frame_monitor.monitor_value
-     must be given in _diffrn_scan_frame_monitor.integration_time.
+;             The precise time for integration of the monitor value given in
+              _diffrn_scan_frame_monitor.monitor_value
+              must be given in _diffrn_scan_frame_monitor.integration_time.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               integration_time
@@ -11267,6 +12679,8 @@ save_diffrn_scan_frame_monitor.integration_time
     _type.ddl2_code               float
     _type.ddl2_units              seconds
     _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -11274,19 +12688,20 @@ save_diffrn_scan_frame_monitor.monitor_value
 
     _definition.id                '_diffrn_scan_frame_monitor.monitor_value'
     _alias.definition_id          '_diffrn_scan_frame_monitor.value'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.8.2
     _alias.dictionary_uri         cif_img.dic
     _description.text
-;
-    The value reported by the monitor detector should be given in
-     _diffrn_scan_frame_monitor.monitor_value.
+;             The value reported by the monitor detector should be given in
+              _diffrn_scan_frame_monitor.monitor_value.
 
-     The value is typed as float to allow of monitors for very
-     intense beams that cannot report all digits, but when
-     available, all digits of the  monitor should be recorded.
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when
+              available, all digits of the  monitor should be recorded.
 
-     For convenience in automated validation, the deprecated
-     _diffrn_scan_frame_monitor.monitor_value
-     is given as an alias, but should be avoided for new data sets.
+              For convenience in automated validation, the deprecated
+              _diffrn_scan_frame_monitor.monitor_value
+              is given as an alias, but should be avoided for new data sets.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               monitor_value
@@ -11296,6 +12711,9 @@ save_diffrn_scan_frame_monitor.monitor_value
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -11303,9 +12721,8 @@ save_diffrn_scan_frame_monitor.scan_id
 
     _definition.id                '_diffrn_scan_frame_monitor.scan_id'
     _description.text
-;
-    This item is a pointer to _diffrn_scan.id  in
-     the DIFFRN_SCAN  category.
+;             This item is a pointer to _diffrn_scan.id in
+              the DIFFRN_SCAN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               scan_id
@@ -11322,15 +12739,14 @@ save_diffrn_scan_frame_monitor.value
 
     _definition.id                '_diffrn_scan_frame_monitor.value'
     _description.text
-;
-    This is a deprecated version of
-     _diffrn_scan_frame_monitor.monitor_value.
+;             This is a deprecated version of
+              _diffrn_scan_frame_monitor.monitor_value.
 
-     The value is typed as float to allow of monitors for very
-     intense beams that cannot report all digits, but when available,
-     all digits of the monitor should be recorded.
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when available,
+              all digits of the monitor should be recorded.
 
-     DEPRECATED -- DO NOT USE
+              DEPRECATED -- DO NOT USE
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               value
@@ -11340,6 +12756,11 @@ save_diffrn_scan_frame_monitor.value
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
+    _units.code                   none
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_diffrn_scan_frame_monitor.monitor_value'
+    _ddl2_item_related.function_code replacedby
 
 save_
 
@@ -11347,15 +12768,14 @@ save_diffrn_scan_frame_monitor.variant
 
     _definition.id                '_diffrn_scan_frame_monitor.variant'
     _description.text
-;
-    The value of _diffrn_scan_frame_monitor.variant  gives the variant
-     to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
+;             The value of _diffrn_scan_frame_monitor.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
     _name.object_id               variant
@@ -11370,14 +12790,124 @@ save_diffrn_scan_frame_monitor.variant
 
 save_
 
+save_DIFFRN_SOURCE
+
+    _definition.id                diffrn_source
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-04
+    _description.text
+;              Data items in the DIFFRN_SOURCE category record details of
+               the source of radiation used in the diffraction experiment.
+
+               This is a stub category for use of DIFFRN_SOURCE which is
+               specified in the mmCIF_PDBx dictionary
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_source
+    _name.ddl2_mandatory          no
+    _category_key.name            '_diffrn_source.diffrn_id'
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_source.diffrn_id
+
+    _definition.id                '_diffrn_source.diffrn_id'
+    _alias.definition_id          '_diffrn_source.diffrn_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           5.384
+    _alias.dictionary_uri         mmcif_pdbx.dic
+    _description.text
+;              This data item is a pointer to _diffrn.id in the DIFFRN
+               category.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+
+save_
+
+save_diffrn_source.source
+
+    _definition.id                '_diffrn_source.source'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_source.source'           .        5.384        mmcif_pdbx.dic
+         '_diffrn_radiation_source'        .        1.0          cifdic.c91
+         '_diffrn_source'                  .        2.0          cif_core.dic
+
+    _description.text
+;              The general class of the radiation source.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               source
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'sealed X-ray tube'
+         'nuclear reactor'
+         'spallation source'
+         'electron microscope'
+         'rotating-anode X-ray tube'
+         'synchrotron'
+
+save_
+
+save_diffrn_source.type
+
+    _definition.id                '_diffrn_source.type'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_source.type'         .         5.384         mmcif_pdbx.dic
+         '_diffrn_source_type'         .         2.0.1         cif_core.dic
+
+    _description.text
+;              The make, model or name of the source of radiation.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               type
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'NSLS beamline X8C'
+         'Rigaku RU200'
+
+save_
+
 save_MAP
 
-    _definition.id                MAP
+    _definition.id                map
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the MAP  category record
+    Data items in the MAP category record
      the details of maps. Maps record values of parameters,
      such as density, that are functions of position within
      a cell or are functions of orthogonal coordinates in
@@ -11389,7 +12919,7 @@ save_MAP
      Examples are given in the MAP_SEGMENT category.
 ;
     _name.category_id             HEAD
-    _name.object_id               MAP
+    _name.object_id               map
     _name.ddl2_mandatory          no
 
     loop_
@@ -11400,27 +12930,31 @@ save_MAP
          '_map.variant'
 
     _description_example.case
-;
-         loop_
-         _map.id
-         _map.details
+;        loop_
+        _map.id
+        _map.details
 
-         rho_calc
-    ;
-         density calculated from F_calc derived from the ATOM_SITE
-         list
-    ;
-         rho_obs
-    ;
-         density combining the observed structure factors with the
-         calculated phases
-    ;
+        rho_calc
+   ;
+        density calculated from F_calc derived from the ATOM_SITE
+        list
+   ;
+        rho_obs
+   ;
+        density combining the observed structure factors with the
+        calculated phases
+   ;
 ;
     _description_example.detail
+;   Example 1. Identifying an observed density map
+                and a calculated density map
 ;
-    Example 1. Identifying an observed density map
-                 and a calculated density map
-;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         map_group
 
 save_
 
@@ -11428,9 +12962,9 @@ save_map.details
 
     _definition.id                '_map.details'
     _description.text
-;
-    The value of _map.details  should give a
-     description of special aspects of each map.
+;              The value of _map.details should give a
+               description of special aspects of each map.
+
 ;
     _name.category_id             map
     _name.object_id               details
@@ -11441,13 +12975,11 @@ save_map.details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;
-    Example 1. Identifying an observed density map
-                 and a calculated density map
+;   Example 1. Identifying an observed density map
+                and a calculated density map
 ;
     _description_example.detail
-;
-        loop_
+;        loop_
         _map.id
         _map.details
 
@@ -11468,12 +13000,12 @@ save_map.diffrn_id
 
     _definition.id                '_map.diffrn_id'
     _description.text
-;
-    This item is a pointer to _diffrn.id  in the
-     DIFFRN  category.
+;             This item is a pointer to _diffrn.id in the
+              DIFFRN category.
 ;
     _name.category_id             map
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
     _type.purpose                 Key
     _type.source                  Assigned
@@ -11487,9 +13019,8 @@ save_map.entry_id
 
     _definition.id                '_map.entry_id'
     _description.text
-;
-    This item is a pointer to _entry.id  in the
-     ENTRY  category.
+;             This item is a pointer to _entry.id in the
+              ENTRY category.
 ;
     _name.category_id             map
     _name.object_id               entry_id
@@ -11506,15 +13037,14 @@ save_map.id
 
     _definition.id                '_map.id'
     _description.text
-;
-    The value of _map.id  must uniquely identify
-     each map for the given diffrn.id or entry.id.
+;             The value of _map.id must uniquely identify
+              each map for the given '_diffrn.id' or entry.id.
 ;
     _name.category_id             map
     _name.object_id               id
     _name.ddl2_mandatory          yes
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -11525,15 +13055,14 @@ save_map.variant
 
     _definition.id                '_map.variant'
     _description.text
-;
-    The value of _map.variant  gives the variant
-     to which the given map row is related.
+;             The value of _map.variant gives the variant
+              to which the given map row is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             map
     _name.object_id               variant
@@ -11550,16 +13079,16 @@ save_
 
 save_MAP_SEGMENT
 
-    _definition.id                MAP_SEGMENT
+    _definition.id                map_segment
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the MAP_SEGMENT  category record
+    Data items in the MAP_SEGMENT category record
      the details about each segment (section or brick) of a map.
 ;
     _name.category_id             HEAD
-    _name.object_id               MAP_SEGMENT
+    _name.object_id               map_segment
     _name.ddl2_mandatory          no
 
     loop_
@@ -11569,38 +13098,42 @@ save_MAP_SEGMENT
          '_map_segment.variant'
 
     _description_example.case
-;
-       loop_
-       _map.id
-       _map.details
+;        loop_
+        _map.id
+        _map.details
 
-       rho_calc
-    ;
-       density calculated from F_calc derived from the ATOM_SITE list
-    ;
-       rho_obs
-    ;
-       density combining the observed structure factors with the
-       calculated phases
-    ;
+        rho_calc
+     ;
+        density calculated from F_calc derived from the ATOM_SITE list
+     ;
+        rho_obs
+     ;
+        density combining the observed structure factors with the
+        calculated phases
+     ;
 
-       loop_
-       _map_segment.map_id
-       _map_segment.id
-       _map_segment.array_id
-       _map_segment.binary_id
-       _map_segment.mask_array_id
-       _map_segment.mask_binary_id
-       rho_calc rho_calc map_structure 1 mask_structure 1
-       rho_obs  rho_obs  map_structure 2 mask_structure 1
+        loop_
+        _map_segment.map_id
+        _map_segment.id
+        _map_segment.array_id
+        _map_segment.binary_id
+        _map_segment.mask_array_id
+        _map_segment.mask_binary_id
+        rho_calc rho_calc map_structure 1 mask_structure 1
+        rho_obs  rho_obs  map_structure 2 mask_structure 1
 ;
     _description_example.detail
+;   Example 1. Identifying an observed density map
+                and a calculated density map, each consisting of one
+                segment, both using the same array structure
+                and mask.
 ;
-    Example 1. Identifying an observed density map
-                 and a calculated density map, each consisting of one
-                 segment, both using the same array structure
-                 and mask.
-;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         map_group
 
 save_
 
@@ -11608,12 +13141,11 @@ save_map_segment.array_id
 
     _definition.id                '_map_segment.array_id'
     _description.text
-;
-    The value of _map_segment.array_id identifies the array
-     structure into which the map is organized.
+;             The value of _map_segment.array_id identifies the array 
+              structure into which the map is organized.
 
-     This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+              This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             map_segment
     _name.object_id               array_id
@@ -11630,9 +13162,8 @@ save_map_segment.array_section_id
 
     _definition.id                '_map_segment.array_section_id'
     _description.text
-;
-    This item is a pointer to _array_structure_list_section.id
-     in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
     _name.object_id               array_section_id
@@ -11650,13 +13181,12 @@ save_map_segment.binary_id
 
     _definition.id                '_map_segment.binary_id'
     _description.text
-;
-    The value of _map_segment.binary_id  distinguishes the particular
-     set of data organized according to _map_segment.array_id  in
-     which the data values of the map are stored.
+;             The value of _map_segment.binary_id distinguishes the particular 
+              set of data organized according to _map_segment.array_id in 
+              which the data values of the map are stored.
 
-     This item is a pointer to _array_data.binary_id  in the
-     ARRAY_DATA  category.
+              This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
 ;
     _name.category_id             map_segment
     _name.object_id               binary_id
@@ -11666,6 +13196,7 @@ save_map_segment.binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
+    _units.code                   none
 
 save_
 
@@ -11673,9 +13204,8 @@ save_map_segment.details
 
     _definition.id                '_map_segment.details'
     _description.text
-;
-    The value of _map_segment.details  should give a
-     description of special aspects of each segment of a map.
+;             The value of _map_segment.details should give a
+              description of special aspects of each segment of a map.
 ;
     _name.category_id             map_segment
     _name.object_id               details
@@ -11697,9 +13227,8 @@ save_map_segment.id
 
     _definition.id                '_map_segment.id'
     _description.text
-;
-    The value of _map_segment.id  must uniquely
-     identify each segment of a map.
+;             The value of _map_segment.id must uniquely
+              identify each segment of a map.
 ;
     _name.category_id             map_segment
     _name.object_id               id
@@ -11717,9 +13246,8 @@ save_map_segment.map_id
 
     _definition.id                '_map_segment.map_id'
     _description.text
-;
-    This item is a pointer to _map.id
-     in the MAP  category.
+;             This item is a pointer to _map.id
+              in the MAP category.
 ;
     _name.category_id             map_segment
     _name.object_id               map_id
@@ -11736,23 +13264,22 @@ save_map_segment.mask_array_id
 
     _definition.id                '_map_segment.mask_array_id'
     _description.text
-;
-    The value of _map_segment.mask_array_id, if given, describes
-     the array structure into which the mask for the map is
-     organized.  If no value is given, then all elements of
-     the map are valid.  If a value is given, then only
-     elements of the map for which the corresponding element
-     of the mask is non-zero are valid.  The value of
-     _map_segment.mask_array_id  differs from the value of
-     _map_segment.array_id  in order to permit the mask to be
-     given as, say, unsigned 8-bit integers, while the map is
-     given as a data type with more range.  However, the two
-     array structures must be aligned, using the same axes in
-     the same order with the same displacements and
-     increments.
+;             The value of _map_segment.mask_array_id, if given, describes
+              the array structure into which the mask for the map is
+              organized.  If no value is given, then all elements of
+              the map are valid.  If a value is given, then only
+              elements of the map for which the corresponding element
+              of the mask is non-zero are valid.  The value of
+              _map_segment.mask_array_id differs from the value of
+              _map_segment.array_id in order to permit the mask to be
+              given as, say, unsigned 8-bit integers, while the map is
+              given as a data type with more range.  However, the two
+              array structures must be aligned, using the same axes in
+              the same order with the same displacements and
+              increments.
 
-     This item is a pointer to _array_structure.id  in the
-     ARRAY_STRUCTURE  category.
+              This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
 ;
     _name.category_id             map_segment
     _name.object_id               mask_array_id
@@ -11769,9 +13296,8 @@ save_map_segment.mask_array_section_id
 
     _definition.id                '_map_segment.mask_array_section_id'
     _description.text
-;
-    This item is a pointer to _array_structure_list_section.id
-     in the ARRAY_STRUCTURE_LIST_SECTION  category.
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
     _name.object_id               mask_array_section_id
@@ -11788,13 +13314,12 @@ save_map_segment.mask_binary_id
 
     _definition.id                '_map_segment.mask_binary_id'
     _description.text
-;
-    The value of _map_segment.mask_binary_id  identifies the
-     particular set of data organized according to
-     _map_segment.mask_array_id specifying the mask for the map.
+;             The value of _map_segment.mask_binary_id identifies the 
+              particular set of data organized according to 
+              _map_segment.mask_array_id specifying the mask for the map.
 
-     This item is a pointer to _array_data.binary_id  in the
-     ARRAY_DATA  category.
+              This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
 ;
     _name.category_id             map_segment
     _name.object_id               mask_binary_id
@@ -11804,6 +13329,7 @@ save_map_segment.mask_binary_id
     _type.container               Single
     _type.contents                Integer
     _type.ddl2_code               int
+    _units.code                   none
 
 save_
 
@@ -11811,15 +13337,14 @@ save_map_segment.variant
 
     _definition.id                '_map_segment.variant'
     _description.text
-;
-    The value of _map_segment.variant  gives the variant
-     to which the given map segment is related.
+;             The value of _map_segment.variant gives the variant
+              to which the given map segment is related.
 
-     If this value is not given, the variant is assumed to be
-     the default null variant.
+              If this value is not given, the variant is assumed to be
+              the default null variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
 ;
     _name.category_id             map_segment
     _name.object_id               variant
@@ -11836,12 +13361,12 @@ save_
 
 save_VARIANT
 
-    _definition.id                VARIANT
+    _definition.id                variant
     _definition.scope             Category
     _definition.class             Loop
     _description.text
 ;
-    Data items in the VARIANT  category record
+    Data items in the VARIANT category record
      the details about sets of variants of data items.
 
      There is sometimes a need to allow for multiple versions of the
@@ -11881,7 +13406,7 @@ save_VARIANT
      be used.
 ;
     _name.category_id             HEAD
-    _name.object_id               VARIANT
+    _name.object_id               variant
     _name.ddl2_mandatory          no
 
     loop_
@@ -11891,55 +13416,58 @@ save_VARIANT
          '_variant.entry_id'
 
     _description_example.case
-;
-    loop_
-    _variant.variant
-    _variant.role
-    _variant.timestamp
-    _variant.variant_of
-    _variant.details
-        . "raw data" 2007-08-03T23:20:00 ..
-        indexed "preferred" 2007-08-04T01:17:28.
-          "indexed cell and refined beam centre"
+;        loop_
+        _variant.variant
+        _variant.role
+        _variant.timestamp
+        _variant.variant_of
+        _variant.details
+            . "raw data" 2007-08-03T23:20:00 . .
+            indexed "preferred" 2007-08-04T01:17:28 .
+              "indexed cell and refined beam centre"
 
-    loop_
-    _diffrn_detector_element.detector_id
-    _diffrn_detector_element.id
-    _diffrn_detector_element.reference_center_fast
-    _diffrn_detector_element.reference_center_slow
-    _diffrn_detector_element.reference_center_units
-    _diffrn_detector_element.variant
-    d1     d1_ccd_1  201.5 201.5  mm .
-    d1     d1_ccd_2  -1.8  201.5  mm .
-    d1     d1_ccd_3  201.6  -1.4  mm .
-    d1     d1_ccd_4  -1.7   -1.5  mm .
-    d1     d1_ccd_1  201.3 201.6  mm  indexed
-    d1     d1_ccd_2  -2.0  201.6  mm  indexed
-    d1     d1_ccd_3  201.3  -1.5  mm  indexed
-    d1     d1_ccd_4  -1.9   -1.6  mm  indexed
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        _diffrn_detector_element.variant
+        d1     d1_ccd_1  201.5 201.5  mm  .
+        d1     d1_ccd_2  -1.8  201.5  mm  .
+        d1     d1_ccd_3  201.6  -1.4  mm  .
+        d1     d1_ccd_4  -1.7   -1.5  mm  .
+        d1     d1_ccd_1  201.3 201.6  mm  indexed
+        d1     d1_ccd_2  -2.0  201.6  mm  indexed
+        d1     d1_ccd_3  201.3  -1.5  mm  indexed
+        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
 ;
     _description_example.detail
+;   Example 1. Distinguishing between a raw beam centre and a refined beam
+       centre inferred after indexing.  Detector d1 is composed of
+       four CCD detector elements, each 200 mm by 200 mm, arranged
+       in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+       Note that the beam centre is slightly displaced from each of the
+       detector elements, just beyond the lower right corner of 1,
+       the lower left corner of 2, the upper right corner of 3 and
+       the upper left corner of 4.  For each element, the detector
+       face coordinate system is assumed to have the fast axis
+       running from left to right and the slow axis running from
+       top to bottom with the origin at the top left corner.
+
+       After indexing and refinement, the centre is shifted by 0.2 mm
+       left and 0.1 mm down.
 ;
-    Example 1. Distinguishing between a raw beam centre and a refined beam
-        centre inferred after indexing.  Detector d1 is composed of
-        four CCD detector elements, each 200 mm by 200 mm, arranged
-        in a square, in the pattern
 
-                    1     2
-                       *
-                    3     4
-
-        Note that the beam centre is slightly displaced from each of the
-        detector elements, just beyond the lower right corner of 1,
-        the lower left corner of 2, the upper right corner of 3 and
-        the upper left corner of 4.  For each element, the detector
-        face coordinate system is assumed to have the fast axis
-        running from left to right and the slow axis running from
-        top to bottom with the origin at the top left corner.
-
-        After indexing and refinement, the centre is shifted by 0.2 mm
-        left and 0.1 mm down.
-;
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         variant_group
 
 save_
 
@@ -11947,8 +13475,7 @@ save_variant.details
 
     _definition.id                '_variant.details'
     _description.text
-;
-    A description of special aspects of the variant.
+;             A description of special aspects of the variant.
 ;
     _name.category_id             variant
     _name.object_id               details
@@ -11958,7 +13485,8 @@ save_variant.details
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
-    _description_example.case     'indexed cell and refined beam centre'
+    _description_example.case
+        'indexed cell and refined beam centre'
 
 save_
 
@@ -11966,12 +13494,12 @@ save_variant.diffrn_id
 
     _definition.id                '_variant.diffrn_id'
     _description.text
-;
-    This item is a pointer to _diffrn.id  in the
-     diffrn  category.
+;             This item is a pointer to _diffrn.id in the
+              diffrn category.
 ;
     _name.category_id             variant
     _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          implicit
     _type.purpose                 Key
     _type.source                  Assigned
@@ -11985,9 +13513,8 @@ save_variant.entry_id
 
     _definition.id                '_variant.entry_id'
     _description.text
-;
-    This item is a pointer to _entry.id  in the
-     entry  category
+;             This item is a pointer to _entry.id in the
+              entry category
 ;
     _name.category_id             variant
     _name.object_id               entry_id
@@ -12004,15 +13531,14 @@ save_variant.role
 
     _definition.id                '_variant.role'
     _description.text
-;
-    The value of _variant.role   specified a role
-     for this variant.  Possible roles are null, 'preferred',
-     'raw data', and 'unsuccessful trial'.
+;             The value of _variant.role  specified a role
+              for this variant.  Possible roles are null, 'preferred',
+              'raw data', and 'unsuccessful trial'.
 
-     A null value for _variant.role  leaves the
-     precise role of the variant unspecified.  No inference should
-     be made that the variant with the latest time stamp is
-     preferred.
+              A null value for _variant.role leaves the
+              precise role of the variant unspecified.  No inference should
+              be made that the variant with the latest time stamp is
+              preferred.
 ;
     _name.category_id             variant
     _name.object_id               role
@@ -12027,25 +13553,22 @@ save_variant.role
       _enumeration_set.state
       _enumeration_set.detail
          'preferred'
-;
-         A value of 'preferred' indicates that rows of any categories
-         specifying this variant should be used in preference to rows with the
-         same key specifying other variants or the null variant. It is an error
-         to specify two variants that appear in the same category with the same
-         key as being preferred, but it is not an error to specify more than
-         one variant as preferred in other cases.
+;    A value of 'preferred' indicates that rows of any categories specifying
+     this variant should be used in preference to rows with the same key
+     specifying other variants or the null variant.  It is an error to specify
+     two variants that appear in the same category with the same key as being
+     preferred, but it is not an error to specify more than one variant as
+     preferred in other cases.
 ;
          'raw data'
-;
-         A value of 'raw data' indicates data prior to any corrections,
-         calculations or refinements. It is not necessarily an error for raw
-         data also to be a variant of an earlier variant. It may be replacement
-         raw data for earlier data believed to be erroneous.
+;    A value of 'raw data' indicates data prior to any corrections, 
+     calculations or refinements.  It is not necessarily an error for raw data
+     also to be a variant of an earlier variant.  It may be replacement raw 
+     data for earlier data believed to be erroneous.
 ;
          'unsuccessful trial'
-;
-         A value of 'unsuccessful trial' indicates data that should not be used
-         for further calculation.
+;    A value of 'unsuccessful trial' indicates data that should not be used
+     for further calculation.
 ;
 
 save_
@@ -12054,11 +13577,10 @@ save_variant.timestamp
 
     _definition.id                '_variant.timestamp'
     _description.text
-;
-    The date and time identifying a variant.  This is not
-     necessarily the precise time of the measurement or calculation
-     of the individual related data items, but a timestamp that
-     reflects the order in which the variants were defined.
+;             The date and time identifying a variant.  This is not 
+              necessarily the precise time of the measurement or calculation
+              of the individual related data items, but a timestamp that 
+              reflects the order in which the variants were defined.
 ;
     _name.category_id             variant
     _name.object_id               timestamp
@@ -12075,18 +13597,17 @@ save_variant.variant
 
     _definition.id                '_variant.variant'
     _description.text
-;
-    The value of _variant.variant  must uniquely identify
-     each variant for the given diffraction experiment and/or entry
+;             The value of _variant.variant must uniquely identify
+              each variant for the given diffraction experiment and/or entry
 
-     This item has been made implicit and given a default value of
-     null.
+              This item has been made implicit and given a default value of 
+              null.
 ;
     _name.category_id             variant
     _name.object_id               variant
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               code
@@ -12098,14 +13619,13 @@ save_variant.variant_of
 
     _definition.id                '_variant.variant_of'
     _description.text
-;
-    The value of _variant.variant_of  gives the variant
-     from which this variant was derived.  If this value is not given,
-     the variant is assumed to be derived from the default null
-     variant.
+;            The value of _variant.variant_of gives the variant
+             from which this variant was derived.  If this value is not given,
+             the variant is assumed to be derived from the default null 
+             variant.
 
-     This item is a pointer to _variant.variant  in the
-     VARIANT  category.
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
 ;
     _name.category_id             variant
     _name.object_id               variant_of
@@ -12122,6 +13642,62 @@ save_
       _dictionary_audit.version
       _dictionary_audit.date
       _dictionary_audit.revision
+         1.8.9                    2025-06-10
+;
+       Addition of missing diffrn.id pointers
+
+        + Add _diffrn_detector_element.diffrn_id
+        + Add _diffrn_measurement_axis.diffrn_id
+        + Add _diffrn_scan.diffrn_id
+        + Add _diffrn_scan_axis.diffrn_id
+        + Add _diffrn_scan_collection.diffrn_id
+        + Add _diffrn_scan_frame.diffrn_id
+        + Add _diffrn_scan_frame_axis.diffrn_id
+        + Add _diffrn_scan_frame_axis.diffrn_id
+        + Add _diffrn_scan_frame_monitor.diffrn_id
+;
+         1.8.8.2                  2025-06-10
+;
+       Pick up minor type corrections from 1.8.9 dcitionary
+;
+         1.8.8.1                  2025-05-25
+;
+       Minor corrections to 1.8.8 found while working on 1.8.9
+;
+         1.8.8                    2024-01-20
+;   Additional flux tags and change to ddl2 version being the master
+    instead of the html version being the master.  Make changes to
+    support conversions to DDLm and back to DDL2.  Mark tags aliased
+    from mmCIF_PDBx dictionary.
+
+    + Change from use of _item.type_code to _item_type.code
+    + Fix extraneous single quote after _array_data_external_data.file_compression
+    + Change 'photons per second' to photons_per_second in units
+    + Add micrometres, photons, photons_per_second, and 
+      photons_per_seconf_per_micrometre_squared to units
+    + Add stub DIFFRN category
+    + Add _diffrn.id
+    + Add  _diffrn_radiation.beam_flux_density
+    + Add _diffrn_radiation.beam_flux_density_integrated
+    + Add  _diffrn_radiation.beam_flux_integrated
+    + Add _diffrn_radiation.beam_flux_integration_time
+    + Add _diffrn_radiation.beam_incident_flux
+    + Add _diffrn_radiation.beam_incident_flux_integrated
+    + Add stub DIFFRN_SOURCE category
+    + Add _diffrn_source.diffrn_id
+    + Add _diffrn_source.source
+    + Add _diffrn_source.type
+;
+         1.8.7                    2023-01-26
+;   Various additions
+
+    + Add _array_data_external_data.file_compression
+      2022-06-09 (jrh).
+    + Fix incorrect _diffrn_scan_axis.angle_range
+      example and clarify definition 2022-06-09 (jrh)
+    + Clarify wording describing _array_intensities.overload 
+      2022-12-31 (ab) 
+;
          1.8.6                    2022-05-11
 ;
        Add missing archive tags to external data tags, clarify use of
@@ -12146,49 +13722,48 @@ save_
         + Add _array_data_external_data.version
 ;
          1.8.4                    2021-04-15
-;
-       Copy-editing refinements (bm)
+;   Copy-editing refinements (bm)
 
-        + Add _item_related.related_name and
-          "_item_related.function_code replacedby" to deprecated items.
-        + Add "_item_default.value  ." to *_variant items
-        + Change uses of \%Angstroms to \%angstr\"oms
-        + Change category save frames to upper case names
-        + Fix misssing superscript terminating ^
+    + Add _item_related.related_name and
+      "_item_related.function_code replacedby" to deprecated items.
+    + Add "_item_default.value  ." to *_variant items
+    + Change uses of \%Angstroms to \%angstr\"oms
+    + Change category save frames to upper case names
+    + Fix misssing superscript terminating ^
 
-        Preliminary version of external data tags (jrh)
+    Preliminary version of external data tags (jrh)
 
-        + Add _array_data.external_format
-        + Add _array_data.external_version
-        + Add _array_data.external_location_uri
-        + Add _array_data.external_path
-        + Add _array_data.external_frame
-        + Add _array_data.external_archive_path
-        + Add _array_data.external_archive_format
+    + Add _array_data.external_format
+    + Add _array_data.external_version
+    + Add _array_data.external_location_uri
+    + Add _array_data.external_path
+    + Add _array_data.external_frame
+    + Add _array_data.external_archive_path
+    + Add _array_data.external_archive_format
 
-        Note the second block of mads is a preliminary version.  When they are
-        done they may well be removed from here and reappear in a 1.8.5
-        dictionary.
+    Note the second block of mads is a preliminary version.  When they are
+    done they may well be removed from here and reappear in a 1.8.5
+    dictionary.
+
 ;
          1.8.3                    2021-02-28
-;
-       Correction as per Brian McMahon
+;   Correction as per Brian McMahon
 
-        + Fix _item.name for _array_structure_list.array_section_id
-        + Remove spurious _item_aliases.alias_name from
-          _diffrn_radiation.polarisn_ratio_esd
-        + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
-        + Provide missing _diffrn_scan_frame_monitor.monitor_value  definition
-        + Deprecate _diffrn_scan_frame_monitor.value
+    + Fix _item.name for _array_structure_list.array_section_id
+    + Remove spurious _item_aliases.alias_name from
+      _diffrn_radiation.polarisn_ratio_esd
+    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
+    + Provide missing _diffrn_scan_frame_monitor.monitor_value definition
+    + Deprecate _diffrn_scan_frame_monitor.value
 ;
          1.8.2                    2021-02-21
 ;
        Corrections and additions for ITVG 2021
 
         + Add McStas as an axis coordinate system
-        + Add _array_intensities.underload  as optional
-        + Add _diffrn_scan_collection.details  as optional
-        + Add _diffrn_scan_collection.variant  as optional
+        + Add _array_intensities.underload as optional
+        + Add _diffrn_scan_collection.details as optional
+        + Add _diffrn_scan_collection.variant as optional
 ;
          1.8.1                    2021-01-30
 ;
@@ -12200,15 +13775,15 @@ save_
         + Fix wrong _item.mandatory_code in _variant.variant_of
 ;
          1.8.0                    2021-01-24
-;
-       Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
 
-        + Add _diffrn_data_frame.center_derived  as optional
-        + Add _diffrn_measurement.sample_detector_distance_derived  as optional
-        + Change _diffrn_scan.date_start  to mandatory
-        + Add _diffrn_scan.date_end_estimated  as mandatory
-        + Fix .array_id and .binary_id columns to be implicit in all cases to
-          facilitate mini_cbfs
+    + Add _diffrn_data_frame.center_derived as optional
+    + Add _diffrn_measurement.sample_detector_distance_derived as optional
+    + Change _diffrn_scan.date_start to mandatory
+    + Add _diffrn_scan.date_end_estimated as mandatory
+    + Fix .array_id and .binary_id columns to be implicit in all cases to
+      facilitate mini_cbfs
+
 ;
          1.7.11                   2018-12-03
 ;
@@ -12253,50 +13828,47 @@ save_
          DIFFRN_SCAN_FRAME_AXIS.
 ;
          1.7.9                    2014-04-05
-;
-       Corrections to Stokes parameter description. (HJB)
+;  Corrections to Stokes parameter description. (HJB)
 
-         + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
-         and _diffrn_scan_frame.polarizn_Stokes_I  to explicitly include
-       non-polarized       component.
+    + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
+    and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
+        component.
 
-         + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
-         description and _diffrn_scan_frame.polarizn_Stokes_V  description.
+    + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
+    description and _diffrn_scan_frame.polarizn_Stokes_V description.
+
 ;
          1.7.8                    2014-02-22
-;
-       Minor changes to NeXus mapping. (HJB)
+;  Minor changes to NeXus mapping. (HJB)
 
-            + Conform NeXus mapping of DIFFRN_DETECTOR  to neXus
-            NXdetector base class terminology
+       + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
+       NXdetector base class terminology
 
-            + Add _diffrn_detector.gain_setting  to handle
-            the reverse mapping from NeXus of the equivalent field in
-       NXdetector.
+       + Add _diffrn_detector.gain_setting to handle
+       the reverse mapping from NeXus of the equivalent field in NXdetector.
 ;
          1.7.7                    2014-02-22
-;
-       Major changes to NeXus mapping to conform to JS functional
-         mapping prototype, add Stoke parameter tags for polarization
-         and beam intensity, and add an new tag for FEL axes (HJB)
+;  Major changes to NeXus mapping to conform to JS functional
+    mapping prototype, add Stoke parameter tags for polarization
+    and beam intensity, and add an new tag for FEL axes (HJB)
 
-            + Add
-            _axis.equipment_component,
-            _diffrn_radiation.polarizn_Stokes_I,
-            _diffrn_radiation.polarizn_Stokes_Q,
-            _diffrn_radiation.polarizn_Stokes_U,
-            _diffrn_radiation.polarizn_Stokes_V,
-            _diffrn_scan_frame.polarizn_Stokes_I,
-            _diffrn_scan_frame.polarizn_Stokes_Q,
-            _diffrn_scan_frame.polarizn_Stokes_U,
-            _diffrn_scan_frame.polarizn_Stokes_V.
-            + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
-            + Update dictionary version
+       + Add
+       _axis.equipment_component,
+       _diffrn_radiation.polarizn_Stokes_I,
+       _diffrn_radiation.polarizn_Stokes_Q,
+       _diffrn_radiation.polarizn_Stokes_U,
+       _diffrn_radiation.polarizn_Stokes_V,
+       _diffrn_scan_frame.polarizn_Stokes_I,
+       _diffrn_scan_frame.polarizn_Stokes_Q,
+       _diffrn_scan_frame.polarizn_Stokes_U,
+       _diffrn_scan_frame.polarizn_Stokes_V.
+       + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
+       + Update dictionary version
 ;
          1.7.6                    2013-10-29
 ;
        To avoid a conflict with PDB software, remove the null value
-         enumeration for _variant.role  (HJB)
+         enumeration for _variant.role (HJB)
 ;
          1.7.5                    2013-10-27
 ;
@@ -12312,64 +13884,64 @@ save_
          +  Change case of category names to conform to PDB conventions. (JW)
 ;
          1.7.3                    2013-10-15
-;
-       Major cleanup of dictionary typos, misplaced loops, etc
-            by John Westbrook
+;  Major cleanup of dictionary typos, misplaced loops, etc
+       by John Westbrook
 
-         +  Change _item.mandatory_code of all *.variant to implicit
-         +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
-         +  Correct many _item.name values that were wrong or missing
-            quote marks
+    +  Change _item.mandatory_code of all *.variant to implicit
+    +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
+    +  Correct many _item.name values that were wrong or missing
+       quote marks
+
 ;
          1.7.2                    2013-10-07
-;
-       Add FEL detector positioning tags and change back to NXgoniometer
+;  Add FEL detector positioning tags and change back to NXgoniometer
 
-         +  Add
-            _axis.rotation_axis  and
-            _axis.rotation  and
-         +  Change NXsample back to NXgoniometer
+    +  Add
+       _axis.rotation_axis and
+       _axis.rotation and
+    +  Change NXsample back to NXgoniometer
+
 ;
          1.7.1                    2013-08-10
-;
-       Minor cleanup (HJB)
+;  Minor cleanup (HJB)
 
-         +  Correction to description of
-              _diffrn_data_frame.array_section_id
-         +  Change NXgoniometer to NXsample
-         +  Fix typos in NeXus mappings
+    +  Correction to description of
+         _diffrn_data_frame.array_section_id
+    +  Change NXgoniometer to NXsample
+    +  Fix typos in NeXus mappings
+
 ;
          1.7                      2013-06-18
-;
-       Additions to start merge of CBF, HDF5 and NeXus (HJB)
+;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
 
-         +  Define new ARRAY_STRUCTURE_LIST_SECTION category
-         +  Add new _category.NX_mapping_details DDL tag to carry
-            details on NeXus category mappings.
-         +  Define new tags _array_structure_list_section.array_id,
-            _array_structure_list_section.id,
-            _array_structure_list_section.index,
-            _array_structure_list_section.end,
-            _array_structure_list_section.start,
-            _array_structure_list_section.stride,
-            _array_structure_list_section.variant,
-            _diffrn_data_frame.array_section_id,
-            _diffrn_detector.layer_thickness,
-            _map_segment.array_section_id,
-            _map_segment.mask_array_section_id
+    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
+    +  Add new _category.NX_mapping_details DDL tag to carry
+       details on NeXus category mappings.
+    +  Define new tags _array_structure_list_section.array_id,
+       _array_structure_list_section.id,
+       _array_structure_list_section.index,
+       _array_structure_list_section.end,
+       _array_structure_list_section.start,
+       _array_structure_list_section.stride,
+       _array_structure_list_section.variant,
+       _diffrn_data_frame.array_section_id,
+       _diffrn_detector.layer_thickness,
+       _map_segment.array_section_id,
+       _map_segment.mask_array_section_id
+
 ;
          1.6.4                    2011-07-02
-;
-       Corrections to support DLS Dectris header as per G. Winter (HJB)
+;  Corrections to support DLS Dectris header as per G. Winter (HJB)
 
-         +  Define new tags _diffrn_scan.time_period,
-            _diffrn_scan.time_rstrt_incr,
-            _diffrn_scan_frame.time_period,
-            _diffrn_scan_frame.time_rstrt_incr
-         +  fix bad category name in loop in _diffrn_detector.id
-         +  remove stray text field terminator at line 4642
-         +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
-         +  make formerly mandatory and implicit deprecated items non-mandatory
+    +  Define new tags _diffrn_scan.time_period,
+       _diffrn_scan.time_rstrt_incr,
+       _diffrn_scan_frame.time_period,
+       _diffrn_scan_frame.time_rstrt_incr 
+    +  fix bad category name in loop in _diffrn_detector.id
+    +  remove stray text field terminator at line 4642
+    +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
+    +  make formerly mandatory and implicit deprecated items non-mandatory
+
 ;
          1.6.3                    2010-08-26
 ;
@@ -12377,39 +13949,37 @@ save_
 
          +  Move descriptive dictionary comments into
          _datablock.description with category tree described
-         +  add default _array_data.array_id  value of 1
+         +  add default _array_data.array_id value of 1
          +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
          +  add VARIANT category and tags
          +  add DIFFRN_SCAN_FRAME_MONITOR category
 ;
          1.5.4                    2007-07-28
-;
-       Typographics corrections (HJB)
+;  Typographics corrections (HJB)
 
-          + Corrected embedded degree characters to \%
-          + Corrected embedded Aring to \%A
-          + Added trailing ^ for a power
-          + Removed 2 cases of a space after an underscore
-            in tag name.
+     + Corrected embedded degree characters to \%
+     + Corrected embedded Aring to \%A
+     + Added trailing ^ for a power
+     + Removed 2 cases of a space after an underscore
+       in tag name.
 ;
          1.5.3                    2007-07-08
-;
-       Changes to support SLS miniCBF and suggestions
-        from the 24 May 07 BNL imgCIF workshop (HJB)
+;  Changes to support SLS miniCBF and suggestions
+   from the 24 May 07 BNL imgCIF workshop (HJB)
 
-          + Added new data items
-            '_array_data.header_contents',
-            '_array_data.header_convention',
-            '_diffrn_data_frame.center_fast',
-            '_diffrn_data_frame.center_slow',
-            '_diffrn_data_frame.center_units',
-            '_diffrn_measurement.sample_detector_distance',
-            '_diffrn_measurement.sample_detector_voffset
-          + Deprecated data items
-            '_diffrn_detector_element.center[1]',
-            '_diffrn_detector_element.center[2]'
-          + Added comments and example on miniCBF
-          + Changed all array_id data items to implicit
+     + Added new data items
+       '_array_data.header_contents',
+       '_array_data.header_convention',
+       '_diffrn_data_frame.center_fast',
+       '_diffrn_data_frame.center_slow',
+       '_diffrn_data_frame.center_units',
+       '_diffrn_measurement.sample_detector_distance',
+       '_diffrn_measurement.sample_detector_voffset
+     + Deprecated data items
+       '_diffrn_detector_element.center[1]',
+       '_diffrn_detector_element.center[2]'
+     + Added comments and example on miniCBF
+     + Changed all array_id data items to implicit
 ;
          1.5.2                    2007-05-06
 ;
@@ -12421,107 +13991,105 @@ save_
         and clean up more line folds (HJB)
 ;
          1.5                      2007-07-25
-;
-       This is a cumulative list of the changes proposed since the
-        imgCIF workshop in Hawaii in July 2006.  It is the result
-        of contributions by H. J. Bernstein, A. Hammersley,
-        J. Wright and W. Kabsch.
+;  This is a cumulative list of the changes proposed since the
+   imgCIF workshop in Hawaii in July 2006.  It is the result
+   of contributions by H. J. Bernstein, A. Hammersley,
+   J. Wright and W. Kabsch.
 
-        2007-02-19 Consolidated changes (edited by HJB)
-          + Added new data items
-            '_array_structure.compression_type_flag',
-            '_array_structure_list_axis.fract_displacement',
-            '_array_structure_list_axis.displacement_increment',
-            '_array_structure_list_axis.reference_angle',
-            '_array_structure_list_axis.reference_displacement',
-            '_axis.system',
-            '_diffrn_detector_element.reference_center_fast',
-            '_diffrn_detector_element.reference_center_slow',
-            '_diffrn_scan_axis.reference_angle',
-            '_diffrn_scan_axis.reference_displacement',
-            '_map.details', '_map.diffrn_id',
-            '_map.entry_id', '_map.id',
-            '_map_segment.array_id', '_map_segment.binary_id',
-            '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
-            '_map_segment.id', '_map_segment.map_id',
-            '_map_segment.details.
-          + Change type of
-            '_array_structure.byte_order' and
-            '_array_structure.compression_type'
-            to ucode to make these values case-insensitive
-          + Add values 'packed_v2' and 'byte_offset' to enumeration of values
-       for      '_array_structure.compression_type'
-          + Add to definitions for the binary data type to handle new
-       compression      types, maps, and a variety of new axis types.
-         2007-07-25 Cleanup of typos for formal release (HJB)
-          + Corrected text fields for reference_ tag descriptions that
-            were off by one column
-          + Fix typos in comments listing fract_ tags
-          + Changed name of release from 1.5_DRAFT to 1.5
-          + Fix unclosed text fields in various map definitions
+   2007-02-19 Consolidated changes (edited by HJB)
+     + Added new data items
+       '_array_structure.compression_type_flag',
+       '_array_structure_list_axis.fract_displacement',
+       '_array_structure_list_axis.displacement_increment',
+       '_array_structure_list_axis.reference_angle',
+       '_array_structure_list_axis.reference_displacement',
+       '_axis.system',
+       '_diffrn_detector_element.reference_center_fast',
+       '_diffrn_detector_element.reference_center_slow',
+       '_diffrn_scan_axis.reference_angle',
+       '_diffrn_scan_axis.reference_displacement',
+       '_map.details', '_map.diffrn_id',
+       '_map.entry_id', '_map.id',
+       '_map_segment.array_id', '_map_segment.binary_id',
+       '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
+       '_map_segment.id', '_map_segment.map_id',
+       '_map_segment.details.
+     + Change type of 
+       '_array_structure.byte_order' and
+       '_array_structure.compression_type'
+       to ucode to make these values case-insensitive
+     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
+       '_array_structure.compression_type'
+     + Add to definitions for the binary data type to handle new compression
+       types, maps, and a variety of new axis types.
+    2007-07-25 Cleanup of typos for formal release (HJB)
+     + Corrected text fields for reference_ tag descriptions that
+       were off by one column
+     + Fix typos in comments listing fract_ tags
+     + Changed name of release from 1.5_DRAFT to 1.5
+     + Fix unclosed text fields in various map definitions
+
 ;
          1.4                      2006-07-04
-;
-       This is a change to reintegrate all changes made in the course of
-        publication of ITVG, by the RCSB from April 2005 through
-        August 2008 and changes for the 2006 imgCIF workshop in
-        Hawaii.
+;  This is a change to reintegrate all changes made in the course of
+   publication of ITVG, by the RCSB from April 2005 through
+   August 2008 and changes for the 2006 imgCIF workshop in
+   Hawaii.
 
-        2006-07-04 Consolidated changes for the 2006 imgCIF workshop (edited by
-       HJB)    + Correct type of '_array_structure_list.direction' from 'int'
-       to 'code'.    + Added new data items suggested by CN
-            '_diffrn_data_frame.details'
-            '_array_intensities.pixel_fast_bin_size',
-            '_array_intensities.pixel_slow_bin_size  and
-            '_array_intensities.pixel_binning_method
-          + Added deprecated item for completeness
-            '_diffrn_frame_data.details'
-          + Added entry for missing item in contents list
-            '_array_structure_list_axis.displacement'
-          + Added new MIME type X-BASE32K based on work by VL, KM, GD, HJB
-          + Correct description of MIME boundary delimiter to start in
-            column 1.
-          + General cleanup of text fields to conform to changes for ITVG
-            by removing empty lines at start and finish of text field.
-          + Amend example for ARRAY_INTENSITIES to include binning.
-          + Add local copy of type specification (as 'code') for all children
-            of '_diffrn.id '.
-          + For consistency, change all references to 'pi' to '\p' and all
-            references to 'Angstroms' to '\%Angstroms'.
-          + Clean up all powers to use IUCr convention of '^power^', as in
-            '10^3^' for '10**3'.
-          + Update 'yyyy-mm-dd' type regex to allow truncation from the right
-            and improve comments to explain handling of related mmCIF
-            'yyyy-mm-dd:hh:mm' type, and use of 'Z' for GMT time zone.
+   2006-07-04 Consolidated changes for the 2006 imgCIF workshop (edited by HJB)
+     + Correct type of '_array_structure_list.direction' from 'int' to 'code'.
+     + Added new data items suggested by CN
+       '_diffrn_data_frame.details'
+       '_array_intensities.pixel_fast_bin_size',
+       '_array_intensities.pixel_slow_bin_size and
+       '_array_intensities.pixel_binning_method
+     + Added deprecated item for completeness
+       '_diffrn_frame_data.details'
+     + Added entry for missing item in contents list
+       '_array_structure_list_axis.displacement'
+     + Added new MIME type X-BASE32K based on work by VL, KM, GD, HJB
+     + Correct description of MIME boundary delimiter to start in
+       column 1.
+     + General cleanup of text fields to conform to changes for ITVG
+       by removing empty lines at start and finish of text field.
+     + Amend example for ARRAY_INTENSITIES to include binning.
+     + Add local copy of type specification (as 'code') for all children
+       of '_diffrn.id'.
+     + For consistency, change all references to 'pi' to '\p' and all
+       references to 'Angstroms' to '\%Angstroms'.
+     + Clean up all powers to use IUCr convention of '^power^', as in
+       '10^3^' for '10**3'.
+     + Update 'yyyy-mm-dd' type regex to allow truncation from the right
+       and improve comments to explain handling of related mmCIF
+       'yyyy-mm-dd:hh:mm' type, and use of 'Z' for GMT time zone.
 
-        2005-03-08 and
-        2004-08-08 fixed cases where _item_units.code  used
-                   instead of _item_type.code (JDW)
-        2004-04-15 fixed item ordering in
-                    _diffrn_measurement_axis.measurement_id
-                    added sub_category 'vector' (JDW)
+   2005-03-08 and
+   2004-08-08 fixed cases where _item_units.code  used
+              instead of _item_type.code (JDW)
+   2004-04-15 fixed item ordering in
+               _diffrn_measurement_axis.measurement_id
+               added sub_category 'vector' (JDW)
 ;
          1.3.2                    2005-06-25
-;
-       2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
-                   to those of current mmCIF; float modified by allowing
-       integers             terminated by a point as valid. The 'time' part of
-                   yyyy-mm-dd types made optional in the regexp. (BM)
+;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+              to those of current mmCIF; float modified by allowing integers
+              terminated by a point as valid. The 'time' part of
+              yyyy-mm-dd types made optional in the regexp. (BM)
 
-        2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
-        (NJA)
+   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
+   (NJA)
 
-        2005-02-21  Minor corrections to spelling and punctuation
-        (NJA)
+   2005-02-21  Minor corrections to spelling and punctuation
+   (NJA)
 
-        2005-01-08 Changes as per Nicola Ashcroft.
-        + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
-        + Spelled out "micrometres" for "um" and "millimetres" for "mm".
-        + Removed phrase "which may be stored" from ARRAY_STRUCTURE
-          description.
-        + Removed unused 'byte-offsets' compressions and updated
-          cites to ITVG for '_array_structure.compression_type'.
-        (HJB)
+   2005-01-08 Changes as per Nicola Ashcroft.
+   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
+   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
+   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
+     description.
+   + Removed unused 'byte-offsets' compressions and updated
+     cites to ITVG for '_array_structure.compression_type'.
+   (HJB)
 ;
          1.3.1                    2003-08-13
 ;
@@ -12534,40 +14102,40 @@ save_
        Changes as per Gotzon Madariaga.
        + Fix the ARRAY_DATA example to align '_array_data.binary_id'
        and X-Binary-ID.
-       + Add a range to '_array_intensities.gain_esd '.
+       + Add a range to '_array_intensities.gain_esd'.
        + In the example of DIFFRN_DETECTOR_ELEMENT,
        '_diffrn_detector_element.id' and
        '_diffrn_detector_element.detector_id' interchanged.
        + Fix typos for direction, detector and axes.
        + Clarify description of polarisation.
        + Clarify axes in '_diffrn_detector_element.center[1]'
-        '_diffrn_detector_element.center[2] '.
+        '_diffrn_detector_element.center[2]'.
        + Add local item types for items that are pointers.
        (HJB)
 ;
          1.3.0                    2003-07-24
 ;
-       Changes as per Brian McMahon.
-       + Consistently quote tags embedded in text.
-       + Clean up introductory comments.
-       + Adjust line lengths to fit in 80 character window.
-       + Fix several descriptions in AXIS category which
-         referred to '_axis.type' instead of the current item.
-       + Fix erroneous use of deprecated item
-         '_diffrn_detector_axis.id' in examples for
-         DIFFRN_SCAN_AXIS.
-       + Add deprecated items '_diffrn_detector_axis.id'
-         and '_diffrn_measurement_axis.id'.
-       (HJB)
+   Changes as per Brian McMahon.
+   + Consistently quote tags embedded in text.
+   + Clean up introductory comments.
+   + Adjust line lengths to fit in 80 character window.
+   + Fix several descriptions in AXIS category which
+     referred to '_axis.type' instead of the current item.
+   + Fix erroneous use of deprecated item
+     '_diffrn_detector_axis.id' in examples for
+     DIFFRN_SCAN_AXIS.
+   + Add deprecated items '_diffrn_detector_axis.id'
+     and '_diffrn_measurement_axis.id'.
+   (HJB)
 ;
          1.2.4                    2003-07-14
 ;
-       Changes as per I. David Brown.
-       + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
-         dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
-       + Provide a copy of the deprecated DIFFRN_FRAME_DATA
-         category for completeness.
-       (HJB)
+   Changes as per I. David Brown.
+   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
+     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
+   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
+     category for completeness.
+   (HJB)
 ;
          1.2.3                    2003-07-03
 ;
@@ -12606,41 +14174,40 @@ save_
 ;
          1.1                      2001-02-06
 ;
-       Draft resulting from discussions on header for use at NSLS.  (HJB)
+   Draft resulting from discussions on header for use at NSLS.  (HJB)
 
-       + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
+   + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
 
-       + Change '_diffrn_detector_axis.id' to
-       '_diffrn_detector_axis.detector_id '.
+   + Change '_diffrn_detector_axis.id' to '_diffrn_detector_axis.detector_id'.
 
-       + Add '_diffrn_measurement_axis.measurement_device' and change
-         '_diffrn_measurement_axis.id' to
-         '_diffrn_measurement_axis.measurement_id '.
+   + Add '_diffrn_measurement_axis.measurement_device' and change
+     '_diffrn_measurement_axis.id' to
+     '_diffrn_measurement_axis.measurement_id'.
 
-       + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
-        '_diffrn_radiation.div_x_y_source',
-        '_diffrn_radiation.polarizn_source_norm',
-       '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
-       '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
-       '_diffrn_scan_axis.displacement_rstrt_incr',
-       '_diffrn_scan_frame_axis.angle_increment',
-       '_diffrn_scan_frame_axis.angle_rstrt_incr',
-       '_diffrn_scan_frame_axis.displacement',
-       '_diffrn_scan_frame_axis.displacement_increment',and
-       '_diffrn_scan_frame_axis.displacement_rstrt_incr '.
+   + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
+    '_diffrn_radiation.div_x_y_source',
+    '_diffrn_radiation.polarizn_source_norm',
+   '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
+   '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
+   '_diffrn_scan_axis.displacement_rstrt_incr',
+   '_diffrn_scan_frame_axis.angle_increment',
+   '_diffrn_scan_frame_axis.angle_rstrt_incr',
+   '_diffrn_scan_frame_axis.displacement',
+   '_diffrn_scan_frame_axis.displacement_increment',and
+   '_diffrn_scan_frame_axis.displacement_rstrt_incr'.
 
-       + Add '_diffrn_measurement.device' to category key.
+   + Add '_diffrn_measurement.device' to category key.
 
-       + Update yyyy-mm-dd to allow optional time with fractional seconds
-         for time stamps.
+   + Update yyyy-mm-dd to allow optional time with fractional seconds
+     for time stamps.
 
-       + Fix typos caught by RS.
+   + Fix typos caught by RS.
 
-       + Add ARRAY_STRUCTURE_LIST_AXIS  category, and use concept of axis sets
-       to   allow for coupled axes, as in spiral scans.
+   + Add ARRAY_STRUCTURE_LIST_AXIS category, and use concept of axis sets to
+     allow for coupled axes, as in spiral scans.
 
-       + Add examples for fairly complete headers thanks to R. Sweet and P.
-         Ellis.
+   + Add examples for fairly complete headers thanks to R. Sweet and P.
+     Ellis.
 ;
          1.0                      2000-12-21
 ;
@@ -12662,74 +14229,74 @@ save_
 ;
          0.7.0                    2000-09-09
 ;
-       Respond to comments by I. David Brown.  (HJB)
+   Respond to comments by I. David Brown.  (HJB)
 
-       + Add further comments on '\n' and '\t'.
+   + Add further comments on '\n' and '\t'.
 
-       + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
-         and adding metres.  Change 'meter' to 'metre' throughout.
+   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
+     and adding metres.  Change 'meter' to 'metre' throughout.
 
-       + Add missing enumerations to '_array_structure.compression_type'
-         and make 'none' the default.
+   + Add missing enumerations to '_array_structure.compression_type'
+     and make 'none' the default.
 
-       + Remove parent-child relationship between
-         '_array_structure_list.index' and '_array_structure_list.precedence'.
+   + Remove parent-child relationship between
+     '_array_structure_list.index' and '_array_structure_list.precedence'.
 
-       + Improve alphabetization.
+   + Improve alphabetization.
 
-       + Fix '_array_intensities.gain_esd' related function.
+   + Fix '_array_intensities.gain_esd' related function.
 
-       + Improve comments in AXIS.
+   + Improve comments in AXIS.
 
-       + Fix DIFFRN_FRAME_DATA example.
+   + Fix DIFFRN_FRAME_DATA example.
 
-       + Remove erroneous DIFFRN_MEASUREMENT  example.
+   + Remove erroneous DIFFRN_MEASUREMENT example.
 
-       + Add '_diffrn_measurement_axis.id' to the category key.
+   + Add '_diffrn_measurement_axis.id' to the category key.
 ;
          0.6.0                    1999-01-14
 ;
-       Remove redundant information for ENC_NONE data.  (HJB)
+   Remove redundant information for ENC_NONE data.  (HJB)
 
-       + After the D5 remove binary section identifier, size and
-         compression type.
+   + After the D5 remove binary section identifier, size and
+     compression type.
 
-       + Add Control-L to header.
+   + Add Control-L to header.
 ;
          0.5.1                    1999-01-03
 ;
        Cleanup of typos and syntax errors.  (HJB)
 
-       + Cleanup example details for DIFFRN_SCAN  category.
+       + Cleanup example details for DIFFRN_SCAN category.
 
        + Add missing quote marks for '_diffrn_scan.id' definition.
 ;
          0.5                      1999-01-01
 ;
-       Modifications for axis definitions and reduction of binary header.  (HJB)
+   Modifications for axis definitions and reduction of binary header.  (HJB)
 
-       + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
+   + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
 
-       + Add AXIS  category.
+   + Add AXIS category.
 
-       + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
-         from cif_mm.dic for clarity.
+   + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
+     from cif_mm.dic for clarity.
 
-       + Change '_array_structure.encoding_type' from type code to uline and
-         added X-Binary-Element-Type to MIME header.
+   + Change '_array_structure.encoding_type' from type code to uline and
+     added X-Binary-Element-Type to MIME header.
 
-       + Add detector beam centre '_diffrn_detector_element.center[1]' and
-         '_diffrn_detector_element.center[2] '.
+   + Add detector beam centre '_diffrn_detector_element.center[1]' and
+     '_diffrn_detector_element.center[2]'.
 
-       + Correct item name of '_diffrn_refln.frame_id '.
+   + Correct item name of '_diffrn_refln.frame_id'.
 
-       + Replace reference to '_array_intensities.undefined' by
-         '_array_intensities.undefined_value'.
+   + Replace reference to '_array_intensities.undefined' by
+     '_array_intensities.undefined_value'.
 
-       + Replace references to '_array_intensity.scaling' with
-         '_array_intensities.scaling'.
+   + Replace references to '_array_intensity.scaling' with
+     '_array_intensities.scaling'.
 
-       + Add DIFFRN_SCAN ... categories.
+   + Add DIFFRN_SCAN... categories.
 ;
          0.4                      1998-08-11
 ;
@@ -12743,67 +14310,67 @@ save_
 ;
          0.3                      1998-07-04
 ;
-       Modifications for imgCIF.  (HJB)
+   Modifications for imgCIF.  (HJB)
 
-       + Add binary type, which is a text field containing a variant on
-         MIME encoded data.
+   + Add binary type, which is a text field containing a variant on
+     MIME encoded data.
 
-       + Change type of '_array_data.data' to binary and specify internal
-         structure of raw binary data.
+   + Change type of '_array_data.data' to binary and specify internal
+     structure of raw binary data.
 
-       + Add '_array_data.binary_id', and make
-         '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
-         into pointers to this item.
+   + Add '_array_data.binary_id', and make
+     '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
+     into pointers to this item.
 ;
          0.2                      1997-12-02
 ;
-       Modifications to the CBF draft.  (JW)
+   Modifications to the CBF draft.  (JW)
 
-       + Add category hierarchy for describing frame data developed from
-         discussions at the BNL imgCIF Workshop Oct 1997.   The following
-         changes are made in implementing the workshop draft.  Category
-         DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
-         DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT .   The
-         parent item for '_diffrn_frame_data.array_id' is changed from
-         '_array_structure_list.array_id' to '_array_structure.id'. Item
-         '_diffrn_detector.array_id' is deleted.
-       + Add data item '_diffrn_frame_data.binary_id' to identify data
-         groups within a binary section.  The formal identification of the
-         binary section is still fuzzy.
+   + Add category hierarchy for describing frame data developed from
+     discussions at the BNL imgCIF Workshop Oct 1997.   The following
+     changes are made in implementing the workshop draft.  Category
+     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
+     DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT.   The
+     parent item for '_diffrn_frame_data.array_id' is changed from
+     '_array_structure_list.array_id' to '_array_structure.id'. Item
+     '_diffrn_detector.array_id' is deleted.
+   + Add data item '_diffrn_frame_data.binary_id' to identify data
+     groups within a binary section.  The formal identification of the
+     binary section is still fuzzy.
 ;
          0.1                      1997-01-24
 ;
-       First draft of this dictionary in DDL 2.1 compliant format by John
-       Westbrook (JW).  This version is adapted from the Crystallographic
-       Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
-       (AH).
+   First draft of this dictionary in DDL 2.1 compliant format by John
+   Westbrook (JW).  This version is adapted from the Crystallographic
+   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
+   (AH).
 
-       Modifications to the CBF draft.  (JW)
+   Modifications to the CBF draft.  (JW)
 
-       + In this version the array description has been cast in the categories
-         ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
-         have been generalized to describe array data  of arbitrary dimension.
+   + In this version the array description has been cast in the categories
+     ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
+     have been generalized to describe array data  of arbitrary dimension.
 
-       + Array data in this description are contained in the category
-         ARRAY_DATA .  This departs from the CBF notion of data existing
-         in some special comment. In this description, data are handled as an
-         ordinary data item encapsulated in a character data type.   Although
-         data this manner deviates from CIF conventions, it does not violate
-         any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
-         the binary representation which will permit some level of data
-         validation.  In this version, the placeholder type code "any" has
-         been used. This translates to a regular expression which will match
-         any pattern.
+   + Array data in this description are contained in the category
+     ARRAY_DATA.  This departs from the CBF notion of data existing
+     in some special comment. In this description, data are handled as an
+     ordinary data item encapsulated in a character data type.   Although
+     data this manner deviates from CIF conventions, it does not violate
+     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
+     the binary representation which will permit some level of data
+     validation.  In this version, the placeholder type code "any" has
+     been used. This translates to a regular expression which will match
+     any pattern.
 
-         It should be noted that DDL 2.1 already supports array data objects
-         although these have not been used in the current mmCIF dictionary.
-         It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
-         ITEM_STRUCTURE_LIST categories to provide the information that is
-         carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
-         moving the array structure to the DDL level it would be possible to
-         define an array type as well as a regular expression defining the
-         data format.
+     It should be noted that DDL 2.1 already supports array data objects
+     although these have not been used in the current mmCIF dictionary.
+     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
+     ITEM_STRUCTURE_LIST categories to provide the information that is
+     carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
+     moving the array structure to the DDL level it would be possible to
+     define an array type as well as a regular expression defining the
+     data format.
 
-       + Multiple array sections can be properly handled within a single
-         datablock.
+   + Multiple array sections can be properly handled within a single
+     datablock.
 ;

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -2140,7 +2140,7 @@ save_array_intensities.gain_esd
     _name.linked_item_id          '_array_intensities.gain'
     _name.ddl2_mandatory          Yes
     _type.purpose                 SU
-    _type.source                  Assigned
+    _type.source                  Related
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               Float
@@ -5774,6 +5774,10 @@ save_axis.depends_on
     _name.object_id               depends_on
     _name.linked_item_id          '_axis.id'
     _name.ddl2_mandatory          No
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -6137,7 +6141,7 @@ save_DIFFRN
     _definition.id                DIFFRN
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-10
+    _definition.update            2025-09-11
     _description.text
 ;              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
@@ -6157,10 +6161,6 @@ save_
 save_diffrn.id
 
     _definition.id                '_diffrn.id'
-    _alias.definition_id          '_diffrn.id'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           5.385
-    _alias.dictionary_uri         mmcif_pdbx.dic
     _description.text
 ;              This data item uniquely identifies a set of diffraction
                data.
@@ -6629,7 +6629,7 @@ save_DIFFRN_DETECTOR
     _definition.id                DIFFRN_DETECTOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-10
+    _definition.update            2025-09-11
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -7467,7 +7467,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                DIFFRN_MEASUREMENT
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-10
+    _definition.update            2025-09-11
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -7957,6 +7957,10 @@ save_diffrn_measurement_axis.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          Implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -8037,7 +8041,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-10
+    _definition.update            2025-09-11
     _description.text
 ;             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
@@ -9363,6 +9367,10 @@ save_diffrn_reflns.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          Yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -10072,6 +10080,10 @@ save_diffrn_scan.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          Implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -12180,7 +12192,7 @@ save_DIFFRN_SOURCE
     _definition.id                DIFFRN_SOURCE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-10
+    _definition.update            2025-09-11
     _description.text
 ;              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
@@ -12198,10 +12210,6 @@ save_
 save_diffrn_source.diffrn_id
 
     _definition.id                '_diffrn_source.diffrn_id'
-    _alias.definition_id          '_diffrn_source.diffrn_id'
-    _alias.deprecation_date       .
-    _alias.ddl2_version           5.384
-    _alias.dictionary_uri         mmcif_pdbx.dic
     _description.text
 ;              This data item is a pointer to _diffrn.id in the DIFFRN
                category.
@@ -12210,6 +12218,10 @@ save_diffrn_source.diffrn_id
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _name.ddl2_mandatory          Yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -12222,9 +12234,8 @@ save_diffrn_source.source
       _alias.deprecation_date
       _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_source.source'           .        5.384        mmcif_pdbx.dic
-         '_diffrn_radiation_source'        .        1.0          cifdic.c91
-         '_diffrn_source'                  .        2.0          cif_core.dic
+         '_diffrn_radiation_source'         .         1.0         cifdic.c91
+         '_diffrn_source'                   .         2.0         cif_core.dic
 
     _description.text
 ;              The general class of the radiation source.
@@ -12252,15 +12263,10 @@ save_
 save_diffrn_source.type
 
     _definition.id                '_diffrn_source.type'
-
-    loop_
-      _alias.definition_id
-      _alias.deprecation_date
-      _alias.ddl2_version
-      _alias.dictionary_uri
-         '_diffrn_source.type'         .         5.384         mmcif_pdbx.dic
-         '_diffrn_source_type'         .         2.0.1         cif_core.dic
-
+    _alias.definition_id          '_diffrn_source_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
     _description.text
 ;              The make, model or name of the source of radiation.
 ;
@@ -13476,48 +13482,6 @@ save_
     +  Fix typos in NeXus mappings
 
 ;
-         1.7.10                   2014-04-25
-;
-       Additions of esd's to polarization tags.  Change to NeXus mapping to use
-        NXtransformations instead of NXpoise (HJB)
-
-         + Add _diffrn_radiation.polarisn_norm_esd,
-         _diffrn_radiation.polarisn_ratio_esd,
-         _diffrn_radiation.polarizn_source_norm_esd,
-         _diffrn_radiation.polarizn_source_ratio_esd,
-         _diffrn_radiation.polarizn_Stokes_I_esd,
-         _diffrn_radiation.polarizn_Stokes_Q_esd,
-         _diffrn_radiation.polarizn_Stokes_U_esd,
-         _diffrn_radiation.polarizn_Stokes_V_esd,
-         _diffrn_scan_frame.polarizn_Stokes_I_esd,
-         _diffrn_scan_frame.polarizn_Stokes_Q_esd,
-         _diffrn_scan_frame.polarizn_Stokes_U_esd,
-         _diffrn_scan_frame.polarizn_Stokes_V_esd.
-         + Change NeXus mapping for ARRAY_STRUCTURE_LIST
-         ARRAY_STRUCTURE_LIST_AXIS, AXIS,
-         DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
-         DIFFRN_SCAN_FRAME_AXIS.
-;
-         1.7.11                   2018-12-03
-;
-       Changes for CBFlib 0.9.6 release (HJB)
-
-        + Remove _array_structure_list.array_section_id
-        + Revisions to _category.NX_mapping_details in most categories for
-        array sections.
-        + Change to uniform use of entry:NXentry
-        + Change to uniform use of identification of NXdetector by detector
-        element
-        + Change to uniform use of data_ARRAYID_BINARYID
-        + Add _array_structure_list.array_section_id
-        + Add _map_segment.mask_array_section_id
-        + Add _diffrn_scan_collection.scan_id
-        + Add _diffrn_scan_collection.type
-        + Add _diffrn_scan_collection.translation_width
-        + Add _diffrn_radiation.beam_width
-        + Add _diffrn_radiation.beam_height
-        + Add _diffrn_radiation.beam_flux
-;
          1.7.2                    2013-10-07
 ;  Add FEL detector positioning tags and change back to NXgoniometer
 
@@ -13592,6 +13556,48 @@ save_
     + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
     description and _diffrn_scan_frame.polarizn_Stokes_V description.
 
+;
+         1.7.10                   2014-04-25
+;
+       Additions of esd's to polarization tags.  Change to NeXus mapping to use
+        NXtransformations instead of NXpoise (HJB)
+
+         + Add _diffrn_radiation.polarisn_norm_esd,
+         _diffrn_radiation.polarisn_ratio_esd,
+         _diffrn_radiation.polarizn_source_norm_esd,
+         _diffrn_radiation.polarizn_source_ratio_esd,
+         _diffrn_radiation.polarizn_Stokes_I_esd,
+         _diffrn_radiation.polarizn_Stokes_Q_esd,
+         _diffrn_radiation.polarizn_Stokes_U_esd,
+         _diffrn_radiation.polarizn_Stokes_V_esd,
+         _diffrn_scan_frame.polarizn_Stokes_I_esd,
+         _diffrn_scan_frame.polarizn_Stokes_Q_esd,
+         _diffrn_scan_frame.polarizn_Stokes_U_esd,
+         _diffrn_scan_frame.polarizn_Stokes_V_esd.
+         + Change NeXus mapping for ARRAY_STRUCTURE_LIST
+         ARRAY_STRUCTURE_LIST_AXIS, AXIS,
+         DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
+         DIFFRN_SCAN_FRAME_AXIS.
+;
+         1.7.11                   2018-12-03
+;
+       Changes for CBFlib 0.9.6 release (HJB)
+
+        + Remove _array_structure_list.array_section_id
+        + Revisions to _category.NX_mapping_details in most categories for
+        array sections.
+        + Change to uniform use of entry:NXentry
+        + Change to uniform use of identification of NXdetector by detector
+        element
+        + Change to uniform use of data_ARRAYID_BINARYID
+        + Add _array_structure_list.array_section_id
+        + Add _map_segment.mask_array_section_id
+        + Add _diffrn_scan_collection.scan_id
+        + Add _diffrn_scan_collection.type
+        + Add _diffrn_scan_collection.translation_width
+        + Add _diffrn_radiation.beam_width
+        + Add _diffrn_radiation.beam_height
+        + Add _diffrn_radiation.beam_flux
 ;
          1.8.0                    2021-01-24
 ;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)

--- a/cif_img_expanded.dic
+++ b/cif_img_expanded.dic
@@ -1,0 +1,14704 @@
+#\#CIF_2.0
+
+data_CIF_IMG.DIC
+
+    _dictionary.title             cif_img.dic
+    _dictionary.class             Instance
+    _dictionary.version           1.8.9
+    _dictionary.date              2025-09-16
+    _dictionary.ddl_conformance   3.14.0
+    _dictionary.namespace         ddlm
+    _description.text
+;##############################################################################
+#                                                                            #
+#                       Image CIF Dictionary (imgCIF)                        #
+#             and Crystallographic Binary File Dictionary (CBF)              #
+#            Extending the Macromolecular CIF Dictionary (mmCIF)             #
+#                                                                            #
+#                              Version 1.8.9                                 #
+#                              of 2025-06-10                                 #
+#++/--                                                                       #
+#+/-                                                                         #
+#    ###################################################################     #
+#    # *** WARNING *** THIS IS A DRAFT FOR DISCUSSION *** WARNING ***  #     #
+#    #                 SUBJECT TO CHANGE WITHOUT NOTICE                #     #
+#    #       SEND COMMENTS TO imgcif-l@iucr.org CITING THE VERSION     #     #
+#    ###################################################################     #
+#                  This draft edited by Herbert J. Bernstein                 #
+#                                                                            #
+#     by Andrew P. Hammersley, Herbert J. Bernstein and John D. Westbrook    #
+#                                                                            #
+# This dictionary was adapted from a format discussed at the imgCIF Workshop #
+# held at BNL Oct 1997 and the Crystallographic Binary File Format Draft     #
+# Proposal by Andrew Hammersley.  The first DDL 2.1 Version was created by   #
+# John Westbrook.  This version is being prepared in support of the 2024     #
+# revisions to ITVG, and was drafted by Herbert J. Bernstein and             #
+# incorporates comments by James Hester, I. David Brown, John Westbrook,     #
+# Brian McMahon, Bob Sweet, Paul Ellis, Harry Powell, Wilfred Li,            #
+# Gotzon Madariaga, Frances C. Bernstein, Chris Nielsen, Nicola Ashcroft,    #
+# Aaron Brewster, James Hester and others and reflects comments in           #
+# Bernstein, H. J., Foerster, A., Bhowmick, A., Brewster, A. S.,             #
+# Brockhauser, S., Gelisio, L., Hall, D. R., Leonarski, F., Mariani, V.,     #
+# Santoni, G., Vonrhein, C. & Winter, G. (2020). "Gold Standard for          #
+# Macromolecular Crystallography Diffraction Data", IUCrJ, 7, 784--792,      #
+# https://doi.org/10.1107/S2052252520008672,                                 #
+# https://doi.org//10.1107/S2052252520008672/ti5018sup1.pdf,                 #
+# https://doi.org//10.1107/S2052252520008672/ti5018sup2.pdf                  #
+
+##############################################################################
+#    CONTENTS
+#
+#        CATEGORY_GROUP_LIST
+#        SUB_CATEGORY
+#
+#        category  ARRAY_DATA 
+#
+#                  _array_data.array_id
+#                  _array_data.binary_id
+#                  _array_data.data
+#                  _array_data.external_data_id
+#                  _array_data.header_contents
+#                  _array_data.header_convention
+#                  _array_data.variant
+#
+
+#        category  ARRAY_DATA_EXTERNAL_DATA 
+#
+#                  _array_data_external_data.archive_format
+#                  _array_data_external_data.archive_path
+#                  _array_data_external_data.file_compression
+#                  _array_data_external_data.format
+#                  _array_data_external_data.frame
+#                  _array_data_external_data.id
+#                  _array_data_external_data.path
+#                  _array_data_external_data.uri
+#                  _array_data_external_data.variant
+#                  _array_data_external_data.version
+#
+
+#        category  ARRAY_ELEMENT_SIZE 
+#
+#                  _array_element_size.array_id
+#                  _array_element_size.index
+#                  _array_element_size.size
+#                  _array_element_size.variant
+#
+
+#        category  ARRAY_INTENSITIES 
+#
+#                  _array_intensities.array_id
+#                  _array_intensities.binary_id
+#                  _array_intensities.details
+#                  _array_intensities.gain
+#                  _array_intensities.gain_esd
+#                  _array_intensities.linearity
+#                  _array_intensities.offset
+#                  _array_intensities.overload
+#                  _array_intensities.pixel_fast_bin_size
+#                  _array_intensities.pixel_slow_bin_size
+#                  _array_intensities.pixel_binning_method
+#                  _array_intensities.scaling
+#                  _array_intensities.undefined_value
+#                  _array_intensities.underload
+#                  _array_intensities.variant
+#
+
+#        category  ARRAY_STRUCTURE 
+#
+#                  _array_structure.byte_order
+#                  _array_structure.compression_type
+#                  _array_structure.compression_type_flag
+#                  _array_structure.encoding_type
+#                  _array_structure.id
+#                  _array_structure.variant
+#
+
+#        category  ARRAY_STRUCTURE_LIST 
+#
+#                  _array_structure_list.axis_set_id
+#                  _array_structure_list.array_id
+#                  _array_structure_list.array_section_id
+#                  _array_structure_list.dimension
+#                  _array_structure_list.direction
+#                  _array_structure_list.index
+#                  _array_structure_list.precedence
+#                  _array_structure_list.variant
+#
+
+#        category  ARRAY_STRUCTURE_LIST_SECTION 
+#
+#                  _array_structure_list_section.array_id
+#                  _array_structure_list_section.end
+#                  _array_structure_list_section.id
+#                  _array_structure_list_section.index
+#                  _array_structure_list_section.start
+#                  _array_structure_list_section.stride
+#                  _array_structure_list_section.variant
+#
+
+#        category  ARRAY_STRUCTURE_LIST_AXIS 
+#
+#                  _array_structure_list_axis.axis_id
+#                  _array_structure_list_axis.axis_set_id
+#                  _array_structure_list_axis.angle
+#                  _array_structure_list_axis.angle_increment
+#                  _array_structure_list_axis.angular_pitch
+#                  _array_structure_list_axis.displacement
+#                  _array_structure_list_axis.displacement_increment
+#                  _array_structure_list_axis.fract_displacement
+#                  _array_structure_list_axis.fract_displacement_increment
+#                  _array_structure_list_axis.radial_pitch
+#                  _array_structure_list_axis.reference_angle
+#                  _array_structure_list_axis.reference_displacement
+#                  _array_structure_list_axis.variant
+#
+
+#        category  AXIS 
+#
+#                  _axis.depends_on
+#                  _axis.equipment
+#                  _axis.equipment_component
+#                  _axis.id
+#                  _axis.offset[1]
+#                  _axis.offset[2]
+#                  _axis.offset[3]
+#                  _axis.rotation
+#                  _axis.rotation_axis
+#                  _axis.type
+#                  _axis.system
+#                  _axis.vector[1]
+#                  _axis.vector[2]
+#                  _axis.vector[3]
+#                  _axis.variant
+#
+
+#        category  DIFFRN 
+#
+#                  _diffrn.id
+#
+
+#        category  DIFFRN_DATA_FRAME 
+#
+#                  _diffrn_data_frame.array_id
+#                  _diffrn_data_frame.array_section_id
+#                  _diffrn_data_frame.binary_id
+#                  _diffrn_data_frame.center_derived
+#                  _diffrn_data_frame.center_fast
+#                  _diffrn_data_frame.center_slow
+#                  _diffrn_data_frame.center_units
+#                  _diffrn_data_frame.detector_element_id
+#                  _diffrn_data_frame.diffrn_id
+#                  _diffrn_data_frame.id
+#                  _diffrn_data_frame.details
+#                  _diffrn_data_frame.variant
+#
+
+#        category  DIFFRN_DETECTOR 
+#
+#                  _diffrn_detector.details
+#                  _diffrn_detector.detector
+#                  _diffrn_detector.diffrn_id
+#                  _diffrn_detector.dtime
+#                  _diffrn_detector.gain_setting
+#                  _diffrn_detector.id
+#                  _diffrn_detector.layer_thickness
+#                  _diffrn_detector.number_of_axes
+#                  _diffrn_detector.type
+#                  _diffrn_detector.variant
+#
+
+#        category  DIFFRN_DETECTOR_AXIS 
+#
+#                  _diffrn_detector_axis.axis_id
+#                  _diffrn_detector_axis.detector_id
+#                  _diffrn_detector_axis.diffrn_id
+#                  _diffrn_detector_axis.variant
+#
+
+#        category  DIFFRN_DETECTOR_ELEMENT 
+#
+#                  _diffrn_detector_element.id
+#                  _diffrn_detector_element.detector_id
+#                  _diffrn_detector_element.diffrn_id
+#                  _diffrn_detector_element.reference_center_fast
+#                  _diffrn_detector_element.reference_center_slow
+#                  _diffrn_detector_element.reference_center_units
+#                  _diffrn_detector_element.variant
+#
+
+#        category  DIFFRN_MEASUREMENT 
+#
+#                  _diffrn_measurement.diffrn_id
+#                  _diffrn_measurement.details
+#                  _diffrn_measurement.device
+#                  _diffrn_measurement.device_details
+#                  _diffrn_measurement.device_type
+#                  _diffrn_measurement.diffrn_id
+#                  _diffrn_measurement.id
+#                  _diffrn_measurement.method
+#                  _diffrn_measurement.number_of_axes
+#                  _diffrn_measurement.sample_detector_distance
+#                  _diffrn_measurement.sample_detector_voffset
+#                  _diffrn_measurement.specimen_support
+#                  _diffrn_measurement.variant
+#
+
+#        category  DIFFRN_MEASUREMENT_AXIS 
+#
+#                  _diffrn_measurement_axis.axis_id
+#                  _diffrn_measurement_axis.measurement_device
+#                  _diffrn_measurement_axis.measurement_id
+#                  _diffrn_measurement_axis.variant
+#
+
+#        category  DIFFRN_RADIATION 
+#
+#                  _diffrn_radiation.beam_width
+#                  _diffrn_radiation.beam_height
+#                  _diffrn_radiation.beam_flux
+#                  _diffrn_radiation.collimation
+#                  _diffrn_radiation.diffrn_id
+#                  _diffrn_radiation.div_x_source
+#                  _diffrn_radiation.div_y_source
+#                  _diffrn_radiation.div_x_y_source
+#                  _diffrn_radiation.filter_edge
+#                  _diffrn_radiation.inhomogeneity
+#                  _diffrn_radiation.monochromator
+#                  _diffrn_radiation.polarisn_norm
+#                  _diffrn_radiation.polarisn_ratio
+#                  _diffrn_radiation.polarisn_norm_esd
+#                  _diffrn_radiation.polarisn_ratio_esd
+#                  _diffrn_radiation.polarizn_source_norm
+#                  _diffrn_radiation.polarizn_source_norm_esd
+#                  _diffrn_radiation.polarizn_source_ratio
+#                  _diffrn_radiation.polarizn_source_ratio_esd
+#                  _diffrn_radiation.polarizn_Stokes_I
+#                  _diffrn_radiation.polarizn_Stokes_Q
+#                  _diffrn_radiation.polarizn_Stokes_U
+#                  _diffrn_radiation.polarizn_Stokes_V
+#                  _diffrn_radiation.polarizn_Stokes_I_esd
+#                  _diffrn_radiation.polarizn_Stokes_Q_esd
+#                  _diffrn_radiation.polarizn_Stokes_U_esd
+#                  _diffrn_radiation.polarizn_Stokes_V_esd
+#                  _diffrn_radiation.probe
+#                  _diffrn_radiation.type
+#                  _diffrn_radiation.variant
+#                  _diffrn_radiation.wavelength_id
+#                  _diffrn_radiation.xray_symbol
+#
+
+#        category  DIFFRN_REFLN 
+#
+#                  _diffrn_refln.diffrn_id
+#                  _diffrn_refln.frame_id
+#                  _diffrn_refln.variant
+#
+
+#        category  DIFFRN_SCAN 
+#
+#                  _diffrn_scan.id
+#                  _diffrn_scan.date_end
+#                  _diffrn_scan.date_end_estimated
+#                  _diffrn_scan.date_start
+#                  _diffrn_scan.diffrn_id
+#                  _diffrn_scan.integration_time
+#                  _diffrn_scan.frame_id_start
+#                  _diffrn_scan.frame_id_end
+#                  _diffrn_scan.frames
+#                  _diffrn_scan.time_period
+#                  _diffrn_scan.time_rstrt_incr
+#                  _diffrn_scan.variant
+#
+
+#        category  DIFFRN_SCAN_AXIS 
+#
+#                  _diffrn_scan_axis.axis_id
+#                  _diffrn_scan_axis.angle_start
+#                  _diffrn_scan_axis.angle_range
+#                  _diffrn_scan_axis.angle_increment
+#                  _diffrn_scan_axis.angle_rstrt_incr
+#                  _diffrn_scan_axis.displacement_start
+#                  _diffrn_scan_axis.displacement_range
+#                  _diffrn_scan_axis.displacement_increment
+#                  _diffrn_scan_axis.displacement_rstrt_incr
+#                  _diffrn_scan_axis.displacement_diffrn_id
+#                  _diffrn_scan_axis.reference_angle
+#                  _diffrn_scan_axis.reference_displacement
+#                  _diffrn_scan_axis.scan_id
+#                  _diffrn_scan_axis.variant
+#
+
+#        category  DIFFRN_SCAN_COLLECTION 
+#
+#                  _diffrn_scan_collection.details
+#                  _diffrn_scan_collection.diffrn_id
+#                  _diffrn_scan_collection.scan_id
+#                  _diffrn_scan_collection.type
+#                  _diffrn_scan_collection.translation_width
+#                  _diffrn_scan_collection.variant
+#
+
+#        category  DIFFRN_SCAN_FRAME 
+#
+#                  _diffrn_scan_frame.date
+#                  _diffrn_scan_frame.diffrn_id
+#                  _diffrn_scan_frame.frame_id
+#                  _diffrn_scan_frame.frame_number
+#                  _diffrn_scan_frame.integration_time
+#                  _diffrn_scan_frame.polarizn_Stokes_I
+#                  _diffrn_scan_frame.polarizn_Stokes_Q
+#                  _diffrn_scan_frame.polarizn_Stokes_U
+#                  _diffrn_scan_frame.polarizn_Stokes_V
+#                  _diffrn_scan_frame.polarizn_Stokes_I_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_Q_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_U_esd
+#                  _diffrn_scan_frame.polarizn_Stokes_V_esd
+#                  _diffrn_scan_frame.scan_id
+#                  _diffrn_scan_frame.time_period
+#                  _diffrn_scan_frame.time_rstrt_incr
+#                  _diffrn_scan_frame.variant
+#
+
+#        category  DIFFRN_SCAN_FRAME_AXIS 
+#
+#                  _diffrn_scan_frame_axis.axis_id
+#                  _diffrn_scan_frame_axis.angle
+#                  _diffrn_scan_frame_axis.angle_increment
+#                  _diffrn_scan_frame_axis.angle_rstrt_incr
+#                  _diffrn_scan_frame_axis.displacement
+#                  _diffrn_scan_frame_axis.displacement_increment
+#                  _diffrn_scan_frame_axis.displacement_rstrt_incr
+#                  _diffrn_scan_frame_axis.diffrn_id
+#                  _diffrn_scan_frame_axis.reference_angle
+#                  _diffrn_scan_frame_axis.reference_displacement
+#                  _diffrn_scan_frame_axis.frame_id
+#                  _diffrn_scan_frame_axis.variant
+#
+
+#        category  DIFFRN_SCAN_FRAME_MONITOR 
+#
+#                  _diffrn_scan_frame_monitor.id
+#                  _diffrn_scan_frame_monitor.detector_id
+#                  _diffrn_scan_frame_monitor.diffrn_id
+#                  _diffrn_scan_frame_monitor.frame_id
+#                  _diffrn_scan_frame_monitor.integration_time
+#                  _diffrn_scan_frame_monitor.monitor_value
+#                  _diffrn_scan_frame_monitor.scan_id
+#                  _diffrn_scan_frame_monitor.variant
+#
+
+#        category  DIFFRN_SOURCE 
+#
+#                  _diffrn_source.diffrn_id
+#                  _diffrn_source.source
+#                  _diffrn_source.type
+#
+
+#        category  MAP 
+#
+#                  _map.details
+#                  _map.diffrn_id
+#                  _map.entry_id
+#                  _map.id
+#                  _map.variant
+#
+
+#        category  MAP_SEGMENT 
+#
+#                  _map_segment.array_id
+#                  _map_segment.array_section_id
+#                  _map_segment.binary_id
+#                  _map_segment.mask_array_id
+#                  _map_segment.mask_array_section_id
+#                  _map_segment.mask_binary_id
+#                  _map_segment.id
+#                  _map_segment.map_id
+#                  _map_segment.details
+#                  _map_segment.variant
+#
+
+#        category  VARIANT 
+#
+#                  _variant.details
+#                  _variant.diffrn_id
+#                  _variant.entry_id
+#                  _variant.role
+#                  _variant.timestamp
+#                  _variant.variant
+#                  _variant.variant_of
+#
+
+#       ***DEPRECATED*** data items 
+#
+#                  _diffrn_detector_axis.id
+#                  _diffrn_detector_element.center[1]
+#                  _diffrn_detector_element.center[2]
+#                  _diffrn_measurement_axis.id
+#                  _diffrn_scan_frame_monitor.value
+#
+#       ***DEPRECATED*** category  DIFFRN_FRAME_DATA
+#
+#                  _diffrn_frame_data.array_id
+#                  _diffrn_frame_data.binary_id
+#                  _diffrn_frame_data.detector_element_id
+#                  _diffrn_frame_data.id
+#                  _diffrn_frame_data.details
+#
+
+#        ITEM_TYPE_LIST
+#        ITEM_UNITS_LIST
+#        DICTIONARY_HISTORY
+#
+##############################################################################
+
+#Category Group Table:  #
++--------------------------------------------------------------------------------------------------------------------+
+|ARRAY_DATA_GROUP|Categories that describe array data.                                                               |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || ARRAY_DATA               | Data items in the ARRAY_DATA category are the containers for the     ||
+|                ||                          | array data items described in the category ARRAY_STRUCTURE.          ||
+|                ||                          |                                                                      ||
+|                ||                          | It is recognized that the data in this category need to be used in   ||
+|                ||                          | two distinct ways. During a data collection the lack of ancillary    ||
+|                ||                          | data and timing constraints in processing data may dictate the need  ||
+|                ||                          | to make a 'miniCBF' nothing more than an essential minimum of        ||
+|                ||                          | information to record the results of the data collection. In that    ||
+|                ||                          | case it is proper to use the ARRAY_DATA category as a container for  ||
+|                ||                          | just a single image and a compacted, beam-line dependent list of     ||
+|                ||                          | data collection parameter values. In such a case, only the tags      ||
+|                ||                          | '_array_data.header_convention', '_array_data.header_contents' and   ||
+|                ||                          | '_array_data.data' need be populated.                                ||
+|                ||                          |                                                                      ||
+|                ||                          | For full processing and archiving, most of the tags in this          ||
+|                ||                          | dictionary will need to be populated.                                ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_DATA_EXTERNAL_DATA     | Data items in the ARRAY_DATA_EXTERNAL_DATA category      | ||
+|                || |   |                              | record information needed to refer to data arrays in     | ||
+|                || |   |                              | external datasets.  All necessary metadata must also     | ||
+|                || |   |                              | be copied or linked.                                     | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_ELEMENT_SIZE       | Data items in the ARRAY_ELEMENT_SIZE category record the physical    ||
+|                ||                          | size of array elements along each array dimension.                   ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_INTENSITIES        | Data items in the ARRAY_INTENSITIES category record the information  ||
+|                ||                          | required to recover the intensity data from the set of data values   ||
+|                ||                          | stored in the ARRAY_DATA category.                                   ||
+|                ||                          |                                                                      ||
+|                ||                          | The detector may have a complex relationship between the raw         ||
+|                ||                          | intensity values and the number of incident photons. In most cases,  ||
+|                ||                          | the number stored in the final array will have a simple linear       ||
+|                ||                          | relationship to the actual number of incident photons, given by      ||
+|                ||                          | _array_intensities.gain. If raw, uncorrected values are presented    ||
+|                ||                          | (e.g. for calibration experiments), the value of                     ||
+|                ||                          | _array_intensities.linearity will be 'raw' and                       ||
+|                ||                          | _array_intensities.gain will not be used.                            ||
+|                ||--------------------------+----------------------------------------------------------------------||
+|                || ARRAY_STRUCTURE          | Data items in the ARRAY_STRUCTURE category record the organization   ||
+|                ||                          | and encoding of array data that may be stored in the ARRAY_DATA      ||
+|                ||                          | category.                                                            ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | ARRAY_STRUCTURE_LIST         | Data items in the ARRAY_STRUCTURE_LIST category record   | ||
+|                || |   |                              | the size and organization of each array dimension.       | ||
+|                || |   |                              |                                                          | ||
+|                || |   |                              | The relationship to physical axes may be given.          | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_SECTION | Data items in the ARRAY_STRUCTURE_LIST_SECTION   | | ||
+|                || |   | |   |                              | category identify the dimension-by-dimension     | | ||
+|                || |   | |   |                              | start, end and stride of each section of an      | | ||
+|                || |   | |   |                              | array that is to be referenced.                  | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | For any array of array_id, ARRAYID, array        | | ||
+|                || |   | |   |                              | section ids of the form                          | | ||
+|                || |   | |   |                              | ARRAYID(start1:end1:stride1,start2:end2:stride2, | | ||
+|                || |   | |   |                              | ...)                                             | | ||
+|                || |   | |   |                              | are defined by default.                          | | ||
+|                || |   | |   |------------------------------+--------------------------------------------------| | ||
+|                || |   | |   | ARRAY_STRUCTURE_LIST_AXIS    | Data items in the ARRAY_STRUCTURE_LIST_AXIS      | | ||
+|                || |   | |   |                              | category describe the physical settings of sets  | | ||
+|                || |   | |   |                              | of axes for the centres of pixels that           | | ||
+|                || |   | |   |                              | correspond to data points described in the       | | ||
+|                || |   | |   |                              | ARRAY_STRUCTURE_LIST category.                   | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | In the simplest cases, the physical increments   | | ||
+|                || |   | |   |                              | of a single axis correspond to the increments of | | ||
+|                || |   | |   |                              | a single array index. More complex               | | ||
+|                || |   | |   |                              | organizations, e.g. spiral scans, may require    | | ||
+|                || |   | |   |                              | coupled motions along multiple axes.             | | ||
+|                || |   | |   |                              |                                                  | | ||
+|                || |   | |   |                              | Note that a spiral scan uses two coupled axes:   | | ||
+|                || |   | |   |                              | one for the angular direction and one for the    | | ||
+|                || |   | |   |                              | radial direction. This differs from a            | | ||
+|                || |   | |   |                              | cylindrical scan for which the two axes are not  | | ||
+|                || |   | |   |                              | coupled into one set.                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   |-----------------------------------------------------------------------------------------| ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|AXIS_GROUP      |Categories that describe axes.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || AXIS | Data items in the AXIS category record the information required to describe the various  ||
+|                ||      | goniometer, detector, source and other axes needed to specify a data collection or the   ||
+|                ||      | axes defining the coordinate system of an image.                                         ||
+|                ||      |                                                                                          ||
+|                ||      | The location of each axis is specified by two vectors: the axis itself, given by a unit  ||
+|                ||      | vector in the direction of the axis, and an offset to the base of the unit vector.       ||
+|                ||      |                                                                                          ||
+|                ||      | The vectors defining an axis are referenced to an appropriate coordinate system. The     ||
+|                ||      | axis vector, itself, is a dimensionless unit vector. Where meaningful, the offset vector ||
+|                ||      | is given in millimetres. In coordinate systems not measured in metres, the offset is not ||
+|                ||      | specified and is taken as zero.                                                          ||
+|                ||      |                                                                                          ||
+|                ||      | The available coordinate systems are:                                                    ||
+|                ||      |                                                                                          ||
+|                ||      | The imgCIF standard laboratory coordinate system                                         ||
+|                ||      | The NeXus/HDF5 McStas laboratory coordinate system                                       ||
+|                ||      | The direct lattice (fractional atomic coordinates)                                       ||
+|                ||      | The orthogonal Cartesian coordinate system (real space)                                  ||
+|                ||      | The reciprocal lattice                                                                   ||
+|                ||      | An abstract orthogonal Cartesian coordinate frame                                        ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|DIFFRN_GROUP    |Categories that describe details of the diffraction experiment.                                    |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || DIFFRN                     | Data items in the DIFFRN category record the details about the     ||
+|                ||                            | diffraction data and their measurement. This is a stub category    ||
+|                ||                            | for the cif_img dicionary to complete the tree for tags that are   ||
+|                ||                            | aliases for tags in the various diffrn_... categories in the       ||
+|                ||                            | mmCIF_PDBx dictionary.                                             ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_DATA_FRAME          | Data items in the DIFFRN_DATA_FRAME category record the details    ||
+|                ||                            | about each frame of data.                                          ||
+|                ||                            |                                                                    ||
+|                ||                            | The items in this category were previously in a DIFFRN_FRAME_DATA  ||
+|                ||                            | category, which is now deprecated. The items from the old category ||
+|                ||                            | are provided as aliases but should not be used for new work.       ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_DETECTOR            | Data items in the DIFFRN_DETECTOR category describe the detector   ||
+|                ||                            | used to measure the scattered radiation, including any analyser    ||
+|                ||                            | and post-sample collimation.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_AXIS | Data items in the DIFFRN_DETECTOR_AXIS category associate axes   | ||
+|                || |   |                      | with detectors.                                                  | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_DETECTOR_ELEMENT | Data items in the DIFFRN_DETECTOR_ELEMENT category record the | ||
+|                || |   |                         | details about spatial layout and other characteristics of     | ||
+|                || |   |                         | each element of a detector which may have multiple elements.  | ||
+|                || |   |                         |                                                               | ||
+|                || |   |                         | In most cases, giving more detailed information in            | ||
+|                || |   |                         | ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS is         | ||
+|                || |   |                         | preferable to simply providing the centre of the detector     | ||
+|                || |   |                         | element.                                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_MEASUREMENT         | Data items in the DIFFRN_MEASUREMENT category record details about ||
+|                ||                            | the device used to orient and/or position the crystal during data  ||
+|                ||                            | measurement and the manner in which the diffraction data were      ||
+|                ||                            | measured.                                                          ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_MEASUREMENT_AXIS | Data items in the DIFFRN_MEASUREMENT_AXIS category associate  | ||
+|                || |   |                         | axes with goniometers.                                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || DIFFRN_RADIATION           | Data items in the DIFFRN_RADIATION category describe the radiation ||
+|                ||                            | used for measuring diffraction intensities, its collimation and    ||
+|                ||                            | monochromatization before the sample.                              ||
+|                ||                            |                                                                    ||
+|                ||                            | Post-sample treatment of the beam is described by data items in    ||
+|                ||                            | the DIFFRN_DETECTOR category.                                      ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_REFLN               | This category redefinition has been added to extend the key of the ||
+|                ||                            | standard DIFFRN_REFLN category.                                    ||
+|                ||                            |                                                                    ||
+|                ||                            | Data items in the DIFFRN_REFLN category record details about the   ||
+|                ||                            | intensities in the diffraction data set identified by              ||
+|                ||                            | _diffrn_refln.diffrn_id.                                           ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLN data items refer to individual intensity          ||
+|                ||                            | measurements and must be included in looped lists.                 ||
+|                ||                            |                                                                    ||
+|                ||                            | The DIFFRN_REFLNS data items specify the parameters that apply to  ||
+|                ||                            | all intensity measurements in the particular diffraction data set  ||
+|                ||                            | identified by _diffrn_reflns.diffrn_id and _diffrn_refln.frame_id  ||
+|                ||----------------------------+--------------------------------------------------------------------||
+|                || DIFFRN_SCAN                | Data items in the DIFFRN_SCAN category describe the parameters of  ||
+|                ||                            | one or more scans, relating axis positions to frames.              ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_AXIS | Data items in the DIFFRN_SCAN_AXIS category describe the settings of | ||
+|                || |   |                  | axes for particular scans. Unspecified axes are assumed to be at     | ||
+|                || |   |                  | their zero points.                                                   | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_COLLECTION | Data items in the DIFFRN_SCAN_COLLECTION category describe the | ||
+|                || |   |                        | type of collection strategy involved in each scan.             | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | DIFFRN_SCAN_FRAME | Data items in the DIFFRN_SCAN_FRAME category describe the           | ||
+|                || |   |                   | relationships of particular frames to scans.                        | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_AXIS | Data items in the DIFFRN_SCAN_FRAME_AXIS category      | | ||
+|                || |   | |   |                        | describe the settings of axes for particular frames.   | | ||
+|                || |   | |   |                        | Unspecified axes are assumed to be at their zero       | | ||
+|                || |   | |   |                        | points. If, for any given frame, nonzero values apply  | | ||
+|                || |   | |   |                        | for any of the data items in this category, those      | | ||
+|                || |   | |   |                        | values should be given explicitly in this category and | | ||
+|                || |   | |   |                        | not simply inferred from values in DIFFRN_SCAN_AXIS.   | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |---+-----------------------------------------------------------------------------------------| ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || |   | |   | DIFFRN_SCAN_FRAME_MONITOR | Data items in the DIFFRN_SCAN_FRAME_MONITOR         | | ||
+|                || |   | |   |                           | category record the values and details about each   | | ||
+|                || |   | |   |                           | monitor for each frame of data during a scan.       | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | Each monitor value is uniquely identified by the    | | ||
+|                || |   | |   |                           | combination of the scan id given by                 | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.scan_id, the frame id given by   | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.frame_id, the monitor's  | | ||
+|                || |   | |   |                           | detector id given by                                | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.detector_id, and a       | | ||
+|                || |   | |   |                           | 1-based ordinal given by                            | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.id.                      | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | If there is only one frame for the scan, the value  | | ||
+|                || |   | |   |                           | of _diffrn_scan_frame_monitor.frame_id may be       | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | |   |                           |                                                     | | ||
+|                || |   | |   |                           | A single frame may have more than one monitor       | | ||
+|                || |   | |   |                           | value, and each monitor value may be the result of  | | ||
+|                || |   | |   |                           | integration over the entire frame integration time  | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame.integration_time, or many        | | ||
+|                || |   | |   |                           | monitor values may be reported over shorter times   | | ||
+|                || |   | |   |                           | given by the value of                               | | ||
+|                || |   | |   |                           | _diffrn_scan_frame_monitor.integration_time. If     | | ||
+|                || |   | |   |                           | only one monitor value for a given monitor is       | | ||
+|                || |   | |   |                           | collected during the integration time of the frame, | | ||
+|                || |   | |   |                           | the value of _diffrn_scan_frame_monitor.id may be   | | ||
+|                || |   | |   |                           | omitted.                                            | | ||
+|                || |   | +-------------------------------------------------------------------------------------+ | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || DIFFRN_SOURCE              | Data items in the DIFFRN_SOURCE category describe details of the   ||
+|                ||                            | source of radiation used in the diffraction experiment.            ||
+|                ||                            | This is a stub category for use of DIFFRN_SOURCE which is          ||
+|                ||                            | specified in the mmCIF_PDBx dictionary                             ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|MAP_GROUP       |Categories that describe maps.                                                                     |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || MAP     | Data items in the MAP category record the details of a map. Maps record values of     ||
+|                ||         | parameters, such as density, that are functions of position within a cell or are      ||
+|                ||         | functions of orthogonal coordinates in three space.                                   ||
+|                ||         |                                                                                       ||
+|                ||         | A map may is composed of one or more map segments specified in the MAP_SEGMENT        ||
+|                ||         | category.                                                                             ||
+|                ||         |                                                                                       ||
+|                ||         | Examples are given in the MAP_SEGMENT category.                                       ||
+|                ||-------------------------------------------------------------------------------------------------||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                || |   | MAP_SEGMENT | Data items in the MAP_SEGMENT category record the details about each      | ||
+|                || |   |             | segment (section or brick) of a map.                                      | ||
+|                || +---------------------------------------------------------------------------------------------+ ||
+|                |+-------------------------------------------------------------------------------------------------+|
+|----------------+---------------------------------------------------------------------------------------------------|
+|VARIANT_GROUP   |Categories that describe variants                                                                  |
+|                |---------------------------------------------------------------------------------------------------|
+|                |+-------------------------------------------------------------------------------------------------+|
+|                || VARIANT | Data items in the VARIANT category record the details about sets of variants of data  ||
+|                ||         | items.                                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | There is sometimes a need to allow for multiple versions of the same data items in    ||
+|                ||         | order to allow for refinements and corrections to earlier assumptions, observations   ||
+|                ||         | and calculations. In order to allow data sets to contain more than one variant of the ||
+|                ||         | same information, an optional ...variant data item as a pointer to _variant.variant   ||
+|                ||         | has been added to the key of every category, as an implicit data item with a null     ||
+|                ||         | (empty) default value.                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | All rows in a category with the same variant value are considered to be related to    ||
+|                ||         | one another and to all rows in other categories with the same variant value. For a    ||
+|                ||         | given variant, all such rows are also considered to be related to all rows with a     ||
+|                ||         | null variant value, except that a row with a null variant value is for which all      ||
+|                ||         | other components of its key are identical to those entries in another row with a      ||
+|                ||         | non-null variant value is not related the the rows with that non-null variant value.  ||
+|                ||         | This behavior is similar to the convention for identifying alternate conformers in an ||
+|                ||         | atom list.                                                                            ||
+|                ||         |                                                                                       ||
+|                ||         | An optional role may be specified for a variant as the value of _variant.role.        ||
+|                ||         | Possible roles are null, "preferred", "raw data", "unsuccessful trial".               ||
+|                ||         |                                                                                       ||
+|                ||         | variants may carry an optional timestamp as the value of _variant.timestamp.          ||
+|                ||         |                                                                                       ||
+|                ||         | variants may be related to other variants from which they were derived by the value   ||
+|                ||         | of _variant.variant_of                                                                ||
+|                ||         |                                                                                       ||
+|                ||         | Further details about the variant may be specified as the value of _variant.details.  ||
+|                ||         |                                                                                       ||
+|                ||         | In order to allow variant information from multiple datasets to be combined,          ||
+|                ||         | _variant.diffrn_id and/or _variant.entry_id may be used.                              ||
+|                |+-------------------------------------------------------------------------------------------------+|
++--------------------------------------------------------------------------------------------------------------------+
+;
+
+save_HEAD
+
+    _definition.id                HEAD
+    _definition.scope             Category
+    _definition.class             Head
+    _description.text
+;
+    The HEAD category is the parent category of all definitions in the
+    dictionary
+;
+    _name.category_id             HEAD
+    _name.object_id               HEAD
+
+    _import.get
+        [{'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
+          'save':multiblock_core}]
+
+save_
+
+save_ARRAY_DATA
+
+    _definition.id                array_data
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_DATA category are the containers for
+     the array data items described in the category ARRAY_STRUCTURE.
+
+     It is recognized that the data in this category need to be used in
+     two distinct ways.  During a data collection the lack of ancillary
+     data and timing constraints in processing data may dictate the
+     need to make a 'miniCBF', nothing more than an essential minimum
+     of information to record the results of the data collection.  In that
+     case it is proper to use the ARRAY_DATA category as a
+     container for just a single image and a compacted, beamline-dependent
+     list of data collection parameter values.  In such
+     a case, only the tags '_array_data.header_convention',
+     '_array_data.header_contents' and '_array_data.data' need be
+     populated.
+
+     For full processing and archiving, most of the tags in this
+     dictionary will need to be populated.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_data
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_data.array_id'
+         '_array_data.binary_id'
+         '_array_data.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+
+         loop_
+        _array_data.array_id
+        _array_data.binary_id
+        _array_data.data
+        image_1 1
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF_CANONICAL"
+        Content-Transfer-Encoding: X-BASE16
+        X-Binary-Size: 3927126
+        X-Binary-ID: 1
+        Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
+
+        # Hexadecimal encoding, byte 0, byte order ...21
+        #
+        H4< 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
+        ....
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+        image_2 2
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF-PACKED"
+        Content-Transfer-Encoding: BASE64
+        X-Binary-Size: 3745758
+        X-Binary-ID: 2
+        Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+
+        ELhQAAAAAAAA...
+        ...
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+;
+        Example 1.
+
+        This example shows two binary data blocks.  The first one
+        was compressed by the CBF_CANONICAL compression algorithm and is
+        presented as hexadecimal data.  The first character 'H' on the
+        data lines means hexadecimal.  It could have been 'O' for octal
+        or 'D' for decimal.  The second character on the line shows
+        the number of bytes in each word (in this case '4'), which then
+        requires eight hexadecimal digits per word.  The third character
+        gives the order of octets within a word, in this case '<'
+        for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
+        character '>' could have been used for the ordering 1234
+        (i.e. 'little-endian').  The block has a 'message digest'
+        to check the integrity of the data.
+
+        The second block is similar, but uses CBF_PACKED compression
+        and BASE64 encoding.  Note that the size and the digest are
+        different.
+;
+;
+        ###CBF: VERSION 1.5
+        # CBF file written by CBFlib v0.7.8
+
+        data_insulin_pilatus6m
+
+        _array_data.header_convention SLS_1.0
+        _array_data.header_contents
+        ;
+        # Detector: PILATUS 6M SN: 60-0001
+        # 2007/Jun/17 15:12:36.928
+        # Pixel_size 172e-6 m x 172e-6 m
+        # Silicon sensor, thickness 0.000320 m
+        # Exposure_time 0.995000 s
+        # Exposure_period 1.000000 s
+        # Tau = 194.0e-09 s
+        # Count_cutoff 1048575 counts
+        # Threshold_setting 5000 eV
+        # Wavelength 1.2398 A
+        # Energy_range (0, 0) eV
+        # Detector_distance 0.15500 m
+        # Detector_Voffset -0.01003 m
+        # Beam_xy (1231.00, 1277.00) pixels
+        # Flux 22487563295 ph/s
+        # Filter_transmission 0.0008
+        # Start_angle 13.0000 deg.
+        # Angle_increment 1.0000 deg.
+        # Detector_2theta 0.0000 deg.
+        # Polarization 0.990
+        # Alpha 0.0000 deg.
+        # Kappa 0.0000 deg.
+        # Phi 0.0000 deg.
+        # Chi 0.0000 deg.
+        # Oscillation_axis  X, CW
+        # N_oscillations 1
+        ;
+
+        _array_data.data
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="x-CBF_BYTE_OFFSET"
+        Content-Transfer-Encoding: BINARY
+        X-Binary-Size: 6247567
+        X-Binary-ID: 1
+        X-Binary-Element-Type: "signed 32-bit integer"
+        X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+        Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
+        X-Binary-Number-of-Elements: 6224001
+        X-Binary-Size-Fastest-Dimension: 2463
+        X-Binary-Size-Second-Dimension: 2527
+        X-Binary-Size-Padding: 4095
+
+        ...
+
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+;
+        Example 2.
+
+        This example shows a single image in a miniCBF, provided by
+        E. Eikenberry.  The entire CBF consists of one data block
+        containing one category and three tags.  The CBFlib
+        program convert_miniCBF and a suitable template file
+        can be used to convert this miniCBF to a full imgCIF
+        file.
+;
+
+    _nx_mapping.details
+;    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.data  DATAARRAY
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_data.array_id
+
+    _definition.id                '_array_data.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+
+              If not given, it defaults to 1.
+
+;
+    _name.category_id             array_data
+    _name.object_id               array_id
+    _name.linked_item_id          '_array_structure.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_data.binary_id
+
+    _definition.id                '_array_data.binary_id'
+    _description.text
+;             This item is an integer identifier which, along with
+              _array_data.array_id, should uniquely identify the
+              particular block of array data.
+
+              If _array_data.binary_id is not explicitly given,
+              it defaults to 1.
+
+              The value of _array_data.binary_id distinguishes
+              among multiple sets of data with the same array
+              structure.
+
+              If the MIME header of the data array specifies a
+              value for X-Binary-ID, the value of  _array_data.binary_id
+              should be equal to the value given for X-Binary-ID.
+;
+    _name.category_id             array_data
+    _name.object_id               binary_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _enumeration.default          1
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_data.data
+
+    _definition.id                '_array_data.data'
+    _description.text
+;             The value of _array_data.data contains the array data
+              encapsulated in a STAR string.  The value of this item is 
+              required unless a value is given for 
+               _array_data.external_data_id instead, in which 
+              case, a null value of '.' should be given here.
+
+              The representation used is a variant on the
+              Multipurpose Internet Mail Extensions (MIME) specified
+              in RFC 2045-2049 by N. Freed et al.  The boundary
+              delimiter used in writing an imgCIF or CBF is
+              \n--CIF-BINARY-FORMAT-SECTION-- (including the
+              required initial \n--, where \n represents the system
+              newline character(s)).
+
+              The Content-Type may be any of the discrete types permitted
+              in RFC 2045; 'application/octet-stream' is recommended
+              for diffraction images in the ARRAY_DATA category.
+              Note:  When appropriate in other categories, e.g. for
+              photographs of crystals, more precise types, such as
+              'image/jpeg', 'image/tiff', 'image/png', etc. should be used.
+
+              If an octet stream was compressed, the compression should
+              be specified by the parameter
+                conversions="X-CBF_PACKED"
+              or the parameter
+                conversions="X-CBF_CANONICAL"
+              or the parameter
+                conversions="X-CBF_BYTE_OFFSET"
+              or the parameter
+                conversions="X-CBF_BACKGROUND_OFFSET_DELTA"
+
+              If the parameter 
+                conversions="X-CBF_PACKED"
+              is given it may be further modified with the parameters
+                uncorrelated_sections
+              or
+                flat
+              (e.g. conversions="X-CBF_PACKED flat").
+              In such cases the _array_structure.compression_type_flag
+              should also be present with the corresponding value.
+
+              If the "uncorrelated_sections" parameter is
+              given, each section will be compressed without using
+              the prior section for averaging.
+
+              If the "flat" parameter is given, each
+              image will be treated as one long row.
+
+              Note that X-CBF_CANONICAL and X-CBF_PACKED are
+              slower but more efficient compressions than the others.
+              The X-CBF_BYTE_OFFSET compression is a good compromise
+              between speed and efficiency for ordinary diffraction
+              images.  The X-CBF_BACKGROUND_OFFSET_DELTA compression
+              is oriented towards sparse data, such as masks and
+              tables of replacement pixel values for images with
+              overloaded spots.
+
+              The Content-Transfer-Encoding may be 'BASE64',
+              'Quoted-Printable', 'X-BASE8', 'X-BASE10',
+              'X-BASE16' or 'X-BASE32K', for an imgCIF or 'BINARY'
+              for a CBF.  The octal, decimal and hexadecimal transfer
+              encodings are provided for convenience in debugging and
+              are not recommended for archiving and data interchange.
+
+              In a CIF, one of the parameters 'charset=us-ascii',
+              'charset=utf-8' or 'charset=utf-16' may be used on the
+              Content-Transfer-Encoding to specify the character set
+              used for the external presentation of the encoded data.
+              If no charset parameter is given, the character set of
+              the enclosing CIF is assumed.  In any case, if a BOM
+              flag is detected (FE FF for big-endian UTF-16, FF FE for
+              little-endian UTF-16 or EF BB BF for UTF-8) is detected,
+              the indicated charset will be assumed until the end of the
+              encoded data or the detection of a different BOM.  The
+              charset of the Content-Transfer-Encoding is not the character
+              set of the encoded data, only the character set of the
+              presentation of the encoded data and should be respecified
+              for each distinct STAR string.
+
+              In an imgCIF file, the encoded binary data begin after
+              the empty line terminating the header.  In an imgCIF file,
+              the encoded binary data ends with the terminating boundary
+              delimiter '\n--CIF-BINARY-FORMAT-SECTION----'
+              in the currently effective charset or with the '\n;'
+              that terminates the STAR string.
+
+              In a CBF, the raw binary data begin after an empty line
+              terminating the header and after the sequence:
+
+              Octet   Hex   Decimal  Purpose
+                0     0C       12    Ctrl-L: page break
+                1     1A       26    Ctrl-Z: stop listings, MS-DOS
+                2     04       04    Ctrl-D: stop listings, UNIX
+                3     D5      213    binary section begins
+
+              None of these octets are included in the calculation of
+              the message size or in the calculation of the
+              message digest.
+
+              The X-Binary-Size header specifies the size of the
+              equivalent binary data in octets.  If compression was
+              used, this size is the size after compression, including
+              any book-keeping fields.  An adjustment is made for
+              the deprecated binary formats in which eight bytes of binary
+              header are used for the compression type.  In this case,
+              the eight bytes used for the compression type are subtracted
+              from the size, so that the same size will be reported
+              if the compression type is supplied in the MIME header.
+              Use of the MIME header is the recommended way to
+              supply the compression type.  In general, no portion of
+              the  binary header is included in the calculation of the size.
+
+              The X-Binary-Element-Type header specifies the type of
+              binary data in the octets, using the same descriptive
+              phrases as in _array_structure.encoding_type.  The default
+              value is 'unsigned 32-bit integer'.
+
+              An MD5 message digest may, optionally, be used. The 'RSA Data
+              Security, Inc. MD5 Message-Digest Algorithm' should be used.
+              No portion of the header is included in the calculation of the
+              message digest.
+
+              If the Transfer Encoding is 'X-BASE8', 'X-BASE10' or
+              'X-BASE16', the data are presented as octal, decimal or
+              hexadecimal data organized into lines or words.  Each word
+              is created by composing octets of data in fixed groups of
+              2, 3, 4, 6 or 8 octets, either in the order ...4321 ('big-
+              endian') or 1234... ('little-endian').  If there are fewer
+              than the specified number of octets to fill the last word,
+              then the missing octets are presented as '==' for each
+              missing octet.  Exactly two equal signs are used for each
+              missing octet even for octal and decimal encoding.
+              The format of lines is:
+
+              rnd xxxxxx xxxxxx xxxxxx
+
+              where r is 'H', 'O' or 'D' for hexadecimal, octal or
+              decimal, n is the number of octets per word and d is '<'
+              or '>' for the '...4321' and '1234...' octet orderings,
+              respectively.  The '==' padding for the last word should
+              be on the appropriate side to correspond to the missing
+              octets, e.g.
+
+              H4< FFFFFFFF FFFFFFFF 07FFFFFF ====0000
+
+              or
+
+              H3> FF0700 00====
+
+              For these hexadecimal, octal and decimal formats only,
+              comments beginning with '#' are permitted to improve
+              readability.
+
+              BASE64 encoding follows MIME conventions.  Octets are
+              in groups of three: c1, c2, c3.  The resulting 24 bits
+              are broken into four six-bit quantities, starting with
+              the high-order six bits (c1 >> 2) of the first octet, then
+              the low-order two bits of the first octet followed by the
+              high-order four bits of the second octet [(c1 & 3)<<4 | (c2>>4)],
+              then the bottom four bits of the second octet followed by the
+              high-order two bits of the last octet [(c2 & 15)<<2 | (c3>>6)],
+              then the bottom six bits of the last octet (c3 & 63).  Each
+              of these four quantities is translated into an ASCII character
+              using the mapping:
+
+                        1         2         3         4         5         6
+              0123456789012345678901234567890123456789012345678901234567890123
+              |         |         |         |         |         |         |
+              ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+
+              with short groups of octets padded on the right with one '='
+              if c3 is missing, and with '==' if both c2 and c3 are missing.
+
+              X-BASE32K encoding is similar to BASE64 encoding, except that
+              sets of 15 octets are encoded as sets of 8 16-bit Unicode
+              characters, by breaking the 120 bits into 8 15-bit quantities.
+              256 is added to each 15-bit quantity to bring it into a
+              printable Unicode range.  When encoding, zero padding is used
+              to fill out the last 15-bit quantity.  If 8 or more bits of
+              padding are used, a single equals sign (hexadecimal 003D) is
+              appended.  Embedded whitespace and newlines are introduced
+              to produce lines of no more than 80 characters each.  On
+              decoding, all printable ASCII characters and ASCII whitespace
+              characters are ignored except for any trailing equals signs.
+              The number of trailing equals signs indicated the number of
+              trailing octets to be trimmed from the end of the decoded data
+              (see Darakev et al., 2006).
+
+              QUOTED-PRINTABLE encoding also follows MIME conventions, copying
+              octets without translation if their ASCII values are 32...38,
+              42, 48...57, 59, 60, 62, 64...126 and the octet is not a ';'
+              in column 1.  All other characters are translated to =nn, where
+              nn is the hexadecimal encoding of the octet.  All lines are
+              'wrapped' with a terminating '=' (i.e. the MIME conventions
+              for an implicit line terminator are never used).
+
+              The 'X-Binary-Element-Byte-Order' can specify either
+              'BIG_ENDIAN' or 'LITTLE_ENDIAN' byte order of the image
+              data.  Only LITTLE_ENDIAN is recommended.  Processors
+              may treat BIG_ENDIAN as a warning of data that can
+              only be processed by special software.
+
+              The 'X-Binary-Number-of-Elements' specifies the number of
+              elements (not the number of octets) in the decompressed,
+              decoded image.
+
+              The optional 'X-Binary-Size-Fastest-Dimension' specifies the
+              number of elements (not the number of octets) in one row of the
+              fastest changing dimension of the binary data array. This
+              information must be in the MIME header for proper operation of
+              some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Second-Dimension' specifies the
+              number of elements (not the number of octets) in one column of
+              the second-fastest changing dimension of the binary data array.
+              This information must be in the MIME header for proper operation
+              of some of the decompression algorithms.
+
+              The optional 'X-Binary-Size-Third-Dimension' specifies the
+              number of sections for the third-fastest changing dimension of
+              the binary data array.
+
+              The optional 'X-Binary-Size-Padding' specifies the size in
+              octets of an optional padding after the binary array data and
+              before the closing flags for a binary section.
+
+              Reference:
+
+              Darakev, G., Litchev, V., Mitev, K. Z. & Bernstein, H. J. (2006).
+              'Efficient Support of Binary Data in the XML Implementation of
+              the NeXus File Format', abstract W0165, ACA Summer Meeting,
+              Honolulu, HI, USA, July 2006.
+;
+    _name.category_id             array_data
+    _name.object_id               data
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Array
+    _type.dimension               '[]'
+    _type.contents                Complex
+    _type.ddl2_code               binary
+    _units.code                   none
+
+save_
+
+save_array_data.external_data_id
+
+    _definition.id                '_array_data.external_data_id'
+    _description.text
+;             This item is a pointer to _array_data_external_data.id in the
+              ARRAY_DATA_EXTERNAL_DATA category.
+
+              If not given, then the actual array data should be specified as
+              the value of _array_data.data.  If
+              both values are given, the value on _array_data.data takes
+              precedence, and a warning of a possible conflict should be issued. 
+
+;
+    _name.category_id             array_data
+    _name.object_id               external_data_id
+    _name.linked_item_id          '_array_data_external_data.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_data.header_contents
+
+    _definition.id                '_array_data.header_contents'
+    _description.text
+;             This item is a text field for use in minimal CBF files to carry
+              essential header information to be kept with image data
+              in _array_data.data when the tags that normally carry the
+              structured metadata for the image have not been populated.
+
+              Normally this data item should not appear when the full set
+              of tags has been populated and _diffrn_data_frame.details
+              appears.
+;
+    _name.category_id             array_data
+    _name.object_id               header_contents
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_array_data.header_convention
+
+    _definition.id                '_array_data.header_convention'
+    _description.text
+;             This item is an identifier for the convention followed in
+              constructing the contents of _array_data.header_contents
+
+              The permitted values are of an image creator identifier
+              followed by an underscore and a version string.  To avoid
+              confusion about conventions, all creator identifiers
+              should be registered with the IUCr and the conventions
+              for all identifiers and versions should be posted on
+              the MEDSBIO.org web site.
+;
+    _name.category_id             array_data
+    _name.object_id               header_convention
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_data.variant
+
+    _definition.id                '_array_data.variant'
+    _description.text
+;             The value of _array_data.variant gives the variant
+              to which the given ARRAY_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_data
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_DATA_EXTERNAL_DATA
+
+    _definition.id                array_data_external_data
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_DATA_EXTERNAL_DATA category optionally
+     record the location and essential characteristics of arrays of data for
+    use in  ARRAY_DATA that are found external to the cif_img file.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_data_external_data
+    _name.ddl2_mandatory          no
+    _category_key.name            '_array_data_external_data.id'
+    _nx_mapping.details
+;    _array_data.array_id ARRAYID
+    _array_data.binary_id BINARYID
+    _array_data.external_data_id EXTERNAL_DATA_ID
+    _array_data.header_contents HEADER
+    _array_data.header_convention HEADERCONVENTION
+
+    _array_data_external_data.archive_format ARCHIVEFORMAT
+    _array_data_external_data.archive_path ARCHIVEPATH
+    _array_data_external_data.id EXTERNAL_DATA_ID
+    _array_data_external_data.format HDF5
+    _array_data_external_data.uri DATAURI
+    _array_data_external_data.path DATAPATH
+    _array_data_external_data.frame DATAFRAME
+    -->
+
+    /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+       data_ARRAYID_BINARYID --> DATAURI//DATAPATH
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+            @CBF_array_id="ARRAYID"
+            @CBF_binary_id="BINARYID"
+            @CBF_header_contents="HEADER"
+            @CBF_header_convention="HEADERCONVENTION"
+            @CBF_external_data_archive_format="ARCHIVEFORMAT"
+            @CBF_external_data_archive_path="ARCHIVEPATH""
+            @CBF_external_data_uri="DATAURI"
+            @CBF_external_data_path="DATAPATH"
+            @CBF_external_data_frame="DATAFRAME"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_data_external_data.archive_format
+
+    _definition.id                '_array_data_external_data.archive_format'
+    _description.text
+;
+    The type of single-file archive in which image data or multi-image
+    inage containers have been encapsulated, if any. The archive is
+    located at _array_data_external_data.uri.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               archive_format
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         ZIP                      'A ZIP archive'
+         TGZ                      'A Gzipped tar archive'
+         TBZ                      'A Bzip2 tar archive'
+         .                        'No compressed archive is present'
+
+    _enumeration.default          .
+
+save_
+
+save_array_data_external_data.archive_path
+
+    _definition.id                '_array_data_external_data.archive_path'
+    _description.text
+;
+    The location of the image or multi-image image container,
+    such as HDF5 or CBF, within an archive such as a tarball.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               archive_path
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_array_data_external_data.file_compression
+
+    _definition.id                '_array_data_external_data.file_compression'
+    _description.text
+;
+    The type of compression used for the file corresponding to
+    a single frame, if any.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               file_compression
+    _name.ddl2_mandatory          no
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         GZ                       'A Gzipped file'
+         BZ2                      'File compressed with Bzip2'
+         .                        'Individual file compression not used'
+
+    _enumeration.default          .
+
+save_
+
+save_array_data_external_data.format
+
+    _definition.id                '_array_data_external_data.format'
+    _description.text
+;
+    The format in which raw array data referenced by
+    _array_data_external_data.uri and following archive extraction can be
+    accessed. Items in array_structure and array_structure_list refer
+    to the data after any decompressions and other transformations
+    performed by standard libraries associated with the format as
+    described in the description of each format below.
+
+    Note that, if a single file archive, such as a zip or tarball
+    has been specified at _array_data_external_data.uri
+    then the format of the archive, as contrasted with the format of
+    the image or the multi-image image container such as CBF or
+    HDF5 is specified by _array_data_external_data.archive_format
+    and the particular image is specified by the combination of
+    _array_data_external_data.archive_path,
+    _array_data_external_data.format,
+    _array_data_external_data.path, and
+    _array_data_external_data.frame while
+    if no single file archive is used, so that a CBF, HDF5, TIFF or SMV is
+    specified at _array_data_external_data.uri, then
+    the particular image is specified by the combination of
+    _array_data_external_data.format,
+    _array_data_external_data.path, and
+    _array_data_external_data.frame directly.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               format
+    _name.ddl2_mandatory          no
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         CBF
+;
+         The contents of _array_data.data in a single-frame imgCBF file. Other
+         datanames in the external file are ignored.
+;
+         SMV
+;
+         An unprocessed sequence of bytes contained in a file conforming to the
+         SMV format as used by ADSC and other CCD manufacturers.
+;
+         HDF5
+;
+         An array of numbers contained in a dataset in an HDF5 file as returned
+         by HDF5 library functions. '_array_data_external_data.path' is the
+         internal HDF5 path. In an HDF5 file, the path typically identifies a
+         dataset with multiple images. '_array_data_external_data.frame' is
+         used to select a particular image.
+;
+         TIFF
+;
+         An array of numbers corresponding to a decompressed single frame
+         contained within a TIFF file that meets the TIFF 6.0 baseline
+         specification. '_array_data_external_data.frame' is the image number
+         when multiple images are contained in a single TIFF file.
+;
+         MAR
+;
+         An array of numbers corresponding to a decompressed single frame from
+         the Rayonix company.
+;
+         Bruker
+;
+         An array of numbers corresponding to a decompressed single frame from
+         a data file generated by Bruker equipment.
+;
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _array_data.array_id
+         _array_data.binary_id
+         _array_data.external_data_id
+         1 1 1
+         1 2 2
+         loop_
+         _array_data_external_data.id
+         _array_data_external_data.format
+         _array_data_external_data.uri
+         _array_data_external_data.path
+         _array_data_external_data.frame
+         1 HDF5 https://zenodo.org/record/12345/files/tartaric.h5
+         /entry1/detector1/data 1 2 HDF5
+         https://zenodo.org/record/12345/files/tartaric.h5
+         /entry1/detector1/data 2 ...
+;
+;
+         The frames are contained in a single HDF5-format file accessible
+         at https://zenodo.org/record/12345/files/tartaric.h5. An array of 2D
+         images is found at HDF5 location entry1/detector1/data
+;
+;
+         loop_
+         _array_data.array_id
+         _array_data.binary_id
+         _array_data.external_data_id
+         1 1 1
+         1 2 2
+         loop_
+         _array_data_external_data.id
+         _array_data_external_data.format
+         _array_data_external_data.version
+         _array_data_external_data.uri
+         1 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.001
+         2 Bruker Smart6000 https://uni_repo.edu/5341/run1/tartaric.002
+         ...
+;
+;
+         Frames are contained in individual Smart6000 Bruker-format files
+         accessible using https://uni_repo.edu/5341 in subdirectory run1.
+;
+;
+    loop_
+    _array_data.array_id
+    _array_data.binary_id
+    _array_data.external_data_id
+    1 1 1
+    1 2 2
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.archive_format
+    _array_data_external_data.archive_path
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0001.img
+    2 SMV
+        https://data.proteindiffraction.org/ssgcid/MyulA_01062_a_B12-sddc0001574_7k69.tar.bz2
+        TBZ
+        MyulA_01062_a_B12-sddc0001574_7k69/data/317895h4_y_0002.img
+;
+;
+         Frames with SMV format are contained at data.proteindiffraction.org in
+         a tarred archive compressed with bzip2.
+;
+; 
+    loop_
+    _array_data_external_data.id
+    _array_data_external_data.format
+    _array_data_external_data.uri
+    _array_data_external_data.archive_format
+    _array_data_external_data.archive_path
+    _array_data_external_data.file_compression
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/4jga.tar
+        TAR
+        3lls/series/200873f12_x0085.img.bz2 BZ2
+    1 SMV
+        https://data.proteindiffraction.org/ssgcid/4jga.tar
+        TAR
+        3lls/series/200873f12_x0085.img.bz2 BZ2
+;
+;
+         Frames with SMV format are contained at data.proteindiffraction.org in
+         a tarred archive with each frame individually compressed with Bzip2.
+;
+
+save_
+
+save_array_data_external_data.frame
+
+    _definition.id                '_array_data_external_data.frame'
+    _description.text
+;
+
+    The position of the raw data array in what may possibly be a
+    multi-dimensional array of data referenced by   
+       _array_data_external_data.uri and _array_data_external_data.path.
+    For many of the formats, data for a single frame is identified by that
+    reference.  If data for multiple frames or data for portions of
+    one or more frames is referenced, the desired portion can be
+    identified dimension by dimension as an array section identifier 
+    the form
+       ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+    or other valid ARRAY_STRUCTURE_LIST_SECTION
+    identifier.
+    
+    Note that the precendence ordering of dimensions varies, even within a
+    single specified format.  For example HDF5 supports both C slowest first
+    and Fortran fastest first, so it is essential to properly populate
+    ARRAY_STRUCTURE_LIST category.
+    
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               frame
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+    _description_example.case     4
+    _description_example.detail
+        'The fourth frame in the referenced data array'
+
+save_
+
+save_array_data_external_data.id
+
+    _definition.id                '_array_data_external_data.id'
+    _description.text
+;             The value of _array_data_external_data.id must uniquely identify
+              each item of array_data_external_data.              
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_data_external_data.path
+
+    _definition.id                '_array_data_external_data.path'
+    _description.text
+;
+    An optional format-dependent path that is used to locate the
+    external image or images within the object referenced by the combination of
+    _array_data_external_data.uri,
+    _array_data_external_data.archive_path
+    in the case that _array_data_external_data.archive_format
+    specifies a non-null single-file archive format, such as zip or a
+    tarball.  When a single-file archive format is not used, then
+    _array_data_external_data.path
+    locates the external image or images  within the object referenced by
+    _array_data_external_data.uri.
+    In both cases, the specific image within an array of multiple images is
+    identified by _array_data_external_data.frame.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               path
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_array_data_external_data.uri
+
+    _definition.id                '_array_data_external_data.uri'
+    _description.text
+;
+    A URI describing the location of an image external to the current data block
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               uri
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_data_external_data.variant
+
+    _definition.id                '_array_data_external_data.variant'
+    _description.text
+;             The value of _array_data_external_data.variant gives the variant
+              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               variant
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_array_data_external_data.version
+
+    _definition.id                '_array_data_external_data.version'
+    _description.text
+;
+    An identifier for the version of the file format described by
+    '_array_data_external_data.format'.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               version
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_ARRAY_ELEMENT_SIZE
+
+    _definition.id                array_element_size
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_ELEMENT_SIZE category record the physical
+     size of array elements along each array dimension.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_element_size
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_element_size.array_id'
+         '_array_element_size.index'
+         '_array_element_size.variant'
+
+    _description_example.case
+;        loop_
+       _array_element_size.array_id
+       _array_element_size.index
+       _array_element_size.size
+        image_1   1    1.22e-6
+        image_1   2    1.22e-6
+;
+    _description_example.detail
+;      Example 1. A regular 2D array with a uniform element dimension
+                    of 1220 nanometres.
+;
+    _nx_mapping.details
+;    _array_element_size.array_id ARRAYID 
+    _array_element_size.index INDEX   (See _array_element_size.array_id)
+    _array_element_size.size SIZE
+
+    -->
+
+    /entry:NXentry
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+          /?_pixel_size_ARRAYID=SIZE
+            @CBF_array_id="ARRAYID"
+    where "?" is "x", "y", "z" for
+    _array_element_size.index == 1,2, or 3 respectively
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_element_size.array_id
+
+    _definition.id                '_array_element_size.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             array_element_size
+    _name.object_id               array_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_element_size.index
+
+    _definition.id                '_array_element_size.index'
+    _description.text
+;             This item is a pointer to _array_structure_list.index in
+              the ARRAY_STRUCTURE_LIST category.
+;
+    _name.category_id             array_element_size
+    _name.object_id               index
+    _name.linked_item_id          '_array_structure_list.index'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_array_element_size.size
+
+    _definition.id                '_array_element_size.size'
+    _description.text
+;             The size in metres of an image element in this
+              dimension. This supposes that the elements are arranged
+              on a regular grid.
+;
+    _name.category_id             array_element_size
+    _name.object_id               size
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              metres
+    _units.code                   metres
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_array_element_size.variant
+
+    _definition.id                '_array_element_size.variant'
+    _description.text
+;             The value of _array_element_size.variant gives the variant
+              to which the given ARRAY_ELEMENT_SIZE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_element_size
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_INTENSITIES
+
+    _definition.id                array_intensities
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_INTENSITIES category record the
+     information required to recover the intensity data from
+     the set of data values stored in the ARRAY_DATA category.
+
+     The detector may have a complex relationship
+     between the raw intensity values and the number of
+     incident photons.  In most cases, the number stored
+     in the final array will have a simple linear relationship
+     to the actual number of incident photons, given by
+     _array_intensities.gain.  If raw, uncorrected values
+     are presented (e.g. for calibration experiments), the
+     value of _array_intensities.linearity will be 'raw'
+     and _array_intensities.gain will not be used.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_intensities
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_intensities.array_id'
+         '_array_intensities.binary_id'
+         '_array_intensities.variant'
+
+    _description_example.case
+;        loop_
+        _array_intensities.array_id
+        _array_intensities.linearity
+        _array_intensities.gain
+        _array_intensities.overload
+        _array_intensities.undefined_value
+        _array_intensities.pixel_fast_bin_size
+        _array_intensities.pixel_slow_bin_size
+        _array_intensities.pixel_binning_method
+        image_1   linear  1.2    655535   0   2   2    hardware
+;
+    _description_example.detail
+;
+    Example 1
+;
+    _nx_mapping.details
+;    _array_intensities.array_id ARRAYID
+    _array_intensities.binary_id BINARYID
+    _array_intensities.details DETAILS
+    _array_intensities.gain GAIN
+    _array_intensities.gain_esd GAINESD
+    _array_intensities.linearity LINEARITY
+    _array_intensities.offset OFFSET
+    _array_intensities.scaling SCALING
+    _array_intensities.overload OVERLOAD
+    _array_intensities.undefined_value UNDEFVAL
+    _array_intensities.underload UNDERLOAD
+    _array_intensities.pixel_fast_bin_size FBINSIZE
+    _array_intensities.pixel_slow_bin_size SBINSIZE
+    _array_intensities.pixel_binning_method METHOD
+    -->
+
+      /entry:NXentry
+        /data_ARRAYID_BINARYID:NXdata
+          /data_ARRAYID_BINARYID
+              @CBF_array_id="ARRAYID"
+              @CBF_binary_id="BINARYID"
+              @details="DETAILS"
+              @gain=[GAIN]          
+              @gain_esd=[GAINESD]
+              @linearity="LINEARITY"          
+              @offset=[OFFSET]
+              @saturation_value=[OVERLOAD]
+              @scaling_factor=[SCALING]
+              @undefined_value=[UNDEFVAL]
+              @underload_value=[UNDERLOAD]
+              @CBF_array_intensities__pixel_fast_bin_size=[FBINSIZE]
+              @CBF_array_intensities__pixel_slow_bin_size=[SBINSIZE]
+              @CBF_array_intensities__pixel_binning_method="METHOD"
+       /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+
+    The argument has been made that these attributes are not needed
+    because NeXus files are supposed to have 'true values' stored.
+    In many cases that is true and then none of these attributes
+    are needed.  However, with some detectors and some experiments
+    there are good technical and scientific reasons to bring in values
+    that will need processing later to derive 'true values', and in
+    those case some or all of these attributes will be needed.  They
+    are provided for such cases.
+
+    The same attributes could be used as fields in the case of a single
+    data array, but in that case links for all the fields would be needed
+    from NXdata to NXdetector, so it is preferable to use attributes even
+    in the case of a single data array.  The reverse mapping will support
+    both uses.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_intensities.array_id
+
+    _definition.id                '_array_intensities.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             array_intensities
+    _name.object_id               array_id
+    _name.linked_item_id          '_array_structure.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_intensities.binary_id
+
+    _definition.id                '_array_intensities.binary_id'
+    _description.text
+;             This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
+;
+    _name.category_id             array_intensities
+    _name.object_id               binary_id
+    _name.linked_item_id          '_array_data.binary_id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _enumeration.default          1
+    _units.code                   none
+
+save_
+
+save_array_intensities.details
+
+    _definition.id                '_array_intensities.details'
+    _description.text
+;             A description of special aspects of the calculation of array 
+              intensities.
+;
+    _name.category_id             array_intensities
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case     'Gain_setting: low gain (vrf = -0.300)'
+
+save_
+
+save_array_intensities.gain
+
+    _definition.id                '_array_intensities.gain'
+    _description.text
+;             Detector 'gain'. The factor by which linearized
+              intensity count values should be divided to produce
+              true photon counts.
+;
+    _name.category_id             array_intensities
+    _name.object_id               gain
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              counts_per_photon
+    _units.code                   counts_per_photon
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_array_intensities.gain_esd'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_array_intensities.gain_esd
+
+    _definition.id                '_array_intensities.gain_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of detector 'gain'.
+;
+    _name.category_id             array_intensities
+    _name.object_id               gain_esd
+    _name.linked_item_id          '_array_intensities.gain'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              counts_per_photon
+    _units.code                   counts_per_photon
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_array_intensities.gain'
+    _ddl2_item_related.function_code associated_esd
+
+save_
+
+save_array_intensities.linearity
+
+    _definition.id                '_array_intensities.linearity'
+    _description.text
+;             The intensity linearity scaling method used to convert
+              from the raw intensity to the stored element value:
+
+             'linear' is linear.
+
+             'offset'  means that the value defined by
+             _array_intensities.offset should be added to each
+             element value.
+
+             'scaling' means that the value defined by
+             _array_intensities.scaling should be multiplied with each
+             element value.
+
+             'scaling_offset' is the combination of the two previous cases,
+             with the scale factor applied before the offset value.
+
+             'sqrt_scaled' means that the square root of raw
+             intensities multiplied by _array_intensities.scaling is
+             calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling and squaring the
+             result.
+
+             'logarithmic_scaled' means that the logarithm base 10 of
+             raw intensities multiplied by _array_intensities.scaling
+             is calculated and stored, perhaps rounded to the nearest
+             integer. Thus, linearization involves dividing the stored
+             values by _array_intensities.scaling and calculating 10
+             to the power of this number.
+
+             'raw' means that the data are a set of raw values straight
+             from the detector.
+;
+    _name.category_id             array_intensities
+    _name.object_id               linearity
+    _name.ddl2_mandatory          yes
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         linear
+             .
+         offset
+;            The value defined by  _array_intensities.offset should
+             be added to each element value.
+;
+         scaling
+;            The value defined by _array_intensities.scaling should be
+             multiplied with each element value.
+;
+         scaling_offset
+;            The combination of the scaling and offset
+             with the scale factor applied before the offset value.
+;
+         sqrt_scaled
+;            The square root of raw intensities multiplied by
+             _array_intensities.scaling is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored
+             values by _array_intensities.scaling and squaring the
+             result.
+;
+         logarithmic_scaled
+;            The logarithm base 10 of raw intensities multiplied by
+             _array_intensities.scaling  is calculated and stored,
+             perhaps rounded to the nearest integer. Thus,
+             linearization involves dividing the stored values by
+             _array_intensities.scaling and calculating 10 to the
+             power of this number.
+;
+         raw
+;            The array consists of raw values to which no corrections have
+             been applied.  While the handling of the data is similar to
+             that given for 'linear' data with no offset, the meaning of
+             the data differs in that the number of incident photons is
+             not necessarily linearly related to the number of counts
+             reported.  This value is intended for use either in
+             calibration experiments or to allow for handling more
+             complex data-fitting algorithms than are allowed for by
+             this data item.
+;
+
+save_
+
+save_array_intensities.offset
+
+    _definition.id                '_array_intensities.offset'
+    _description.text
+;             Offset value to add to array element values in the manner
+              described by the item _array_intensities.linearity.
+;
+    _name.category_id             array_intensities
+    _name.object_id               offset
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_array_intensities.overload
+
+    _definition.id                '_array_intensities.overload'
+    _description.text
+;             The saturation intensity level for this data array, i.e. the
+              value at or above which correct intensities may not be recorded.
+
+              The valid pixel values are those less than
+              _array_intensities.overload and greater than or equal to 
+              _array_intensities.underload
+;
+    _name.category_id             array_intensities
+    _name.object_id               overload
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              counts
+    _units.code                   counts
+
+save_
+
+save_array_intensities.pixel_binning_method
+
+    _definition.id                '_array_intensities.pixel_binning_method'
+    _description.text
+;             The value of _array_intensities.pixel_binning_method specifies
+              the method used to derive array elements from multiple pixels.
+;
+    _name.category_id             array_intensities
+    _name.object_id               pixel_binning_method
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         hardware
+;              The element intensities were derived from the raw data of one
+               or more pixels by use of hardware in the detector, e.g. by use
+               of shift registers in a CCD to combine pixels into super-pixels.
+;
+         software
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of software.
+;
+         combined
+;              The element intensities were derived from the raw data of more
+               than one pixel by use of both hardware and software, as when
+               hardware binning is used in one direction and software in the
+               other.
+;
+         none
+;              In both directions, the data have not been binned.  The
+               number of pixels is equal to the number of elements.
+
+               When the value of _array_intensities.pixel_binning_method is
+               'none' the values of _array_intensities.pixel_fast_bin_size
+               and _array_intensities.pixel_slow_bin_size both must be 1.
+;
+         unspecified
+;              The method used to derive element intensities is not specified.
+;
+
+    _enumeration.default          unspecified
+
+save_
+
+save_array_intensities.pixel_fast_bin_size
+
+    _definition.id                '_array_intensities.pixel_fast_bin_size'
+    _description.text
+;             The value of _array_intensities.pixel_fast_bin_size specifies
+              the number of pixels that compose one element in the direction
+              of the most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the 
+              detector pixel size.
+;
+    _name.category_id             array_intensities
+    _name.object_id               pixel_fast_bin_size
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              pixels_per_element
+    _enumeration.default          1.
+    _units.code                   pixels_per_element
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_array_intensities.pixel_slow_bin_size
+
+    _definition.id                '_array_intensities.pixel_slow_bin_size'
+    _description.text
+;             The value of _array_intensities.pixel_slow_bin_size specifies
+              the number of pixels that compose one element in the direction
+              of the second most rapidly varying array dimension.
+
+              Typical values are 1, 2, 4 or 8.  When there is 1 pixel per
+              array element in both directions, the value given for
+              _array_intensities.pixel_binning_method normally should be
+              'none'.
+
+              It is specified as a float to allow for binning algorithms that
+              create array elements that are not integer multiples of the
+              detector pixel size.
+;
+    _name.category_id             array_intensities
+    _name.object_id               pixel_slow_bin_size
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              pixels_per_element
+    _enumeration.default          1.
+    _units.code                   pixels_per_element
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_array_intensities.scaling
+
+    _definition.id                '_array_intensities.scaling'
+    _description.text
+;             Multiplicative scaling value to be applied to array data
+              in the manner described by the item
+              _array_intensities.linearity.
+;
+    _name.category_id             array_intensities
+    _name.object_id               scaling
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_array_intensities.undefined_value
+
+    _definition.id                '_array_intensities.undefined_value'
+    _description.text
+;             A value to be substituted for undefined values in
+              the data array.
+;
+    _name.category_id             array_intensities
+    _name.object_id               undefined_value
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_array_intensities.underload
+
+    _definition.id                '_array_intensities.underload'
+    _description.text
+;             The lowest value at which pixels for this detector are
+              measured.
+
+              The valid pixel values are those less than 
+              _array_intensities.overload and greater than or equal to 
+              _array_intensities.underload
+
+;
+    _name.category_id             array_intensities
+    _name.object_id               underload
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              counts
+    _units.code                   counts
+
+save_
+
+save_array_intensities.variant
+
+    _definition.id                '_array_intensities.variant'
+    _description.text
+;             The value of _array_intensities.variant gives the variant
+              to which the given ARRAY_INTENSITIES row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_intensities
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE
+
+    _definition.id                array_structure
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_STRUCTURE category record the organization and
+     encoding of array data that may be stored in the ARRAY_DATA category.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_structure
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_structure.id'
+         '_array_structure.variant'
+
+    _description_example.case
+;     loop_
+    _array_structure.id
+    _array_structure.encoding_type
+    _array_structure.compression_type
+    _array_structure.byte_order
+     image_1       "unsigned 16-bit integer"  none  little_endian
+;
+    _description_example.detail   'Example 1.'
+    _nx_mapping.details
+;
+    Note that this is essentially a type that may apply to multiple
+    binary images, and corresponds to some of the detailed HDF5
+    information about an array.   The following mapping is a placeholder
+    for the names given for future reference, if needed.
+
+    The information in this category is the byte order, the compression
+    information, and the encoding, which is carried in and retrievable
+    from the HDF5 types, properties lists, etc.
+
+    At present NeXus does not expose this information.  This should be
+    discussed.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_structure.byte_order
+
+    _definition.id                '_array_structure.byte_order'
+    _description.text
+;             The order of bytes for integer values which require more
+              than 1 byte.
+
+              (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
+              ordered integers, whereas Hewlett Packard 700
+              series, Sun-4 and Silicon Graphics use high-byte-first
+              ordered integers.  DEC Alphas can produce/use either
+              depending on a compiler switch.)
+;
+    _name.category_id             array_structure
+    _name.object_id               byte_order
+    _name.ddl2_mandatory          yes
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         big_endian
+;       The first byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+         little_endian
+;       The last byte in the byte stream of the bytes which make up an
+        integer value is the most significant byte of an integer.
+;
+
+save_
+
+save_array_structure.compression_type
+
+    _definition.id                '_array_structure.compression_type'
+    _description.text
+;             Type of data-compression method used to compress the array
+              data.
+;
+    _name.category_id             array_structure
+    _name.object_id               compression_type
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         byte_offset
+;       Using the 'byte_offset' compression scheme as per A. Hammersley
+        and the CBFlib manual, section 3.3.3
+;
+         canonical
+;       Using the 'canonical' compression scheme (International Tables
+        for Crystallography Volume G, Section 5.6.3.1) and CBFlib
+        manual section 3.3.1
+;
+         nibble_offset
+;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+        and the CBFlib manual, section 3.3.4
+;
+         none
+;       Data are stored in normal format as defined by
+        _array_structure.encoding_type and
+        _array_structure.byte_order.
+;
+         packed
+;       Using the 'packed' compression scheme, a CCP4-style packing
+        as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+         packed_v2
+;       Using the 'packed' compression scheme, version 2, as per
+        J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
+;
+
+    _enumeration.default          none
+
+save_
+
+save_array_structure.compression_type_flag
+
+    _definition.id                '_array_structure.compression_type_flag'
+    _description.text
+;             Flags modifying the type of data-compression method used to 
+              compress the arraydata.
+;
+    _name.category_id             array_structure
+    _name.object_id               compression_type_flag
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         uncorrelated_sections
+;       When applying packed or packed_v2 compression on an array with
+        uncorrelated sections, do not average in points from the prior
+        section.
+;
+         flat
+;       When applying packed or packed_v2 compression on an array that
+        treats the entire image as a single line set the maximum number
+        of bits for an offset to 65 bits.
+
+        The flag is included for compatibility with software prior to
+        CBFlib_0.7.7, and should not be used for new data sets.
+;
+
+save_
+
+save_array_structure.encoding_type
+
+    _definition.id                '_array_structure.encoding_type'
+    _description.text
+;             Data encoding of a single element of array data.
+
+              The type 'unsigned 1-bit integer' is used for
+              packed Boolean arrays for masks.  Each element
+              of the array corresponds to a single bit
+              packed in unsigned 8-bit data.
+
+              In several cases, the IEEE format is referenced.
+              See IEEE Standard 754-1985 (IEEE, 1985).
+
+              Reference: IEEE (1985). IEEE Standard for Binary Floating-Point
+              Arithmetic. ANSI/IEEE Std 754-1985. New York: Institute of
+              Electrical and Electronics Engineers.
+;
+    _name.category_id             array_structure
+    _name.object_id               encoding_type
+    _name.ddl2_mandatory          yes
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               uline
+
+    loop_
+      _enumeration_set.state
+         'unsigned 1-bit integer'
+         'unsigned 8-bit integer'
+         'signed 8-bit integer'
+         'unsigned 16-bit integer'
+         'signed 16-bit integer'
+         'unsigned 32-bit integer'
+         'signed 32-bit integer'
+         'signed 32-bit real IEEE'
+         'signed 64-bit real IEEE'
+         'signed 32-bit complex IEEE'
+
+save_
+
+save_array_structure.id
+
+    _definition.id                '_array_structure.id'
+    _description.text
+;             The value of _array_structure.id must uniquely identify
+              each item of array data.              
+
+              This item has been made implicit and given a default value of 1
+              as a convenience in writing miniCBF files.  Normally an
+              explicit name with useful content should be used.
+;
+    _name.category_id             array_structure
+    _name.object_id               id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_structure.variant
+
+    _definition.id                '_array_structure.variant'
+    _description.text
+;             The value of _array_structure.variant gives the variant
+              to which the given ARRAY_STRUCTURE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST
+
+    _definition.id                array_structure_list
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;    Data items in the ARRAY_STRUCTURE_LIST category record the size
+     and organization of each array dimension.
+
+     The relationship to physical axes may be given.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_structure_list
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_structure_list.array_id'
+         '_array_structure_list.index'
+         '_array_structure_list.variant'
+
+    _description_example.case
+;        loop_
+       _array_structure_list.array_id
+       _array_structure_list.index
+       _array_structure_list.dimension
+       _array_structure_list.precedence
+       _array_structure_list.direction
+       _array_structure_list.axis_set_id
+        image_1   1    1300    1     increasing  ELEMENT_X
+        image_1   2    1200    2     decreasing  ELEMENY_Y
+;
+    _description_example.detail
+;       Example 1. An image array of 1300 x 1200 elements.  The raster
+                    order of the image is left to right (increasing) in the
+                    first dimension and bottom to top (decreasing) in
+                    the second dimension.
+;
+    _nx_mapping.details
+;    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_derived CENDERIVED
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]
+                  (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment
+                  =FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_structure_list.array_id
+
+    _definition.id                '_array_structure_list.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               array_id
+    _name.linked_item_id          '_array_structure.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_structure_list.array_section_id
+
+    _definition.id                '_array_structure_list.array_section_id'
+    _description.text
+;             This item is a pointer to _array_structure_list_section.id in the
+              ARRAY_STRUCTURE_LIST_SECTION category.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               array_section_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_structure_list.axis_set_id
+
+    _definition.id                '_array_structure_list.axis_set_id'
+    _description.text
+;             This is a descriptor for the physical axis or set of axes
+              corresponding to an array index.
+
+              This data item is related to the axes of the detector
+              itself given in DIFFRN_DETECTOR_AXIS, but usually differs
+              in that the axes in this category are the axes of the
+              coordinate system of reported data points, while the axes in
+              DIFFRN_DETECTOR_AXIS are the physical axes
+              of the detector describing the 'poise' of the detector as an
+              overall physical object.
+
+              If there is only one axis in the set, the identifier of
+              that axis should be used as the identifier of the set.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               axis_set_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_structure_list.dimension
+
+    _definition.id                '_array_structure_list.dimension'
+    _description.text
+;             The number of elements stored in the array structure in 
+              this dimension.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               dimension
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list.direction
+
+    _definition.id                '_array_structure_list.direction'
+    _description.text
+;             Identifies the direction in which this array index changes.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               direction
+    _name.ddl2_mandatory          yes
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         increasing
+;       Indicates the index changes from 1 to the maximum dimension.
+;
+         decreasing
+;       Indicates the index changes from the maximum dimension to 1.
+;
+
+save_
+
+save_array_structure_list.index
+
+    _definition.id                '_array_structure_list.index'
+    _description.text
+;             Identifies the one-based index of the row or column in the
+              array structure.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               index
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list.precedence
+
+    _definition.id                '_array_structure_list.precedence'
+    _description.text
+;             Identifies the rank order in which this array index changes
+              with respect to other array indices.  The precedence of 1
+              indicates the index which changes fastest.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               precedence
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list.variant
+
+    _definition.id                '_array_structure_list.variant'
+    _description.text
+;             The value of _array_structure_list.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST_AXIS
+
+    _definition.id                array_structure_list_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the ARRAY_STRUCTURE_LIST_AXIS category describe
+     the physical settings of sets of axes for the centres of pixels that
+     correspond to data points described in the
+     ARRAY_STRUCTURE_LIST category.
+
+     In the simplest cases, the physical increments of a single axis correspond
+     to the increments of a single array index.  More complex organizations,
+     e.g. spiral scans, may require coupled motions along multiple axes.
+
+     Note that a spiral scan uses two coupled axes: one for the angular
+     direction and one for the radial direction.  This differs from a
+     cylindrical scan for which the two axes are not coupled into one
+     set.
+
+     Axes may be specified either for an entire array or for just a section
+     of an array.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_structure_list_axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_structure_list_axis.axis_set_id'
+         '_array_structure_list_axis.axis_id'
+         '_array_structure_list_axis.variant'
+
+    _nx_mapping.details
+;    _array_structure_list.axis_set_id AXISSETID
+    _array_structure_list.array_id ARRAYID
+    _array_structure_list.array_section_id ARRAYSECTIONID
+    _array_structure_list.dimension DIM
+    _array_structure_list.direction DIR
+    _array_structure_list.index INDEX
+    _array_structure_list.precedence PRECEDENCE
+
+    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id ARRAYSECTIONID -->
+    _array_structure_list_section.index PRECEDENCE-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+     loop_
+    _array_structure_list_axis.axis_id 
+    _array_structure_list_axis.axis_set_id 
+    _array_structure_list_axis.angle 
+    _array_structure_list_axis.angle_increment 
+    _array_structure_list_axis.displacement 
+    _array_structure_list_axis.fract_displacement  
+    _array_structure_list_axis.displacement_increment 
+    _array_structure_list_axis.fract_displacement_increment 
+    _array_structure_list_axis.angular_pitch  
+    _array_structure_list_axis.reference_angle 
+    _array_structure_list_axis.reference_displacement REFDISP
+    AXISID1 AXISSETID ANGLE1 ANGLEINC1 DISP1 FRACTDISP1
+         DISPINC1 FRACTINC1 ANGPITCH1 REFANG1
+    AXISID2 AXISSETID ANGLE2 ANGLEINC2 DISP2 FRACTDISP2
+         DISPINC2 FRACTINC2 ANGPITCH2 REFANG2
+    AXISID3 AXISSETID ANGLE3 ANGLEINC3 DISP3 FRACTDISP3
+         DISPINC3 FRACTINC3 ANGPITCH3 REFANG3
+
+    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.binary_id BINARYID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    ...
+   /entry:NXentry
+     /data_ARRAYID_BINARYID:NXdata
+        @signal="data_ARRAYID_BINARY_ID"
+        /data_ARRAYID_BINARYID[ the data for the array ARRAYID,
+                                binary BINARYID, all sections,
+                                all FRAMES]
+        @axes=[...,AXISID1,...] with AXISID1 inserted at PRECEDENCE-1
+        @AXISID1_indices=[PRECEDENCE-1]
+        @AXISID2_indices=[PRECEDENCE-1]
+        @AXISID3_indices=[PRECEDENCE-1]
+        @AXISID1_origins=[origin1]  (default 0)
+        @AXISID2_origins=[origin2]  (default 0)
+        @AXISID3_origins=[origin3]  (default 0)
+        @AXISID1_sizes=[size1]
+        @AXISID2_sizes=[size2]
+        @AXISID3_sizes=[size3]
+        @AXISID1_strides=[stride1]
+        @AXISID2_strides=[stride2]
+        @AXISID3_strides=[stride3]
+
+        ...
+        /AXISID1 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+        /AXISID2 -->
+            /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+        ...
+
+     /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+               .. 
+           /transformations:NXtransformations
+             /AXISID1=[DISP1,DISP1+DISPINC1,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID1"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE1
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC1
+                @CBF_array_structure_list_axis__displacement=DISP1
+                @CBF_array_structure_list_axis__displacement=FRACTDISP1
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC1
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC1
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH1
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH1
+                @CBF_array_structure_list_axis__reference_angle=REFANG1
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP1
+             /AXISID2=[DISP2,DISP2+DISPINC2,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID2"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE2
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC2
+                @CBF_array_structure_list_axis__displacement=DISP2
+                @CBF_array_structure_list_axis__displacement=FRACTDISP2
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC2
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC2
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH2
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH2
+                @CBF_array_structure_list_axis__reference_angle=REFANG2
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP2
+             /AXISID3=[DISP3,DISP3+DISPINC3,...]   (or using angles where appropriate)
+                @depends_on=...   determined from AXIS definitions
+                @equipment="detector"
+                @offset=[...] determined from AXIS definitions
+                @offset_units="mm"
+                @transformation_type="..." from AXIS definitions
+                @units="mm"
+                @vector=[...] determined from AXIS definitions
+                @CBF_array_structure_list_axis__axis_id="AXISID3"
+                @CBF_array_structure_list_axis__axis_set_id="AXISSETID"
+                @CBF_array_structure_list_axis__angle=ANGLE3
+                @CBF_array_structure_list_axis__angle_increment=ANGLEINC3
+                @CBF_array_structure_list_axis__displacement=DISP3
+                @CBF_array_structure_list_axis__displacement=FRACTDISP3
+                @CBF_array_structure_list_axis__displacement_increment=DISPINC3
+                @CBF_array_structure_list_axis__fract_displacement_increment=FRACTINC3
+                @CBF_array_structure_list_axis__angular_pitch=ANGPITCH3
+                @CBF_array_structure_list_axis__radial_pitch=RADPITCH3
+                @CBF_array_structure_list_axis__reference_angle=REFANG3
+                @CBF_array_structure_list_axis__reference_displacement=REFDISP3
+
+    Notes: The same axis AXISIDn may appear in multiple axis sets for different
+           values of PRECEDENCE of the data array, in which case the values
+           in AXISIDn_indices will be the sorted list of PRECEDENCE-1 values
+           and the array section information will be organized by the
+           same ordering.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_structure_list_axis.angle
+
+    _definition.id                '_array_structure_list_axis.angle'
+    _description.text
+;             The setting of the specified axis in degrees for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               angle
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_array_structure_list_axis.angle_increment
+
+    _definition.id                '_array_structure_list_axis.angle_increment'
+    _description.text
+;             The pixel-centre-to-pixel-centre increment in the angular
+               setting of the specified axis in degrees.  This is not
+               meaningful in the case of 'constant velocity' spiral scans
+               and should not be specified for this case.
+
+               See _array_structure_list_axis.angular_pitch.
+
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               angle_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_array_structure_list_axis.angular_pitch
+
+    _definition.id                '_array_structure_list_axis.angular_pitch'
+    _description.text
+;             The pixel-centre-to-pixel-centre distance for a one-step
+               change in the setting of the specified axis in millimetres.
+
+               This is meaningful only for 'constant velocity' spiral scans
+               or for uncoupled angular scans at a constant radius
+               (cylindrical scans) and should not be specified for cases
+               in which the angle between pixels (rather than the distance
+               between pixels) is uniform.
+
+               See _array_structure_list_axis.angle_increment.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               angular_pitch
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.axis_id
+
+    _definition.id                '_array_structure_list_axis.axis_id'
+    _description.text
+;             The value of this data item is the identifier of one of
+              the axes in the set of axes for which settings are being
+              specified.
+
+              Multiple axes may be specified for the same value of
+              _array_structure_list_axis.axis_set_id.
+
+              This item is a pointer to _axis.id in the
+              AXIS category.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               axis_id
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_structure_list_axis.axis_set_id
+
+    _definition.id                '_array_structure_list_axis.axis_set_id'
+    _description.text
+;             The value of this data item is the identifier of the
+               set of axes for which axis settings are being specified.
+
+               Multiple axes may be specified for the same value of
+               _array_structure_list_axis.axis_set_id.
+
+               This item is a pointer to
+               _array_structure_list.axis_set_id
+               in the ARRAY_STRUCTURE_LIST category.
+
+               If this item is not specified, it defaults to the corresponding
+               axis identifier.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               axis_set_id
+    _name.linked_item_id          '_array_structure_list.axis_set_id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_structure_list_axis.displacement
+
+    _definition.id                '_array_structure_list_axis.displacement'
+    _description.text
+;             The setting of the specified axis in millimetres for the first
+               data point of the array index with the corresponding value
+               of _array_structure_list.axis_set_id.  If the index is
+               specified as 'increasing', this will be the centre of the
+               pixel with index value 1.  If the index is specified as
+             'decreasing', this will be the centre of the pixel with
+               maximum index value.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               displacement
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.displacement_increment
+
+    _definition.id
+        '_array_structure_list_axis.displacement_increment'
+    _description.text
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis in millimetres.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               displacement_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.fract_displacement
+
+    _definition.id
+        '_array_structure_list_axis.fract_displacement'
+    _description.text
+;             The setting of the specified axis as a decimal fraction of 
+               the axis unit vector for the first data point of the array 
+               index with the corresponding value of 
+               _array_structure_list.axis_set_id.  
+
+               If the index is specified as 'increasing', this will be the 
+               centre of the pixel with index value 1.  If the index is 
+               specified as 'decreasing', this will be the centre of the 
+               pixel with maximum index value.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               fract_displacement
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.default          0.0
+    _units.code                   none
+
+save_
+
+save_array_structure_list_axis.fract_displacement_increment
+
+    _definition.id
+        '_array_structure_list_axis.fract_displacement_increment'
+    _description.text
+;             The pixel-centre-to-pixel-centre increment for the displacement
+               setting of the specified axis as a decimal fraction of the
+               axis unit vector.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               fract_displacement_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.radial_pitch
+
+    _definition.id                '_array_structure_list_axis.radial_pitch'
+    _description.text
+;             The radial distance from one 'cylinder' of pixels to the
+               next in millimetres.  If the scan is a 'constant velocity'
+               scan with differing angular displacements between pixels,
+               the value of this item may differ significantly from the
+               value of _array_structure_list_axis.displacement_increment.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               radial_pitch
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.reference_angle
+
+    _definition.id                '_array_structure_list_axis.reference_angle'
+    _description.text
+;             The value of _array_structure_list_axis.reference_angle
+               specifies the setting of the angle of this axis used for 
+               determining a reference beam centre and a reference detector 
+               distance.  It is normally expected to be identical to the 
+               value of _array_structure_list_axis.angle.
+
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               reference_angle
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _units.code                   degrees
+
+save_
+
+save_array_structure_list_axis.reference_displacement
+
+    _definition.id
+        '_array_structure_list_axis.reference_displacement'
+    _description.text
+;             The value of _array_structure_list_axis.reference_displacement
+               specifies the setting of the displacement of this axis used 
+               for determining a reference beam centre and a reference detector
+               distance.  It is normally expected to be identical to the value
+               of _array_structure_list_axis.displacement.
+
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               reference_displacement
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _units.code                   millimetres
+
+save_
+
+save_array_structure_list_axis.variant
+
+    _definition.id                '_array_structure_list_axis.variant'
+    _description.text
+;            The value of _array_structure_list_axis.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST_SECTION
+
+    _definition.id                array_structure_list_section
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
+    the dimension-by-dimension start, end and stride of each section of an
+    array that is to be referenced.
+
+    For any array with identifier ARRAYID, array section ids of the form
+    ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
+    by default.
+
+    For the given index, the elements in the section are of indices:
+    _array_structure_list_section.start,
+    _array_structure_list_section.start + _array_structure_list_section.stride,
+    _array_structure_list_section.start + 2*_array_structure_list_section.stride,
+    ...
+
+    stopping either when the indices leave the limits of the indices
+    of that dimension or 
+    [min(_array_structure_list_section.start, _array_structure_list_section.end),
+     max(_array_structure_list_section.start, _array_structure_list_section.end)].
+    The ordering of these elements is determined by the overall ordering of
+    _array_structure_list_section.array_id and not by the ordering implied
+    by the stride.
+;
+    _name.category_id             HEAD
+    _name.object_id               array_structure_list_section
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_array_structure_list_section.id'
+         '_array_structure_list_section.array_id'
+         '_array_structure_list_section.index'
+         '_array_structure_list_section.variant'
+
+    _description_example.case
+;     loop_
+    _array_structure_list.array_id
+    _array_structure_list.index
+    _array_structure_list.dimension
+    _array_structure_list.precedence
+    _array_structure_list.direction
+    _array_structure_list.axis_set_id
+    myarray   1    1300    1     increasing  ELEMENT_X
+    myarray   2    1200    2     increasing  ELEMENT_Y
+    myarray   3    700     3     increasing  FRAME_NO
+
+     loop_
+    _array_structure_list_section.id
+    _array_structure_list_section.array_id
+    _array_structure_list_section.index
+    _array_structure_list_section.start
+    _array_structure_list_section.end
+    _array_structure_list_section.stride
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+;
+    _description_example.detail
+;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+                    700 frames is defined in ARRAY_STRUCTURE_LIST, and
+                    the array section identifier
+
+                    "myarray(101:1200,101:1100,1:700:10)"
+
+                    is explicitly defined taking every 10th frame and
+                    removing a 100 pixel border.  Note that even though
+                    the slow index high is 700, the last frame that
+                    will actually be included is only 691.
+;
+    _nx_mapping.details
+;    _array_structure_list_section.array_id ARRAYID -->
+    _array_structure_list_section.id SECTIONID -->
+    _array_structure_list_section.index INDEX-->
+    _array_structure_list_section.end END -->
+    _array_structure_list_section.start START -->
+    _array_structure_list_section.stride STRIDE -->
+    /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+           /data_ARRAYID_BINARYID -->
+                /entry/data_ARRAYID_BINARYID/data_ARRAYID_BINARYID
+           /AXISID1 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID1
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID2
+           /AXISID2 -->
+                /entry/instrument/DETECTORELEMENTNAME/transformations/AXISID3
+           /ARRAYSECTIONID:NXdetector_module
+             /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
+             /data_size=[...] the sizes in pixels of ARRAYSECTIONID
+             /data_stride[...] the strides of ARRAYSECTIONID
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_array_structure_list_section.array_id
+
+    _definition.id                '_array_structure_list_section.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               array_id
+    _name.linked_item_id          '_array_structure.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_array_structure_list_section.end
+
+    _definition.id                '_array_structure_list_section.end'
+    _description.text
+;             Identifies the ending ordinal, numbered from 1, for an array
+              element of index _array_structure_list_section.index in the
+              section.
+
+              The value defaults to the dimension for index
+              _array_structure_list_section.index
+              of the array.
+
+              Note that this agrees with the Fortran convention, rather than
+              the Python convention in that, if compatible with the stride,
+              the end element is included in the section as in Fortran, rather
+              than being one beyond the section as in Python.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               end
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list_section.id
+
+    _definition.id                '_array_structure_list_section.id'
+    _description.text
+;             Uniquely identifies the array section chosen.
+
+              To avoid confusion array section IDs that contain parentheses
+              should conform to the default syntax
+
+              ARRAYID(start1:end1:stride1,start2:end2:stride2, ...)
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_array_structure_list_section.index
+
+    _definition.id                '_array_structure_list_section.index'
+    _description.text
+;             This item is a pointer to _array_structure_list.index
+              in the ARRAY_STRUCTURE_LIST category.
+
+              Identifies the one-based index of the row, column, sheet ...
+              the ARRAY_STRUCTURE_LIST category.
+
+              For a multidimensional array, a value must be explicitly given.
+
+              If an index is omitted from a section then all elements for that
+              index are assumed to be included in the section.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               index
+    _name.linked_item_id          '_array_structure_list.index'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_array_structure_list_section.start
+
+    _definition.id                '_array_structure_list_section.start'
+    _description.text
+;             Identifies the starting ordinal, numbered from 1,
+              for an array element of index _array_structure_list_section.index
+              in the section.
+
+              The value defaults to 1.   For the given index, the elements in
+              the section are of indices:
+              _array_structure_list_section.start,
+              _array_structure_list_section.start
+                 + _array_structure_list_section.stride,
+              _array_structure_list_section.start
+                 + 2*_array_structure_list_section.stride,
+                  ...
+
+              stopping either when the indices leave the limits of the indices
+              of that dimension or 
+              [min(_array_structure_list_section.start,
+                  _array_structure_list_section.end),
+               max(_array_structure_list_section.start,
+                  _array_structure_list_section.end)].
+              The ordering of these elements is determined by the overall
+              ordering of _array_structure_list_section.array_id and not by
+              the ordering implied by the stride.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               start
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list_section.stride
+
+    _definition.id                '_array_structure_list_section.stride'
+    _description.text
+;             Identifies the incremental steps to be taken when moving
+              element to element in the section in that particular
+              dimension.  The value of _array_structure_list_section.stride
+              may be positive or negative.  If the stride is zero, the section
+              is just defined by _array_structure_list_section.start.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               stride
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _enumeration.default          1
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_array_structure_list_section.variant
+
+    _definition.id                '_array_structure_list_section.variant'
+    _description.text
+;             The value of _array_structure_list_section.variant gives the
+              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
+              is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               variant
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_AXIS
+
+    _definition.id                axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;   Data items in the AXIS category record the information required
+     to describe the various goniometer, detector, source and other
+     axes needed to specify a data collection or the axes defining the
+     coordinate system of an image.  
+
+     The location of each axis is specified by two vectors: the axis 
+     itself, given by a unit vector in the direction of the axis, and 
+     an offset to the base of the unit vector.  
+
+     The vectors defining an axis are referenced to an appropriate
+     coordinate system, given in _axis.system.  The axis vector itself,
+       [_axis.vector[1], _axis.vector[2], _axis.vector[3]],
+     is a dimensionless unit vector.  Where meaningful, an offset vector
+       [_axis.offset[1], _axis.offset[2], _axis.offset[3]]
+     supplies the offsets to the base of a rotation or translation axis in
+     X, Y and Z.  This is appropriate for the imgCIF standard laboratory 
+     coordinate system, the NeXus/HDF5 McStas laboratory coordinate system 
+     and the last two Cartesian coordinate systems, but for the direct lattice, 
+     X corresponds to a, Y to b and Z to c, while for the reciprocal lattice,
+     X corresponds to a*, Y to b* and Z to c*.
+
+     For purposes of visualization, all the coordinate systems are 
+     taken as right-handed, i.e. using the convention that the extended 
+     thumb of a right hand could point along the first (X) axis, the 
+     straightened pointer finger could point along the second (Y) axis 
+     and the middle finger folded inward could point along the third (Z)
+     axis.  For a right-handed rotation axis, if the right hand is wrapped
+     around the axis with the thumb pointed in the direction of the axis,
+     the fingers point in the positive rotation direction, i.e. clockwise.  
+
+     THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM 
+     The imgCIF standard laboratory coordinate system is a right-handed   
+     orthogonal coordinate system similar to that used by MOSFLM,  
+     but imgCIF puts Z along the X-ray beam, rather than putting X along the
+     X-ray beam as in MOSFLM.
+
+     The vectors for the imgCIF standard laboratory coordinate system
+     form a right-handed Cartesian coordinate system with its origin
+     in the sample or specimen.  The origin of the axis system should,
+     if possible, be defined in terms of mechanically stable axes to be
+     both in the sample and in the beam.  If the sample goniometer or other
+     sample positioner has two axes the intersection of which defines a
+     unique point at which the sample should be mounted to be bathed
+     by the beam, that will be the origin of the axis system.  If no such
+     point is defined, then the midpoint of the line of intersection
+     between the sample and the centre of the beam will define the origin.
+     For this definition the sample positioning system will be set at 
+     its initial reference position for the experiment.
+                             | Y (to complete right-handed system)
+                             |
+                             |
+                             |
+                             |
+                             |
+                             |________________X
+                            /       principal goniometer axis
+                           /
+                          /
+                         /
+                        /
+                       /Z (to source)
+     Axis 1 (X): The X-axis is aligned to the mechanical axis pointing from
+     the sample or specimen along the  principal axis of the goniometer or
+     sample positioning system if the sample positioning system has an axis 
+     that intersects the origin and which forms an angle of more than 22.5 
+     degrees with the beam axis.
+
+     Axis 2 (Y): The Y-axis completes an orthogonal right-handed system
+     defined by the X-axis and the Z-axis (see below).
+
+     Axis 3 (Z): The Z-axis is derived from the source axis which goes from
+     the sample to the source.  The Z-axis is the component of the source axis
+     in the direction of the source orthogonal to the X-axis in the plane
+     defined by the X-axis and the source axis.
+
+     If the conditions for the X-axis can be met, the coordinate system
+     will be based on the goniometer or other sample positioning system
+     and the beam and not on the orientation of the detector, gravity etc.  
+     The vectors necessary to specify all other axes are given by sets of 
+     three components in the order (X, Y, Z).
+     If the axis involved is a rotation axis, it is right-handed, i.e. as
+     one views the object to be rotated from the origin (the tail) of the
+     unit vector, the rotation is clockwise.  If a translation axis is
+     specified, the direction of the unit vector specifies the sense of
+     positive translation.
+
+     In some experimental techniques, there is no goniometer or the principal
+     axis of the goniometer is at a small acute angle with respect to
+     the source axis.  In such cases, other reference axes are needed
+     to define a useful coordinate system.  The order of priority in
+     defining directions in such cases is to use the detector, then
+     gravity, then north.
+
+     If the X-axis cannot be defined as above, then the
+     direction (not the origin) of the X-axis should be parallel to the axis 
+     of the primary detector element corresponding to the most rapidly 
+     varying dimension of that detector element's data array, with its 
+     positive sense corresponding to increasing values of the index for 
+     that dimension.  If the detector is such that such a direction cannot 
+     be defined (as with a point detector) or that the direction forms an
+     angle of less than 22.5 degrees with respect to the source axis, then 
+     the X-axis should be chosen so that if the Y-axis is chosen 
+     in the direction of gravity, and the Z-axis is chosen to be along 
+     the source axis, a right-handed orthogonal coordinate system is chosen.  
+     In the case of a vertical source axis, as a last resort, the 
+     X-axis should be chosen to point north.
+
+     All rotations are given in degrees and all translations are given in mm.
+
+     Axes may be dependent on one another.  The X-axis is the only goniometer
+     axis the direction of which is strictly connected to the hardware.  All
+     other axes are specified by the positions they would assume when the
+     axes upon which they depend are at their zero points.
+
+     When specifying detector axes, the axis is given to the beam centre.
+     The location of the beam centre on the detector should be given in the
+     DIFFRN_DETECTOR category in distortion-corrected millimetres from
+     the (0,0) corner of the detector.
+
+     For convenience when describing detector element (module) placement,
+     an optional mounting rotation axis and rotation angle may be
+     specified.  In such cases, the mounting rotation axis and angle
+     of rotation around the mounting rotation axis are applied after
+     applying the transformations upon which the given axis depends.
+
+     It should be noted that many different origins arise in the definition
+     of an experiment.  In particular, as noted above, it is necessary to
+     specify the location of the beam centre on the detector in terms
+     of the origin of the detector, which is, of course, not coincident
+     with the centre of the sample.
+     THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM 
+     The standard coordinate frame in NeXus is the McStas coordinate frame,
+     in which the Z-axis points in the direction of the incident beam, the
+     X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
+     left as seen from the source and the Y-axis points upwards.  The
+     origin is in the sample.
+
+     Differences in Coordinate Frames
+
+     The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
+     principal goniometer axis, and chooses the Z-axis to point from the sample
+     into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
+     is the component of the vector that points into the beam orthogonal to the
+     X-axis.  The Y-axis is chosen to complete a right-handed axis system.
+
+     Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
+     imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
+     of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
+     from the NeXus coordinate system to the imgCIF coordinate system, we
+     also need two additional axes, as unit vectors, Gravity_cbf the downwards
+     direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).   
+
+     In practice, the beam is not necessarily perfectly horizontal, so Y_nx
+     is not necessarily perfectly vertical. Therefore, in order to generate
+     X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
+     vectors a and b is a new vector c orthogonal to both a and b,
+     chosen so that a, b, c is a right-handed system.  If a and b are
+     orthogonal unit vectors, this right-handed system is an orthonormal
+     coordinate system.
+
+     In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
+
+        Z_nx = Beam_cbf.
+
+     X_nx is defined as being horizontal at right angles to the beam,
+     pointing to the left when seen from the source.  Assuming the beam is
+     not vertical, we can compute X_nx as the normalized cross product of
+     the  beam and gravity:
+
+        X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
+
+     To see that this satisfies the constraint of being horizontal and
+     pointing to the left, consider the case of Beam = ( 0, 0, -1 )
+     and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
+     from the cross product above.  The normalization is only necessary
+     if the beam is not horizontal.
+
+     Finally Y_nx is computed as the cross product of the beam and X_nx,
+     completing an orthonormal right-handed system with Y_nx pointing upwards
+
+        Y_nx = Beam_cbf x X_nx.
+
+     Then we know that in the imgCIF/CBF coordinate frame
+
+        v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
+
+     Thus, given the imgCIF/CBF vectors for the true direction of the beam
+     and the true direction of gravity, we have a linear transformation from
+     the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
+     origins of the two frames agree.   The inverse linear transformation will
+     transform a vector in the imgCIF/CBF coordinate frame into the NeXus
+     coordinate frame.
+
+     In the common case in which the beam is orthogonal to the principal
+     goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
+     Y-axis points upwards, the transformation inverts the X and Z axes.
+     In the other common case in which the beam is orthogonal to the
+     principal goniometer axis and the imgCIF/CBF Y-axis points
+     downwards, the transformation inverts the Y and Z axes.
+
+     Mapping axes
+
+     There are two transformations needed:  coord_xform(v) which takes a vector,
+     v, in the CBF imgCIF Standard Laboratory Coordinate System and returns the
+     equivalent McStas coordinate vector, and offset_xform(o) which takes an
+     offset, o, in the CBF imgCIF Standard Laboratory Coordinate System and
+     returns the equivalent NeXus offset.
+
+     In imgCIF/CBF all the information about all axes other than their
+     settings are gathered in one AXIS category.  The closest equivalent
+     container in NeXus is the NXinstrument class.  We put the information
+     about detector axes into a
+     detector:NXdetector/transformations:NXtransformations NeXus class instance,
+     information about the goniometer into a
+     goniometer:NXgoniometer/transformations:NXtransformations NeXus
+     class instance, etc.  Additionally, in view of the general nature of
+     some axes, such as the coordinate frame axes and gravity, we add a
+     transformations:NXtransformation NeXus class instance under NXentry with
+     axis__gravity, axis__beam and other axes not tied to specific equipment.
+
+     We have applied the coordinate frame transformation changing
+     the CBF laboratory coordinates into McStas coordinates.  Notice that X and
+     Z have changed direction, but Y has not.   In other experimental setups,
+     other transformations may occur.   The offsets for dependent axes are
+     given relative to the total offset of axes on which that axis is dependent.
+     Note that the axis settings do not enter into this calculation, because the
+     offsets of dependent axes are given with all axes at their zero settings.
+     The cbf_location attribute gives a mapping back into the CBF AXIS category
+     in dotted notation.  The first component is the data block.  The second
+     component is "axis".  The third component is either "vector" or
+     "offset"  for information drawn from the AXIS.VECTOR[...] or
+     AXIS.OFFSET[...] respectively.  The last component is the CBF row number
+     to facilitate recovering the original CBF layout.
+
+     THE DIRECT LATTICE (FRACTIONAL COORDINATES) 
+     The unit cell, reciprocal cell and crystallographic orthogonal 
+     Cartesian coordinate system are defined by the CELL and the matrices 
+     in the ATOM_SITES category.
+
+     The direct lattice coordinate system is a system of fractional
+     coordinates aligned to the crystal, rather than to the laboratory.
+     This is a natural coordinate system for maps and atomic coordinates.
+     It is the simplest coordinate system in which to apply symmetry.
+     The axes are determined by the cell edges, and are not necessarily
+     orthogonal.  This coordinate system is not uniquely defined and 
+     depends on the cell parameters in the CELL category and the
+     settings chosen to index the crystal. 
+
+     Molecules in a crystal studied by X-ray diffraction are organized
+     into a repeating regular array of unit cells.  Each unit cell is defined 
+     by three vectors, a, b and c.  To quote from Drenth (2001),
+     "The choice of the unit cell is not unique and therefore, guidelines
+     have been established for selecting the standard basis vectors and
+     the origin.  They are based on symmetry and metric considerations:
+
+      "(1)  The axial system should be right-handed.
+       (2)  The basis vectors should coincide as much as possible with
+       directions of highest symmetry.
+       (3)  The cell taken should be the smallest one that satisfies
+       condition (2)
+       (4)  Of all the lattice vectors, none is shorter than a.
+       (5)  Of those not directed along a, none is shorter than b.
+       (6)  Of those not lying in the ab plane, none is shorter than c.
+       (7)  The three angles between the basis vectors a, b and c are
+       either all acute (<90 degrees) or all obtuse (&ge;90 degrees)."
+
+     These rules do not produce a unique result that is stable under
+     the assumption of experimental errors, and the resulting cell
+     may not be primitive.
+
+     In this coordinate system, the vector (.5, .5, .5) is in the middle
+     of the given unit cell.
+
+     Grid coordinates are an important variation on fractional coordinates
+     used when working with maps.  In imgCIF, the conversion from
+     fractional to grid coordinates is implicit in the array indexing
+     specified by _array_structure_list.dimension.  Note that this
+     implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
+     the origin of the cell for axes along the cell edges with no
+     specified _array_structure_list_axis.displacement will have
+     grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+     THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE) 
+     The orthogonal Cartesian coordinate system is a transformation of
+     the direct lattice to the actual physical coordinates of atoms in
+     space.  It is similar to the laboratory coordinate system, but
+     is anchored to and moves with the crystal, rather than being
+     anchored to the laboratory.  The transformation from fractional
+     to orthogonal Cartesian coordinates is given by the
+              _atom_sites.Cartn_transf_matrix[i][j]  and
+              _atom_sites.Cartn_transf_vector[i]
+     tags.  A common choice for the matrix of the transformation is 
+     given in Protein Data Bank (1992):
+
+              | a      b cos \g   c cos \b                            |
+              | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
+              | 0      0          V/(a b sin \g)                      |
+
+     This is a convenient coordinate system in which to do fitting
+     of models to maps and in which to understand the chemistry of
+     a molecule.
+     THE RECIPROCAL LATTICE 
+     The reciprocal lattice coordinate system is used for diffraction
+     intensities.  It is based on the reciprocal cell, the dual of the cell,
+     in which reciprocal cell edges are derived from direct cell faces:
+
+        a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
+        cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
+        cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
+        cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
+        V = abc (1 - cos^2^ \a 
+                       - cos^2^ \b
+                       - cos^2^ \g
+                       + 2 cos \a cos \b cos \g )^1/2^
+
+     In this form the dimensions of the reciprocal lattice are in reciprocal
+     \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by 
+     multiplying by the wavelength.  Reflections are commonly indexed against
+     this coordinate system as (h, k, l) triples.
+     References:
+
+     Drenth, J. (2001). Introduction to basic crystallography.
+     International tables for crystallography, Vol. F, Crystallography of
+     biological macromolecules, edited by M. G. Rossmann & E. Arnold,
+     1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.    
+
+     Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
+     MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
+     http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
+
+     Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
+     2nd ed., 453 pp. New York: Wiley.
+
+     Protein Data Bank (1992). Atomic Coordinate and Bibliographic
+     Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
+     Brookhaven National Laboratory.
+;
+    _name.category_id             HEAD
+    _name.object_id               axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_axis.id'
+         '_axis.equipment'
+         '_axis.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        omega rotation goniometer     .    1        0        0
+        kappa rotation goniometer omega    -.64279  0       -.76604
+        phi   rotation goniometer kappa    1        0        0
+;
+;      Example 1.
+
+        This example shows the axis specification of the axes of a
+        kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
+        (1989). X-ray structure determination. A practical
+        guide, 2nd ed. p. 134. New York: Wiley Interscience].
+
+        There are three axes specified, and no offsets.  The outermost axis,
+        omega, is pointed along the X axis.  The next innermost axis, kappa,
+        is at a 50 degree angle to the X axis, pointed away from the source.
+        The innermost axis, phi, aligns with the X axis when omega and
+        phi are at their zero points.  If T-omega, T-kappa and T-phi
+        are the transformation matrices derived from the axis settings,
+        the complete transformation would be:
+            X' = (T-omega) (T-kappa) (T-phi) X
+;
+;
+        loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        _axis.offset[1] _axis.offset[2] _axis.offset[3]
+        source       .        source     .       0     0     1   . . .
+        gravity      .        gravity    .       0    -1     0   . . .
+        tranz     translation detector rotz      0     0     1   0 0 -68
+        twotheta  rotation    detector   .       1     0     0   . . .
+        roty      rotation    detector twotheta  0     1     0   0 0 -68
+        rotz      rotation    detector roty      0     0     1   0 0 -68
+;
+;      Example 2.
+
+        This example shows the axis specification of the axes of a
+        detector, source and gravity.  The order has been changed as a
+        reminder that the ordering of presentation of tokens is not
+        significant.  The centre of rotation of the detector has been taken
+        to be 68 mm in the direction away from the source.
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        CELL_A_AXIS    fractional       1 0 0
+        CELL_B_AXIS    fractional       0 1 0
+        CELL_C_AXIS    fractional       0 0 1
+
+        loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing CELL_A_AXIS
+        map 1 25 2 increasing CELL_B_AXIS
+        map 1 25 3 increasing CELL_C_AXIS
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.fract_displacement
+        _array_structure_list_axis.fract_displacement_increment
+        CELL_A_AXIS 0.01 0.02
+        CELL_B_AXIS 0.01 0.02
+        CELL_C_AXIS 0.01 0.02
+;
+;      Example 3.
+
+        This example shows the axis specification of the axes for a map,
+        using fractional coordinates.  Each cell edge has been divided
+        into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS 
+        category.  The map is using only the first octant of the grid
+        in the ARRAY_STRUCTURE_LIST category.
+
+        The fastest changing axis is along A, then along B,
+        and the slowest is along C. 
+
+        The map sampling is being done in the middle of each grid
+        division.
+
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        X    orthogonal       1 0 0
+        Y    orthogonal       0 1 0
+        Z    orthogonal       0 0 1
+
+                loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing X
+        map 2 25 2 increasing Y
+        map 3 25 3 increasing Z
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.displacement
+        _array_structure_list_axis.displacement_increment
+        X 7.5e-8 1.5e-7
+        Y 7.5e-8 1.5e-7
+        Z 7.5e-8 1.5e-7
+;
+;      Example 4.
+
+        This example shows the axis specification of the axes for a map,
+        this time as orthogonal \%angstr\"oms, using the same coordinate system 
+        as for the atomic coordinates.  The map is sampling every 1.5
+        \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
+;
+;
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_D0_X
+    CSPAD_FRONT AXIS_D0_Y
+    CSPAD_FRONT AXIS_D0_Z
+    CSPAD_FRONT AXIS_D0_R
+    CSPAD_FRONT FS_D0Q0
+    CSPAD_FRONT FS_D0Q0S0
+    CSPAD_FRONT FS_D0Q0S0A0
+    CSPAD_FRONT FS_D0Q0S0A1
+    CSPAD_FRONT FS_D0Q0S1
+    CSPAD_FRONT FS_D0Q0S1A0
+    CSPAD_FRONT FS_D0Q0S1A1
+    CSPAD_FRONT FS_D0Q0S2
+    CSPAD_FRONT FS_D0Q0S2A0
+    CSPAD_FRONT FS_D0Q0S2A1
+    CSPAD_FRONT FS_D0Q0S3
+    CSPAD_FRONT FS_D0Q0S3A0
+    CSPAD_FRONT FS_D0Q0S3A1
+    CSPAD_FRONT FS_D0Q0S4
+    CSPAD_FRONT FS_D0Q0S4A0
+    CSPAD_FRONT FS_D0Q0S4A1
+    CSPAD_FRONT FS_D0Q0S5
+    CSPAD_FRONT FS_D0Q0S5A0
+    CSPAD_FRONT FS_D0Q0S5A1
+    CSPAD_FRONT FS_D0Q0S6
+    CSPAD_FRONT FS_D0Q0S6A0
+    CSPAD_FRONT FS_D0Q0S6A1
+    CSPAD_FRONT FS_D0Q0S7
+    CSPAD_FRONT FS_D0Q0S7A0
+    CSPAD_FRONT FS_D0Q0S7A1
+    CSPAD_FRONT FS_D0Q1
+    CSPAD_FRONT FS_D0Q1S0
+    CSPAD_FRONT FS_D0Q1S0A0
+    CSPAD_FRONT FS_D0Q1S0A1
+    CSPAD_FRONT FS_D0Q1S1
+    CSPAD_FRONT FS_D0Q1S1A0
+    CSPAD_FRONT FS_D0Q1S1A1
+    CSPAD_FRONT FS_D0Q1S2
+    CSPAD_FRONT FS_D0Q1S2A0
+    CSPAD_FRONT FS_D0Q1S2A1
+    CSPAD_FRONT FS_D0Q1S3
+    CSPAD_FRONT FS_D0Q1S3A0
+    CSPAD_FRONT FS_D0Q1S3A1
+    CSPAD_FRONT FS_D0Q1S4
+    CSPAD_FRONT FS_D0Q1S4A0
+    CSPAD_FRONT FS_D0Q1S4A1
+    CSPAD_FRONT FS_D0Q1S5
+    CSPAD_FRONT FS_D0Q1S5A0
+    CSPAD_FRONT FS_D0Q1S5A1
+    CSPAD_FRONT FS_D0Q1S6
+    CSPAD_FRONT FS_D0Q1S6A0
+    CSPAD_FRONT FS_D0Q1S6A1
+    CSPAD_FRONT FS_D0Q1S7
+    CSPAD_FRONT FS_D0Q1S7A0
+    CSPAD_FRONT FS_D0Q1S7A1
+    CSPAD_FRONT FS_D0Q2
+    CSPAD_FRONT FS_D0Q2S0
+    CSPAD_FRONT FS_D0Q2S0A0
+    CSPAD_FRONT FS_D0Q2S0A1
+    CSPAD_FRONT FS_D0Q2S1
+    CSPAD_FRONT FS_D0Q2S1A0
+    CSPAD_FRONT FS_D0Q2S1A1
+    CSPAD_FRONT FS_D0Q2S2
+    CSPAD_FRONT FS_D0Q2S2A0
+    CSPAD_FRONT FS_D0Q2S2A1
+    CSPAD_FRONT FS_D0Q2S3
+    CSPAD_FRONT FS_D0Q2S3A0
+    CSPAD_FRONT FS_D0Q2S3A1
+    CSPAD_FRONT FS_D0Q2S4
+    CSPAD_FRONT FS_D0Q2S4A0
+    CSPAD_FRONT FS_D0Q2S4A1
+    CSPAD_FRONT FS_D0Q2S5
+    CSPAD_FRONT FS_D0Q2S5A0
+    CSPAD_FRONT FS_D0Q2S5A1
+    CSPAD_FRONT FS_D0Q2S6
+    CSPAD_FRONT FS_D0Q2S6A0
+    CSPAD_FRONT FS_D0Q2S6A1
+    CSPAD_FRONT FS_D0Q2S7
+    CSPAD_FRONT FS_D0Q2S7A0
+    CSPAD_FRONT FS_D0Q2S7A1
+    CSPAD_FRONT FS_D0Q3
+    CSPAD_FRONT FS_D0Q3S0
+    CSPAD_FRONT FS_D0Q3S0A0
+    CSPAD_FRONT FS_D0Q3S0A1
+    CSPAD_FRONT FS_D0Q3S1
+    CSPAD_FRONT FS_D0Q3S1A0
+    CSPAD_FRONT FS_D0Q3S1A1
+    CSPAD_FRONT FS_D0Q3S2
+    CSPAD_FRONT FS_D0Q3S2A0
+    CSPAD_FRONT FS_D0Q3S2A1
+    CSPAD_FRONT FS_D0Q3S3
+    CSPAD_FRONT FS_D0Q3S3A0
+    CSPAD_FRONT FS_D0Q3S3A1
+    CSPAD_FRONT FS_D0Q3S4
+    CSPAD_FRONT FS_D0Q3S4A0
+    CSPAD_FRONT FS_D0Q3S4A1
+    CSPAD_FRONT FS_D0Q3S5
+    CSPAD_FRONT FS_D0Q3S5A0
+    CSPAD_FRONT FS_D0Q3S5A1
+    CSPAD_FRONT FS_D0Q3S6
+    CSPAD_FRONT FS_D0Q3S6A0
+    CSPAD_FRONT FS_D0Q3S6A1
+    CSPAD_FRONT FS_D0Q3S7
+    CSPAD_FRONT FS_D0Q3S7A0
+    CSPAD_FRONT FS_D0Q3S7A1
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.equipment_component
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source . 0 0 1 . . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
+    AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
+    AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
+    AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
+    AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm . .
+    FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125 0.0 detector_quadrant . .
+    FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0 1.0 11.3696 -23.189925 0.0 detector_sensor . .
+    FS_D0Q0S0A0 rotation detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A0_S translation detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S0A1 rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A1_S translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0 detector_sensor . .
+    FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A0_F translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1A1 rotation detector FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A1_S translation detector AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2 rotation detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0 detector_sensor . .
+    FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1 -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A0_F translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2A1 rotation detector FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A1_S translation detector AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3 rotation detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor . .
+    FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A0_F translation detector FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A1_F translation detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0 -11.2651 24.282775 0.0 detector_sensor . .
+    FS_D0Q0S4A0 rotation detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A0_S translation detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4A1 rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A1_S translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0 detector_sensor . .
+    FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1 -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A0_F translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5A1 rotation detector FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A1_S translation detector AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6 rotation detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
+    FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A0_F translation detector FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A1_F translation detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0 23.3541 9.829875 0.0 detector_sensor . .
+    FS_D0Q0S7A0 rotation detector FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A0_S translation detector AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7A1 rotation detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A1_S translation detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1 rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0 detector_quadrant . .
+    FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.1589875 -11.451825 0.0 detector_sensor . .
+    FS_D0Q1S0A0 rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A0_S translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A1_F translation detector FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.2073875 -34.782825 0.0 detector_sensor . .
+    FS_D0Q1S1A0 rotation detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A0_F translation detector FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A1_F translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2 rotation detector FS_D0Q1 0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . .
+    FS_D0Q1S2A0 rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A0_S translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A1_F translation detector FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0 -34.1402875 23.344475 0.0 detector_sensor . .
+    FS_D0Q1S3A0 rotation detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A0_S translation detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3A1 rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A1_S translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275 0.0 detector_sensor . .
+    FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1 -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A0_F translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4A1 rotation detector FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A1_S translation detector AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor . .
+    FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A0_F translation detector FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A1_F translation detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0 33.2523125 -23.321925 0.0 detector_sensor . .
+    FS_D0Q1S6A0 rotation detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A0_S translation detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6A1 rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A1_S translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225 0.0 detector_sensor . .
+    FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1 -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A0_F translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7A1 rotation detector FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A1_S translation detector AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2 rotation detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0 detector_quadrant . .
+    FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -11.3150125 23.1242 0.0 detector_sensor . .
+    FS_D0Q2S0A0 rotation detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A0_S translation detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S0A1 rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A1_S translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155 0.0 detector_sensor . .
+    FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A0_F translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1A1 rotation detector FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A1_S translation detector AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2 rotation detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor . .
+    FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A0_F translation detector FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A1_F translation detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0 23.6220875 34.2221 0.0 detector_sensor . .
+    FS_D0Q2S3A0 rotation detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A0_S translation detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3A1 rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A1_S translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954 0.0 detector_sensor . .
+    FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1 -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A0_F translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4A1 rotation detector FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A1_S translation detector AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5 rotation detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor . .
+    FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A0_F translation detector FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A1_F translation detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.4854125 -33.2552 0.0 detector_sensor . .
+    FS_D0Q2S6A0 rotation detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A0_S translation detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6A1 rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A1_S translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417 0.0 detector_sensor . .
+    FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1 -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A0_F translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7A1 rotation detector FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A1_S translation detector AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3 rotation detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0 detector_quadrant . .
+    FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1056375 11.6367625 0.0 detector_sensor . .
+    FS_D0Q3S0A0 rotation detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A0_S translation detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S0A1 rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A1_S translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625 0.0 detector_sensor . .
+    FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1 -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A0_F translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1A1 rotation detector FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A1_S translation detector AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0 detector_sensor . .
+    FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1 -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A0_F translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2A1 rotation detector FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A1_S translation detector AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0 detector_sensor . .
+    FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1 -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A0_F translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3A1 rotation detector FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A1_S translation detector AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0 detector_sensor . .
+    FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1 -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A0_F translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4A1 rotation detector FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A1_S translation detector AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0 detector_sensor . .
+    FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1 -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A0_F translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5A1 rotation detector FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A1_S translation detector AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0 detector_sensor . .
+    FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1 -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A0_F translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6A1 rotation detector FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A1_S translation detector AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0 detector_sensor . .
+    FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1 -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A0_F translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7A1 rotation detector FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+;
+;       Example 5.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+;
+;
+
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_DETECTOR_X
+    CSPAD_FRONT AXIS_DETECTOR_Y
+    CSPAD_FRONT AXIS_DETECTOR_Z
+    CSPAD_FRONT AXIS_DETECTOR_PITCH
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source   . 0 0 1 . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
+    AXIS_DETECTOR_Z translation detector
+                                 . 0 0 1 0 0 0 . .
+    AXIS_DETECTOR_Y translation detector
+                   AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_X translation detector
+                   AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
+    AXIS_DETECTOR_PITCH rotation detector
+                   AXIS_DETECTOR_X 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_ROT rotation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
+    AXIS_D0_ORIGIN translation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
+    AXIS_D0_ROT rotation detector
+                    AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0 translation detector
+                    AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
+    AXIS_D0Q0_ROT rotation detector
+                           AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0 translation detector
+                           AXIS_D0 . . . -49.860765625 41.643353125 0.0
+                                      0.0 AXIS_D0Q0_ROT
+    AXIS_D0Q0S0_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S0 translation detector
+                          AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
+                                      89.66181 AXIS_D0Q0S0_ROT
+    AXIS_D0Q0S0A0_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A0 translation detector
+                        AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S0A0_ROT
+    AXIS_D0Q0S0A0_F translation detector
+                      AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A0_S translation detector
+                      AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S0A1_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A1 translation detector
+                        AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S0A1_ROT
+    AXIS_D0Q0S0A1_F translation detector
+                      AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A1_S translation detector
+                      AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S1 translation detector
+                          AXIS_D0Q0 . . . 34.815 -23.309825 0.0
+                                      90.00132 AXIS_D0Q0S1_ROT
+    AXIS_D0Q0S1A0_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A0 translation detector
+                        AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S1A0_ROT
+    AXIS_D0Q0S1A0_F translation detector
+                      AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A0_S translation detector
+                      AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1A1_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A1 translation detector
+                        AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S1A1_ROT
+    AXIS_D0Q0S1A1_F translation detector
+                      AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A1_S translation detector
+                      AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2_ROT rotation detector
+                          AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q0S2 translation detector
+                          AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
+                                     359.68548 AXIS_D0Q0S2_ROT
+    AXIS_D0Q0S2A0_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A0 translation detector
+                        AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S2A0_ROT
+    AXIS_D0Q0S2A0_F translation detector
+                        AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A0_S translation detector
+                        AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2A1_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A1 translation detector
+                        AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S2A1_ROT
+    AXIS_D0Q0S2A1_F translation detector
+                        AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A1_S translation detector
+                        AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S3 translation detector
+                        AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
+                                   359.96513 AXIS_D0Q0S3_ROT
+    AXIS_D0Q0S3A0_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A0 translation detector
+                        AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S3A0_ROT
+    AXIS_D0Q0S3A0_F translation detector
+                        AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A0_S translation detector
+                        AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3A1_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A1 translation detector
+                        AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S3A1_ROT
+    AXIS_D0Q0S3A1_F translation detector
+                        AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A1_S translation detector
+                        AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S4 translation detector
+                        AXIS_D0Q0 . . . -11.2651 24.282775 0.0
+                                   270.14738 AXIS_D0Q0S4_ROT
+    AXIS_D0Q0S4A0_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A0 translation detector
+                        AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S4A0_ROT
+    AXIS_D0Q0S4A0_F translation detector
+                        AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A0_S translation detector
+                        AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4A1_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A1 translation detector
+                        AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S4A1_ROT
+    AXIS_D0Q0S4A1_F translation detector
+                        AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A1_S translation detector
+                        AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S5 translation detector
+                        AXIS_D0Q0 . . . -34.7336 24.169475 0.0
+                                   270.07896 AXIS_D0Q0S5_ROT
+    AXIS_D0Q0S5A0_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A0 translation detector
+                        AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S5A0_ROT
+    AXIS_D0Q0S5A0_F translation detector
+                        AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A0_S translation detector
+                        AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5A1_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A1 translation detector
+                        AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S5A1_ROT
+    AXIS_D0Q0S5A1_F translation detector
+                        AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A1_S translation detector
+                        AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S6 translation detector
+                        AXIS_D0Q0 . . . 23.5488 33.320375 0.0
+                                   359.78222 AXIS_D0Q0S6_ROT
+    AXIS_D0Q0S6A0_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A0 translation detector
+                        AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S6A0_ROT
+    AXIS_D0Q0S6A0_F translation detector
+                        AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A0_S translation detector
+                        AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6A1_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A1 translation detector
+                        AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S6A1_ROT
+    AXIS_D0Q0S6A1_F translation detector
+                        AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A1_S translation detector
+                        AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S7 translation detector
+                        AXIS_D0Q0 . . . 23.3541 9.829875 0.0
+                                   359.89604 AXIS_D0Q0S7_ROT
+    AXIS_D0Q0S7A0_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A0 translation detector
+                        AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S7A0_ROT
+    AXIS_D0Q0S7A0_F translation detector
+                        AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A0_S translation detector
+                        AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7A1_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A1 translation detector
+                        AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S7A1_ROT
+    AXIS_D0Q0S7A1_F translation detector
+                        AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A1_S translation detector
+                        AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1 translation detector
+                        AXIS_D0 . . . 41.512521875 50.149653125 0.0
+                                   0.0 AXIS_D0Q1_ROT
+    AXIS_D0Q1S0_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S0 translation detector
+                        AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
+                                     0.27238 AXIS_D0Q1S0_ROT
+    AXIS_D0Q1S0A0_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A0 translation detector
+                        AXIS_D0Q1S0 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q1S0A0_ROT
+    AXIS_D0Q1S0A0_F translation detector
+                        AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A0_S translation detector
+                        AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S0A1_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A1 translation detector
+                        AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S0A1_ROT
+    AXIS_D0Q1S0A1_F translation detector
+                        AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A1_S translation detector
+                        AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S1 translation detector
+                        AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
+                                     0.00525999986641 AXIS_D0Q1S1_ROT
+    AXIS_D0Q1S1A0_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A0 translation detector
+                        AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S1A0_ROT
+    AXIS_D0Q1S1A0_F translation detector
+                        AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A0_S translation detector
+                        AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1A1_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A1 translation detector
+                        AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S1A1_ROT
+    AXIS_D0Q1S1A1_F translation detector
+                        AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A1_S translation detector
+                        AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S2 translation detector
+                        AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
+                                   270.02545 AXIS_D0Q1S2_ROT
+    AXIS_D0Q1S2A0_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A0 translation detector
+                        AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S2A0_ROT
+    AXIS_D0Q1S2A0_F translation detector
+                        AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A0_S translation detector
+                        AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2A1_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A1 translation detector
+                        AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S2A1_ROT
+    AXIS_D0Q1S2A1_F translation detector
+                        AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A1_S translation detector
+                        AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S3 translation detector
+                        AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
+                                   270.03066 AXIS_D0Q1S3_ROT
+    AXIS_D0Q1S3A0_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A0 translation detector
+                        AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S3A0_ROT
+    AXIS_D0Q1S3A0_F translation detector
+                        AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A0_S translation detector
+                        AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3A1_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A1 translation detector
+                        AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S3A1_ROT
+    AXIS_D0Q1S3A1_F translation detector
+                        AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A1_S translation detector
+                        AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S4 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
+                                    179.96381 AXIS_D0Q1S4_ROT
+    AXIS_D0Q1S4A0_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A0 translation detector
+                        AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S4A0_ROT
+    AXIS_D0Q1S4A0_F translation detector
+                        AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A0_S translation detector
+                        AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4A1_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A1 translation detector
+                        AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S4A1_ROT
+    AXIS_D0Q1S4A1_F translation detector
+                        AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A1_S translation detector
+                        AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S5 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
+                                   180.02434 AXIS_D0Q1S5_ROT
+    AXIS_D0Q1S5A0_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A0 translation detector
+                        AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S5A0_ROT
+    AXIS_D0Q1S5A0_F translation detector
+                        AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A0_S translation detector
+                        AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5A1_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A1 translation detector
+                        AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S5A1_ROT
+    AXIS_D0Q1S5A1_F translation detector
+                        AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A1_S translation detector
+                        AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S6 translation detector
+                        AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
+                                   270.08027 AXIS_D0Q1S6_ROT
+    AXIS_D0Q1S6A0_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A0 translation detector
+                        AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S6A0_ROT
+    AXIS_D0Q1S6A0_F translation detector
+                        AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A0_S translation detector
+                        AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6A1_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A1 translation detector
+                        AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S6A1_ROT
+    AXIS_D0Q1S6A1_F translation detector
+                        AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A1_S translation detector
+                        AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S7 translation detector
+                        AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
+                                   270.15067 AXIS_D0Q1S7_ROT
+    AXIS_D0Q1S7A0_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A0 translation detector
+                        AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S7A0_ROT
+    AXIS_D0Q1S7A0_F translation detector
+                        AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A0_S translation detector
+                        AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7A1_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A1 translation detector
+                        AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S7A1_ROT
+    AXIS_D0Q1S7A1_F translation detector
+                        AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A1_S translation detector
+                        AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2 translation detector
+                        AXIS_D0 . . . 49.596146875 -41.351371875 0.0
+                                   0.0 AXIS_D0Q2_ROT
+    AXIS_D0Q2S0_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S0 translation detector
+                        AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
+                                    90.04803 AXIS_D0Q2S0_ROT
+    AXIS_D0Q2S0A0_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A0 translation detector
+                        AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S0A0_ROT
+    AXIS_D0Q2S0A0_F translation detector
+                        AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A0_S translation detector
+                        AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S0A1_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A1 translation detector
+                        AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S0A1_ROT
+    AXIS_D0Q2S0A1_F translation detector
+                        AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A1_S translation detector
+                        AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S1 translation detector
+                        AXIS_D0Q2 . . . -34.6999125 23.155 0.0
+                                    90.00592 AXIS_D0Q2S1_ROT
+    AXIS_D0Q2S1A0_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A0 translation detector
+                        AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S1A0_ROT
+    AXIS_D0Q2S1A0_F translation detector
+                        AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A0_S translation detector
+                        AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1A1_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A1 translation detector
+                        AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S1A1_ROT
+    AXIS_D0Q2S1A1_F translation detector
+                        AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A1_S translation detector
+                        AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S2 translation detector
+                        AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
+                                    180.11318 AXIS_D0Q2S2_ROT
+    AXIS_D0Q2S2A0_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A0 translation detector
+                        AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S2A0_ROT
+    AXIS_D0Q2S2A0_F translation detector
+                        AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A0_S translation detector
+                        AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2A1_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A1 translation detector
+                        AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S2A1_ROT
+    AXIS_D0Q2S2A1_F translation detector
+                        AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A1_S translation detector
+                        AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S3 translation detector
+                        AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
+                                   179.92104 AXIS_D0Q2S3_ROT
+    AXIS_D0Q2S3A0_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A0 translation detector
+                        AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S3A0_ROT
+    AXIS_D0Q2S3A0_F translation detector
+                        AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A0_S translation detector
+                        AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3A1_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A1 translation detector
+                        AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S3A1_ROT
+    AXIS_D0Q2S3A1_F translation detector
+                        AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A1_S translation detector
+                        AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S4 translation detector
+                        AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
+                                      89.63875 AXIS_D0Q2S4_ROT
+    AXIS_D0Q2S4A0_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A0 translation detector
+                        AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S4A0_ROT
+    AXIS_D0Q2S4A0_F translation detector
+                        AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A0_S translation detector
+                        AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4A1_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A1 translation detector
+                        AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S4A1_ROT
+    AXIS_D0Q2S4A1_F translation detector
+                        AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A1_S translation detector
+                        AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S5 translation detector
+                        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
+                                    89.68154 AXIS_D0Q2S5_ROT
+    AXIS_D0Q2S5A0_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A0 translation detector
+                        AXIS_D0Q2S5 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A0_ROT
+    AXIS_D0Q2S5A0_F translation detector
+                        AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A0_S translation detector
+                        AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5A1_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A1 translation detector
+                        AXIS_D0Q2S5 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A1_ROT
+    AXIS_D0Q2S5A1_F translation detector
+                        AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A1_S translation detector
+                        AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S6 translation detector
+                        AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
+                                   179.83473 AXIS_D0Q2S6_ROT
+    AXIS_D0Q2S6A0_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A0 translation detector
+                        AXIS_D0Q2S6 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A0_ROT
+    AXIS_D0Q2S6A0_F translation detector
+                        AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A0_S translation detector
+                        AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6A1_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A1 translation detector
+                        AXIS_D0Q2S6 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A1_ROT
+    AXIS_D0Q2S6A1_F translation detector
+                        AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A1_S translation detector
+                        AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S7 translation detector
+                        AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
+                                   180.092 AXIS_D0Q2S7_ROT
+    AXIS_D0Q2S7A0_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A0 translation detector
+                        AXIS_D0Q2S7 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S7A0_ROT
+    AXIS_D0Q2S7A0_F translation detector
+                        AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A0_S translation detector
+                        AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7A1_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A1 translation detector
+                        AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S7A1_ROT
+    AXIS_D0Q2S7A1_F translation detector
+                        AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A1_S translation detector
+                        AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3 translation detector
+                        AXIS_D0 . . . -41.247903125 -50.441634375 0.0
+                                   0.0 AXIS_D0Q3_ROT
+    AXIS_D0Q3S0_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S0 translation detector
+                        AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
+                                   180.12436 AXIS_D0Q3S0_ROT
+    AXIS_D0Q3S0A0_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A0 translation detector
+                        AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S0A0_ROT
+    AXIS_D0Q3S0A0_F translation detector
+                        AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A0_S translation detector
+                        AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S0A1_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A1 translation detector
+                        AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S0A1_ROT
+    AXIS_D0Q3S0A1_F translation detector
+                        AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A1_S translation detector
+                        AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S1 translation detector
+                        AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
+                                   180.00263 AXIS_D0Q3S1_ROT
+    AXIS_D0Q3S1A0_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A0 translation detector
+                        AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S1A0_ROT
+    AXIS_D0Q3S1A0_F translation detector
+                        AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A0_S translation detector
+                        AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1A1_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A1 translation detector
+                        AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S1A1_ROT
+    AXIS_D0Q3S1A1_F translation detector
+                        AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A1_S translation detector
+                        AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S2 translation detector
+                        AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
+                                   269.55191 AXIS_D0Q3S2_ROT
+    AXIS_D0Q3S2A0_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A0 translation detector
+                        AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S2A0_ROT
+    AXIS_D0Q3S2A0_F translation detector
+                        AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A0_S translation detector
+                        AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2A1_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A1 translation detector
+                        AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S2A1_ROT
+    AXIS_D0Q3S2A1_F translation detector
+                        AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A1_S translation detector
+                        AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S3 translation detector
+                        AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
+                                   269.74206 AXIS_D0Q3S3_ROT
+    AXIS_D0Q3S3A0_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A0 translation detector
+                        AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S3A0_ROT
+    AXIS_D0Q3S3A0_F translation detector
+                        AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A0_S translation detector
+                        AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3A1_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A1 translation detector
+                        AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S3A1_ROT
+    AXIS_D0Q3S3A1_F translation detector
+                        AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A1_S translation detector
+                        AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S4 translation detector
+                        AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
+                                   359.81971 AXIS_D0Q3S4_ROT
+    AXIS_D0Q3S4A0_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A0 translation detector
+                        AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S4A0_ROT
+    AXIS_D0Q3S4A0_F translation detector
+                        AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A0_S translation detector
+                        AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4A1_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A1 translation detector
+                        AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S4A1_ROT
+    AXIS_D0Q3S4A1_F translation detector
+                        AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A1_S translation detector
+                        AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S5 translation detector
+                        AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
+                                   359.99883 AXIS_D0Q3S5_ROT
+    AXIS_D0Q3S5A0_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A0 translation detector
+                        AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S5A0_ROT
+    AXIS_D0Q3S5A0_F translation detector
+                        AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A0_S translation detector
+                        AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5A1_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A1 translation detector
+                        AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S5A1_ROT
+    AXIS_D0Q3S5A1_F translation detector
+                        AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A1_S translation detector
+                        AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S6 translation detector
+                        AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
+                                   269.67299 AXIS_D0Q3S6_ROT
+    AXIS_D0Q3S6A0_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A0 translation detector
+                        AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S6A0_ROT
+    AXIS_D0Q3S6A0_F translation detector
+                        AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A0_S translation detector
+                        AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6A1_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A1 translation detector
+                        AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S6A1_ROT
+    AXIS_D0Q3S6A1_F translation detector
+                        AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A1_S translation detector
+                        AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S7 translation detector
+                        AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
+                                   269.67561 AXIS_D0Q3S7_ROT
+    AXIS_D0Q3S7A0_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A0 translation detector
+                        AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S7A0_ROT
+    AXIS_D0Q3S7A0_F translation detector
+                        AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A0_S translation detector
+                        AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7A1_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A1 translation detector
+                        AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S7A1_ROT
+    AXIS_D0Q3S7A1_F translation detector
+                        AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A1_S translation detector
+                        AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
+
+;
+;       Example 6.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
+    _axis.rotation to organize the positional dependencies.  The approach
+    in Example 5 is now preferred.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+
+    To do this, the first vector of importance is an initial placement axis
+    that moves from the origin along the Z axis a distance equal to the
+    detector distance.  This is the origin for the rest of the axes and is
+    called AXIS_D0_ORIGIN.
+
+    Each subsequent movement involves a frame shift.  This is done by using
+    two imgCIF axes: a rotation axis and a translation axis.  The rotation
+    axis is listed first, and includes no offset or angle.  The actual frame
+    shift is done by using a translation axis.  An offset is used first in
+    the parent's frame, and then an angle is listed to rotate around the
+    rotation axis.
+
+    Example, sensor five of quadrant 2.  First a rotation axis is listed:
+
+    AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    This defines a rotation axis around the z axis in the frame of quadrant 2.
+
+    Next a translation axis is listed:
+    AXIS_D0Q2S5 translation detector
+        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
+    Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
+    then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
+
+    And so forth.
+;
+
+    _nx_mapping.details
+;    _axis.id                  AXISID
+    _axis.type                AXISTYPE
+    _axis.equipment           AXISEQUIPMENT
+    _axis.equipment_component AXISEQUIPCOMP
+    _axis.depends_on          AXISDEPENDSON
+    _axis.rotation_axis       AXISROTAXIS
+    _axis.rotation            AXISROTATION
+    _axis.vector[1]           AXISV1
+    _axis.vector[2]           AXISV2
+    _axis.vector[3]           AXISV3
+    _axis.offset[1]           AXISO1
+    _axis.offset[2]           AXISO2
+    _axis.offset[3]           AXISO3
+    _axis.system              AXISSYSTEM
+
+    -->
+
+{     /entry:NXentry
+        /instrument:NXinstrument
+         /DETECTORELEMENTNAME:NXdetector
+for AXISEQUIPMENT=="detector"}
+{     /entry:NXentry
+        /sample:NXsample
+for AXISEQUIPMENT=="goniometer"}
+{     /entry:NXentry
+for AXISEQUIPMENT=="general"}
+          /transformations:NXtransformations
+            /AXISID=[]
+              @units="mm"  if AXISTYPE=="translation" 
+              or @units="degrees"  if AXISTYPE=="rotation"
+              @transformation_type="AXISTYPE"
+              @equipment_component="AXISEQUIPCOMP"
+              @depends_on="AXISDEPENDSON"
+              @rotation_axis="AXISROTAXIS"
+              @rotation=AXISROTATION
+              @rotation_units="degrees"
+              @offset=offsetxform([O1,O2,O3])
+              @offset_inits="mm"
+              @vector=coordxform([V1,V2,V3])
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         axis_group
+         diffrn_group
+
+save_
+
+save_axis.depends_on
+
+    _definition.id                '_axis.depends_on'
+    _description.text
+;            The value of _axis.depends_on specifies the next outermost
+              axis upon which this axis depends, unless
+              _axis.rotation_axis is specified, in which case,
+              _axis.rotation_axis is next outermost and
+              _axis.depends_on is second outermost.
+
+              This item is a pointer to _axis.id in the same category.
+;
+    _name.category_id             axis
+    _name.object_id               depends_on
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_axis.equipment
+
+    _definition.id                '_axis.equipment'
+    _description.text
+;            The value of  _axis.equipment specifies the type of
+              equipment using the axis:  'goniometer', 'detector',
+             'gravity', 'source' or 'general'.
+;
+    _name.category_id             axis
+    _name.object_id               equipment
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         goniometer            'equipment used to orient or position samples'
+         detector              'equipment used to detect reflections'
+         general               'equipment used for general purposes'
+         gravity               'axis specifying the downward direction'
+         source                'axis specifying the direction sample to source'
+
+    _enumeration.default          general
+
+save_
+
+save_axis.equipment_component
+
+    _definition.id                '_axis.equipment_component'
+    _description.text
+;            The value of  _axis.equipment_component specifies
+              an arbitrary identifier of a component of the equipment to which
+              the axis belongs, such as 'detector_arm' or 'detector_module'.
+
+;
+    _name.category_id             axis
+    _name.object_id               equipment_component
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+save_
+
+save_axis.id
+
+    _definition.id                '_axis.id'
+    _description.text
+;            The value of _axis.id must uniquely identify
+              each axis relevant to the experiment.  Note that multiple
+              pieces of equipment may share the same axis (e.g. a twotheta
+              arm), so the category key for AXIS also includes the
+              equipment.
+;
+    _name.category_id             axis
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_axis.offset[1]
+
+    _definition.id                '_axis.offset[1]'
+    _description.text
+;             The [1] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _name.category_id             axis
+    _name.object_id               'offset[1]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_axis.offset[2]
+
+    _definition.id                '_axis.offset[2]'
+    _description.text
+;             The [2] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _name.category_id             axis
+    _name.object_id               'offset[2]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_axis.offset[3]
+
+    _definition.id                '_axis.offset[3]'
+    _description.text
+;             The [3] element of the three-element vector used to specify
+               the offset to the base of a rotation or translation axis.
+
+               The vector is specified in millimetres.
+;
+    _name.category_id             axis
+    _name.object_id               'offset[3]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_axis.rotation
+
+    _definition.id                '_axis.rotation'
+    _description.text
+;            The value of _axis.rotation specifies
+              the fixed base rotation angle for _axis.rotation_axis
+              to which the value of any frame-by-frame setting, if any, should
+              be added.  Normally, only the fixed value would be given.
+;
+    _name.category_id             axis
+    _name.object_id               rotation
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_axis.rotation_axis
+
+    _definition.id                '_axis.rotation_axis'
+    _description.text
+;            The value of _axis.rotation_axis specifies
+              an optional additional dependency for this axis to be applied
+              after applying _axis.depends_on.
+
+              This item is a pointer to _axis.id in the same category.
+;
+    _name.category_id             axis
+    _name.object_id               rotation_axis
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+save_
+
+save_axis.system
+
+    _definition.id                '_axis.system'
+    _description.text
+;            The value of  _axis.system specifies the coordinate
+              system used to define the axis: 'laboratory', 'McStas', 'direct', 
+             'orthogonal', 'reciprocal' or 'abstract'.
+;
+    _name.category_id             axis
+    _name.object_id               system
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         laboratory
+;
+         the axis is referenced to the imgCIF standard laboratory Cartesian
+         coordinate system
+;
+         McStas
+;
+         the axis is referenced to the NeXus/HDF5 McStas laboratory Cartesian
+         coordinate system
+;
+         direct
+;
+         the axis is referenced to the direct lattice
+;
+         orthogonal
+;
+         the axis is referenced to the cell Cartesian orthogonal coordinates
+;
+         reciprocal
+;
+         the axis is referenced to the reciprocal lattice
+;
+         abstract
+;
+         the axis is referenced to an abstract Cartesian coordinate system
+;
+
+    _enumeration.default          laboratory
+
+save_
+
+save_axis.type
+
+    _definition.id                '_axis.type'
+    _description.text
+;            The value of _axis.type specifies the type of
+              axis:  'rotation' or 'translation' (or 'general' when
+              the type is not relevant, as for gravity).
+;
+    _name.category_id             axis
+    _name.object_id               type
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         rotation                 'right-handed axis of rotation'
+         translation              'translation in the direction of the axis'
+         general                  'axis for which the type is not relevant'
+
+    _enumeration.default          general
+
+save_
+
+save_axis.variant
+
+    _definition.id                '_axis.variant'
+    _description.text
+;            The value of _axis.variant gives the variant
+              to which the given AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_axis.vector[1]
+
+    _definition.id                '_axis.vector[1]'
+    _description.text
+;             The [1] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _name.category_id             axis
+    _name.object_id               'vector[1]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_axis.vector[2]
+
+    _definition.id                '_axis.vector[2]'
+    _description.text
+;             The [2] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _name.category_id             axis
+    _name.object_id               'vector[2]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_axis.vector[3]
+
+    _definition.id                '_axis.vector[3]'
+    _description.text
+;             The [3] element of the three-element vector used to specify
+               the direction of a rotation or translation axis.
+               The vector should be normalized to be a unit vector and
+               is dimensionless.
+;
+    _name.category_id             axis
+    _name.object_id               'vector[3]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.default          0.0
+    _units.code                   none
+    _ddl2_sub_category.id         vector
+
+save_
+
+save_DIFFRN
+
+    _definition.id                diffrn
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-16
+    _description.text
+;              Data items in the DIFFRN category record details about the
+               diffraction data and their measurement.
+
+               This is a stub category for the cif_img dicionary to
+               complete the tree for tags that are aliases for tags
+               in the various diffrn_... categories in the mmCIF/PDBx
+               dictionary
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn
+    _name.ddl2_mandatory          no
+    _category_key.name            '_diffrn.id'
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn.id
+
+    _definition.id                '_diffrn.id'
+    _alias.definition_id          '_diffrn.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           5.385
+    _alias.dictionary_uri         mmcif_pdbx.dic
+    _description.text
+;              This data item uniquely identifies a set of diffraction
+               data.
+;
+    _name.category_id             diffrn
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_DIFFRN_DATA_FRAME
+
+    _definition.id                diffrn_data_frame
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;            Data items in the DIFFRN_DATA_FRAME category record
+              the details about each frame of data.
+
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_data_frame
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_data_frame.id'
+         '_diffrn_data_frame.detector_element_id'
+         '_diffrn_data_frame.variant'
+
+    _description_example.case
+;        loop_
+        _diffrn_data_frame.id
+        _diffrn_data_frame.detector_element_id
+        _diffrn_data_frame.array_id
+        _diffrn_data_frame.binary_id
+        frame_1   d1_ccd_1  array_1  1
+        frame_1   d1_ccd_2  array_1  2
+        frame_1   d1_ccd_3  array_1  3
+        frame_1   d1_ccd_4  array_1  4
+;
+    _description_example.detail
+;     Example 1. a frame containing data from four frame elements.
+
+                       Each frame element has a common array configuration
+                       'array_1' described in ARRAY_STRUCTURE and related
+                       categories.  The data for each detector element are
+                       stored in four groups of binary data in the
+                       ARRAY_DATA category, linked by the array_id and
+                       binary_id.
+;
+    _nx_mapping.details
+;    _diffrn_data_frame.array_id ARRAYID
+    _diffrn_data_frame.array_section_id SECTIONID
+    _diffrn_data_frame.binary_id BINID
+    _diffrn_data_frame.center_fast CENF
+    _diffrn_data_frame.center_slow CENS
+    _diffrn_data_frame.center_units UNITS
+    _diffrn_data_frame.detector_element_id ELEMENTID
+    _diffrn_data_frame.id FRAMEID
+    _diffrn_data_frame.details DETAILS
+
+    -->
+
+    /entry:NXentry
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_data_frame__section_id=[SECTIONIDARRAY]
+          /CBF_diffrn_data_frame__binary_id=[BINARYIDARRAY]
+          /CBF_diffrn_data_frame__center_fast_slow=[CENTERARRAY]
+            @units="UNITS"
+          /CBF_diffrn_data_frame__details=["DETAILSARRAY"]
+
+    inserts either ARRAYID (if SECTIONID is not specified or SECTIONID
+    into the element of SECTIONIDARRY for this frame and for this detector
+    element (see below);
+
+    inserts BINID
+    into the element of BINARYIDARRAY for this frame and for this detector
+    element (see below);
+
+    inserts CENF
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the fast centre (see below);
+
+    inserts CENS
+    into the element of CENTERARRAY for this frame, for this detector element
+    and for the slow centre (see below);
+
+    only one CENTERARRY unit is provided.  If there is variation, the values in
+    CENTERARRAY should be rescaled to uniform units.
+
+    _diffrn_data_frame.detector_element_id ELEMENTID -->
+    ELEMENTID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the fast index;
+
+    FRAMEID used to index into the arrays of this category by the ordinal of
+    the matching ELEMENTID in DIFFRN_DETECTOR_ELEMENT__id for the slow index
+    by matching FRAMEID against _diffrn_scan_frame.frame_id and using
+    _diffrn_scan_frame.frame_number from the same row.
+
+    inserts DETAILS
+    into the element of DETAILSARRAY for this frame and for this detector
+    element (see below); 
+
+    The arrays created in the mapping have a slow index of the number of frames
+    and a fast index of the number of detector elements.  There is a middle
+    index for CENTERARRAY in the order fast and then slow.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         diffrn_group
+
+save_
+
+save_diffrn_data_frame.array_id
+
+    _definition.id                '_diffrn_data_frame.array_id'
+    _alias.definition_id          '_diffrn_frame_data.array_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;            This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               array_id
+    _name.linked_item_id          '_array_structure.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          1
+
+save_
+
+save_diffrn_data_frame.array_section_id
+
+    _definition.id                '_diffrn_data_frame.array_section_id'
+    _description.text
+;            This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               array_section_id
+    _name.linked_item_id          '_array_structure_list_section.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_data_frame.binary_id
+
+    _definition.id                '_diffrn_data_frame.binary_id'
+    _alias.definition_id          '_diffrn_frame_data.binary_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;            This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               binary_id
+    _name.linked_item_id          '_array_data.binary_id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _enumeration.default          1
+    _units.code                   none
+
+save_
+
+save_diffrn_data_frame.center_derived
+
+    _definition.id                '_diffrn_data_frame.center_derived'
+    _description.text
+;             The value of _diffrn_data_frame.center_derived
+              is assumed to be 'yes', i.e. that values of
+              _diffrn_data_frame.center_fast and
+              _diffrn_data_frame.center_slow 
+              are derived from the axis settings rather than measured.               
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               center_derived
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+    _enumeration.default          yes
+
+save_
+
+save_diffrn_data_frame.center_fast
+
+    _definition.id                '_diffrn_data_frame.center_fast'
+    _description.text
+;            The value of _diffrn_data_frame.center_fast is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               center_fast
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_data_frame.center_slow
+
+    _definition.id                '_diffrn_data_frame.center_slow'
+    _description.text
+;             The value of _diffrn_data_frame.center_slow is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_data_frame.center_units along the slow
+              axis of the detector from the centre of the first pixel to
+              the point at which the Z axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement the current settings of
+              the detector positioner for the given frame are used.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               center_slow
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_data_frame.center_units
+
+    _definition.id                '_diffrn_data_frame.center_units'
+    _description.text
+;             The value of _diffrn_data_frame.center_units
+              specifies the units in which the values of 
+              _diffrn_data_frame.center_fast and
+              _diffrn_data_frame.center_slow
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               center_units
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         mm                       'millimetres'
+         pixels                   'detector pixels'
+         bins                     'detector bins'
+
+save_
+
+save_diffrn_data_frame.details
+
+    _definition.id                '_diffrn_data_frame.details'
+    _alias.definition_id          '_diffrn_frame_data.details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.4
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             The value of _diffrn_data_frame.details should give a
+              description of special aspects of each frame of data.
+
+              This is an appropriate location in which to record
+              information from vendor headers as presented in those
+              headers, but it should never be used as a substitute
+              for providing the fully parsed information within
+              the appropriate imgCIF/CBF categories.
+
+              Normally, when a conversion from a miniCBF has been done
+              the data from _array_data.header_convention
+              should be transferred to this data item and 
+              _array_data.header_convention
+              should be removed.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+;
+    HEADER_BYTES = 512;
+    DIM = 2;
+    BYTE_ORDER = big_endian;
+    TYPE = unsigned_short;
+    SIZE1 = 3072;
+    SIZE2 = 3072;
+    PIXEL_SIZE = 0.102588;
+    BIN = 2x2;
+    DETECTOR_SN = 901;
+    TIME = 29.945155;
+    DISTANCE = 200.000000;
+    PHI = 85.000000;
+    OSC_START = 85.000000;
+    OSC_RANGE = 1.000000;
+    WAVELENGTH = 0.979381;
+    BEAM_CENTER_X = 157.500000;
+    BEAM_CENTER_Y = 157.500000;
+    PIXEL SIZE = 0.102588;
+    OSCILLATION RANGE = 1;
+    EXPOSURE TIME = 29.9452;
+    TWO THETA = 0;
+    BEAM CENTRE = 157.5 157.5;
+;
+    _description_example.detail
+;              Example of header information extracted from an ADSC Quantum
+               315 detector header by CBFlib_0.7.6.  Image provided by Chris
+               Nielsen of ADSC from a data collection at SSRL beamline 1-5.
+;
+
+save_
+
+save_diffrn_data_frame.detector_element_id
+
+    _definition.id                '_diffrn_data_frame.detector_element_id'
+    _alias.definition_id          '_diffrn_frame_data.detector_element_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               detector_element_id
+    _name.linked_item_id          '_diffrn_detector_element.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_data_frame.diffrn_id
+
+    _definition.id                '_diffrn_data_frame.diffrn_id'
+    _description.text
+;             This item is a pointer to '_diffrn.id'
+              in the DIFFRN category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_data_frame.id
+
+    _definition.id                '_diffrn_data_frame.id'
+    _alias.definition_id          '_diffrn_frame_data.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             The value of _diffrn_data_frame.id must uniquely identify
+              each complete frame of data.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_data_frame.variant
+
+    _definition.id                '_diffrn_data_frame.variant'
+    _description.text
+;             The value of _diffrn_data_frame.variant gives the variant
+              to which the given DIFFRN_DATA_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR
+
+    _definition.id                diffrn_detector
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-16
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR category describe the
+     detector used to measure the scattered radiation, including
+     any analyser and post-sample collimation.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_detector
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_detector.diffrn_id'
+         '_diffrn_detector.id'
+         '_diffrn_detector.variant'
+
+    _description_example.case
+;    _diffrn_detector.diffrn_id             'd1'
+    _diffrn_detector.detector              'multiwire'
+    _diffrn_detector.type                  'Siemens'
+;
+    _description_example.detail
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+    _nx_mapping.details
+;    _diffrn_detector.diffrn_id DIFFRNID 
+    _diffrn_detector.id DETECTORNAME 
+    _diffrn_detector.details DETAILS
+    _diffrn_detector.detector DETECTOR
+    _diffrn_detector.dtime DTIME
+    _diffrn_detector.gain_setting GAINSETTING
+    _diffrn_detector.number_of_axes NAXES
+    _diffrn_detector.type DETTYPE
+
+    --> 
+
+      /entry:NXentry
+        /CBF_scan_id="SCANID"
+        /CBF_diffrn_id="DIFFRNID"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /details="DETAILS"
+              /type="DETECTOR"
+              /deadtime=DTIME
+              /number_of_axes=NAXES
+              /description="DETTYPE"
+              /gain_setting="GAINSETTING"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_detector.details
+
+    _definition.id                '_diffrn_detector.details'
+    _alias.definition_id          '_diffrn_detector_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             A description of special aspects of the radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case     'slow mode'
+
+save_
+
+save_diffrn_detector.detector
+
+    _definition.id                '_diffrn_detector.detector'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_radiation_detector'        .        1.0        cifdic.c91
+         '_diffrn_detector'                  .        2.0        cif_core.dic
+
+    _description.text
+;             The general class of the radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               detector
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'photographic film'
+         'scintillation counter'
+         'CCD plate'
+         'BF~3~ counter'
+
+save_
+
+save_diffrn_detector.diffrn_id
+
+    _definition.id                '_diffrn_detector.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in the DIFFRN
+              category.
+
+              The value of _diffrn.id uniquely defines a set of
+              diffraction data.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector.dtime
+
+    _definition.id                '_diffrn_detector.dtime'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_radiation_detector_dtime'      .      1.0      cifdic.c91
+         '_diffrn_detector_dtime'                .      2.0      cif_core.dic
+
+    _description.text
+;             The deadtime in microseconds of the detector(s) used to
+              measure the diffraction intensities.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               dtime
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              microseconds
+    _enumeration.range            0.0:
+    _units.code                   microseconds
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_detector.gain_setting
+
+    _definition.id                '_diffrn_detector.gain_setting'
+    _description.text
+;             The gain setting for detector.   This is a text string usually
+              reflecting a detector setting that may have a simple or very
+              complex relationship with the value of
+              _array_intensities.gain
+              and should not be used directly for computations without
+              further information.
+
+              This tag is provided for completeness in recording the settings
+              of an experiment using a detector with a panel-switch, jumper
+              or control command that allows a choice of gain settings.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               gain_setting
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_diffrn_detector.id
+
+    _definition.id                '_diffrn_detector.id'
+    _description.text
+;             The value of _diffrn_detector.id must uniquely identify
+              each detector used to collect each diffraction data set.
+
+              If the value of _diffrn_detector.id is not given, it is
+              implicitly equal to the value of
+              _diffrn_detector.diffrn_id.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector.layer_thickness
+
+    _definition.id                '_diffrn_detector.layer_thickness'
+    _description.text
+;             The thickness in mm of the sensing layer of the detector
+              for use in angular corrections.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               layer_thickness
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_detector.number_of_axes
+
+    _definition.id                '_diffrn_detector.number_of_axes'
+    _description.text
+;             The value of _diffrn_detector.number_of_axes gives the
+              number of axes of the positioner for the detector identified
+              by _diffrn_detector.id.
+
+              The word 'positioner' is a general term used in
+              instrumentation design for devices that are used to change
+              the positions of portions of apparatus by linear
+              translation, rotation or combinations of such motions.
+
+              Axes which are used to provide a coordinate system for the
+              face of an area detector should not be counted for this
+              data item.
+
+              The description of each axis should be provided by entries
+              in DIFFRN_DETECTOR_AXIS.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               number_of_axes
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
+
+save_
+
+save_diffrn_detector.type
+
+    _definition.id                '_diffrn_detector.type'
+    _alias.definition_id          '_diffrn_detector_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The make, model or name of the detector device used.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               type
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_diffrn_detector.variant
+
+    _definition.id                '_diffrn_detector.variant'
+    _description.text
+;             The value of _diffrn_detector.variant gives the variant
+              to which the given DIFFRN_DETECTOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR_AXIS
+
+    _definition.id                diffrn_detector_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR_AXIS category associate
+     axes with detectors.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_detector_axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_detector_axis.detector_id'
+         '_diffrn_detector_axis.axis_id'
+         '_diffrn_detector_axis.variant'
+
+    _nx_mapping.details
+;    _diffrn_detector_axis.axis_id AXISID --> 
+    _diffrn_detector_axis.detector_id DETECTORNAME -->
+        /instrument:NXinstrument
+         /DETECTORNAME:NXdetector_group
+         /DETECTORELEMENTNAME:NXdetector
+            /transformations:NXtransformations
+              /AXISID=[]
+
+This information normally will duplicate information obtained from 
+the ARRAY_STRUCTURE_LIST_AXIS.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_detector_axis.axis_id
+
+    _definition.id                '_diffrn_detector_axis.axis_id'
+    _description.text
+;             This data item is a pointer to _axis.id in
+               the AXIS category.
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               axis_id
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_axis.detector_id
+
+    _definition.id                '_diffrn_detector_axis.detector_id'
+    _alias.definition_id          '_diffrn_detector_axis.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
+
+              This item was previously named _diffrn_detector_axis.id
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               detector_id
+    _name.linked_item_id          '_diffrn_detector.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_axis.diffrn_id
+
+    _definition.id                '_diffrn_detector_axis.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_axis.id
+
+    _definition.id                '_diffrn_detector_axis.id'
+    _description.text
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               id
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_axis.variant
+
+    _definition.id                '_diffrn_detector_axis.variant'
+    _description.text
+;            The value of _diffrn_detector_axis.variant gives the variant
+             to which the given DIFFRN_DETECTOR_AXIS row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR_ELEMENT
+
+    _definition.id                diffrn_detector_element
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR_ELEMENT category record
+     the details about spatial layout and other characteristics
+     of each element of a detector which may have multiple elements.
+
+     In most cases, giving more detailed information
+     in ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS
+     is preferable to simply providing the centre of the
+     detector element.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_detector_element
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_detector_element.id'
+         '_diffrn_detector_element.detector_id'
+         '_diffrn_detector_element.variant'
+
+    _description_example.case
+;        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        d1     d1_ccd_1  201.5 201.5  mm
+        d1     d1_ccd_2  -1.8  201.5  mm
+        d1     d1_ccd_3  201.6  -1.4  mm
+        d1     d1_ccd_4  -1.7   -1.5  mm
+;
+    _description_example.detail
+;      Example 1. Detector d1 is composed of four CCD detector elements,
+        each 200 mm by 200 mm, arranged in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+        Note that the beam centre is slightly displaced from each of the
+        detector elements, just beyond the lower right corner of 1,
+        the lower left corner of 2, the upper right corner of 3 and
+        the upper left corner of 4.  For each element, the detector
+        face coordinate system is assumed to have the fast axis
+        running from left to right and the slow axis running from
+        top to bottom with the origin at the top left corner.
+;
+    _nx_mapping.details
+;    _diffrn_detector_element.id ELEMENTID
+    _diffrn_detector_element.detector_id DETECTORNAME
+    _diffrn_detector_element.reference_center_fast RCF
+    _diffrn_detector_element.reference_center_slow RCS
+    _diffrn_detector_element.reference_center_units UNITS
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /beam_center_x=[RCS]  (converted from UNITS as needed)
+            @units=mm
+          /beam_center_y=[RCF]  (converted from UNITS as needed)
+            @units=mm
+          /CBF_diffrn_detector_element__id="ELEMENTID1:ELEMENTID2:..."
+          /CBF_diffrn_detector_element__reference_center_fast=[RCF1,RCF2,...]
+          /CBF_diffrn_detector_element__reference_center_slow=[RCS1,RCS2,...]
+          /CBF_diffrn_detector_element__id="UNITS1:UNITS2:..."
+     inserts ELEMENTID into the colon-separated list of element IDs
+     inserts RCF into the array of reference centres
+     inserts RCS into the array of reference centres
+     inserts ELEMENTID into the colon-separated list of units
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         diffrn_group
+
+save_
+
+save_diffrn_detector_element.center[1]
+
+    _definition.id                '_diffrn_detector_element.center[1]'
+    _description.text
+;             The value of _diffrn_detector_element.center[1] is the X
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated.  The data item
+              _diffrn_data_frame.center_fast
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               'center[1]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+    _ddl2_item_related.related_name '_diffrn_data_frame.center_fast'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_detector_element.center[2]
+
+    _definition.id                '_diffrn_detector_element.center[2]'
+    _description.text
+;             The value of _diffrn_detector_element.center[2] is the Y
+              component of the distortion-corrected beam centre in
+              millimetres from the (0, 0) (lower-left) corner of the
+              detector element viewed from the sample side.
+
+              The X and Y axes are the laboratory coordinate system
+              coordinates defined in the AXIS category measured
+              when all positioning axes for the detector are at their zero
+              settings.  If the resulting X or Y axis is then orthogonal to the
+              detector, the Z axis is used instead of the orthogonal axis.
+
+              Because of ambiguity about the setting used to determine this
+              centre, use of this data item is deprecated. The data item
+              _diffrn_data_frame.center_slow
+              which is referenced to the detector coordinate system and not
+              directly to the laboratory coordinate system should be used
+              instead.
+
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               'center[2]'
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+    _ddl2_sub_category.id         vector
+    _ddl2_item_related.related_name '_diffrn_data_frame.center_slow'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_detector_element.detector_id
+
+    _definition.id                '_diffrn_detector_element.detector_id'
+    _description.text
+;             This item is a pointer to _diffrn_detector.id
+              in the DIFFRN_DETECTOR category.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               detector_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_element.diffrn_id
+
+    _definition.id                '_diffrn_detector_element.diffrn_id'
+    _description.text
+;             This item is a pointer to _diffrn.id
+              in the DIFFRN category.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_element.id
+
+    _definition.id                '_diffrn_detector_element.id'
+    _description.text
+;            The value of _diffrn_detector_element.id must uniquely
+             identify each element of a detector.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_detector_element.reference_center_fast
+
+    _definition.id
+        '_diffrn_detector_element.reference_center_fast'
+    _description.text
+;             The value of _diffrn_detector_element.reference_center_fast is 
+              the fast index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units along the fast
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the 
+              beam) intersects the face of the detector, if in fact it does.   
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than 
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble 
+              of settings.
+
+              It is important to note that for measurements in mm,
+              the sense of the axis is used, rather than the sign of the 
+              pixel-to-pixel increments.
+
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               reference_center_fast
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_detector_element.reference_center_slow
+
+    _definition.id
+        '_diffrn_detector_element.reference_center_slow'
+    _description.text
+;             The value of _diffrn_detector_element.reference_center_slow is
+              the slow index axis beam centre position relative to the detector
+              element face in the units specified in the data item
+              _diffrn_detector_element.reference_center_units along the slow
+              axis of the detector from the centre of the first pixel to 
+              the point at which the Z-axis (which should be collinear with the
+              beam) intersects the face of the detector, if in fact it does.
+              At the time of the measurement all settings of the detector
+              positioner should be at their reference settings.  If more than
+              one reference setting has been used the value given should be 
+              representative of the beam centre as determined from the ensemble
+              of settings.
+
+              It is important to note that the sense of the axis is used,
+              rather than the sign of the pixel-to-pixel increments.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               reference_center_slow
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_detector_element.reference_center_units
+
+    _definition.id
+        '_diffrn_detector_element.reference_center_units'
+    _description.text
+;             The value of _diffrn_detector_element.reference_center_units
+              specifies the units in which the values of 
+              _diffrn_detector_element.reference_center_fast and
+              _diffrn_detector_element.reference_center_slow
+              are presented.  The default is 'mm' for millimetres.  The 
+              alternatives are 'pixels' and 'bins'.  In all cases the
+              centre distances are measured from the centre of the
+              first pixel, i.e. in a 2x2 binning, the measuring origin
+              is offset from the centres of the bins by one half pixel
+              towards the first pixel.
+
+              If 'bins' is specified, the data in
+                  _array_intensities.pixel_fast_bin_size,
+                  _array_intensities.pixel_slow_bin_size, and
+                  _array_intensities.pixel_binning_method
+              are used to define the binning scheme.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               reference_center_units
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         mm                       'millimetres'
+         pixels                   'detector pixels'
+         bins                     'detector bins'
+
+save_
+
+save_diffrn_detector_element.variant
+
+    _definition.id                '_diffrn_detector_element.variant'
+    _description.text
+;             The value of _diffrn_detector_element.variant gives the variant
+              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+               VARIANT category.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_FRAME_DATA
+
+    _definition.id                diffrn_frame_data
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_FRAME_DATA category record
+     the details about each frame of data.
+
+     The items in this category are now in the
+     DIFFRN_DATA_FRAME category.
+
+     The items in the DIFFRN_FRAME_DATA category
+     are now deprecated.  The items from this category
+     are provided as aliases in the 1.0 dictionary
+     or, in the case of _diffrn_frame_data.details,
+     in the 1.4 dictionary.  THESE ITEMS SHOULD NOT
+     BE USED FOR NEW WORK.
+
+     The items from the old category are provided
+     in this dictionary for completeness
+     but should not be used or cited.  To avoid
+     confusion, the example has been removed
+     and the redundant parent-child links to other
+     categories have been removed.
+
+     All _item.mandatory_code values have been changed to 'no'.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_frame_data
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_frame_data.id'
+         '_diffrn_frame_data.detector_element_id'
+
+    _description_example.case
+;
+    # EXAMPLE REMOVED #
+;
+    _description_example.detail
+;
+    THE DIFFRN_FRAME_DATA category is deprecated and should not be used.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+
+save_
+
+save_diffrn_frame_data.array_id
+
+    _definition.id                '_diffrn_frame_data.array_id'
+    _description.text
+;             This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_frame_data
+    _name.object_id               array_id
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.array_id'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_frame_data.binary_id
+
+    _definition.id                '_diffrn_frame_data.binary_id'
+    _description.text
+;             This item is a pointer to _array_data.binary_id in the
+              ARRAY_STRUCTURE category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_frame_data
+    _name.object_id               binary_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _units.code                   none
+    _ddl2_item_related.related_name '_diffrn_data_frame.binary_id'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_frame_data.details
+
+    _definition.id                '_diffrn_frame_data.details'
+    _description.text
+;             The value of _diffrn_frame_data.details should give a
+              description of special aspects of each frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_frame_data
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _ddl2_item_related.related_name '_diffrn_data_frame.details'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_frame_data.detector_element_id
+
+    _definition.id                '_diffrn_frame_data.detector_element_id'
+    _description.text
+;             This item is a pointer to _diffrn_detector_element.id
+              in the DIFFRN_DETECTOR_ELEMENT category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_frame_data
+    _name.object_id               detector_element_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.detector_element_id'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_frame_data.id
+
+    _definition.id                '_diffrn_frame_data.id'
+    _description.text
+;             The value of _diffrn_frame_data.id must uniquely identify
+              each complete frame of data.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_frame_data
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_data_frame.id'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_DIFFRN_MEASUREMENT
+
+    _definition.id                diffrn_measurement
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-16
+    _description.text
+;
+    Data items in the DIFFRN_MEASUREMENT category record details
+     about the device used to orient and/or position the crystal
+     during data measurement and the manner in which the
+     diffraction data were measured.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_measurement
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_measurement.device'
+         '_diffrn_measurement.diffrn_id'
+         '_diffrn_measurement.id'
+         '_diffrn_measurement.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+    _diffrn_measurement.diffrn_id          'd1'
+    _diffrn_measurement.device             '3-circle camera'
+    _diffrn_measurement.device_type        'Supper model X'
+    _diffrn_measurement.device_details     'none'
+    _diffrn_measurement.method             'omega scan'
+    _diffrn_measurement.details
+    ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm, 
+      detector angle 22.5 degrees
+    ;
+;
+;    Example 1. based on PDB entry 5HVP and laboratory records for the
+                 structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_measurement.diffrn_id       's1'
+    _diffrn_measurement.device_type     'Philips PW1100/20 diffractometer'
+    _diffrn_measurement.method          'theta/2theta (\q/2\q)'
+;
+;     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                  [Acta Cryst. (1991), C47, 2276-2277].
+;
+
+    _nx_mapping.details
+;    _diffrn_measurement.diffrn_id DIFFRNID
+    _diffrn_measurement.details DETAILS
+    _diffrn_measurement.device DEVICE
+    _diffrn_measurement.device_details DEVDETAILS
+    _diffrn_measurement.device_type DEVTYPE
+    _diffrn_measurement.id GONIOMETER
+    _diffrn_measurement.method METHOD
+    _diffrn_measurement.number_of_axes NUMBER
+    _diffrn_measurement.sample_detector_distance DIST
+    _diffrn_measurement.sample_detector_distance_derived DISTDERIVED
+    _diffrn_measurement.sample_detector_voffset VOFST
+    _diffrn_measurement.specimen_support SPECSPRT
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /instrument:NXinstrument
+      /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+        /details="DETAILS"
+        /local_name="DEVICE"
+        /description="DEVDETAILS"
+        /type="DEVTYPE"
+        /CBF_diffrn_measurement__method="METHOD"
+          /number_of_axes=NUMBER
+        /CBF_diffrn_measurement__specimen_support="SPECSPRT"
+      /CBF_diffrn_detector__DETECTORNAME:NXdetector
+        /distance=DIST
+          @units="mm"
+        /distance_derived=DISTDERIVED
+        /CBF_diffrn_measurement__sample_detector_voffset=VOFST
+          @units="mm"    
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_measurement.details
+
+    _definition.id                '_diffrn_measurement.details'
+    _alias.definition_id          '_diffrn_measurement_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             A description of special aspects of the intensity
+              measurement.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+;                                 440 frames, 0.20 degrees, 150 sec, detector
+                                  distance 12 cm, detector angle 22.5 degrees
+;
+
+save_
+
+save_diffrn_measurement.device
+
+    _definition.id                '_diffrn_measurement.device'
+    _alias.definition_id          '_diffrn_measurement_device'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The general class of goniometer or device used to support
+              and orient the specimen.
+
+              If the value of _diffrn_measurement.device is not given,
+              it is implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
+
+              Either _diffrn_measurement.device or
+              _diffrn_measurement.id may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id is used to provide
+              a unique link.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         '3-circle camera'
+         '4-circle camera'
+         'kappa-geometry camera'
+         'oscillation camera'
+         'precession camera'
+
+save_
+
+save_diffrn_measurement.device_details
+
+    _definition.id                '_diffrn_measurement.device_details'
+    _alias.definition_id          '_diffrn_measurement_device_details'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             A description of special aspects of the device used to
+              measure the diffraction intensities.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device_details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+;                                 commercial goniometer modified locally to
+                                  allow for 90\% \t arc
+;
+
+save_
+
+save_diffrn_measurement.device_type
+
+    _definition.id                '_diffrn_measurement.device_type'
+    _alias.definition_id          '_diffrn_measurement_device_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The make, model or name of the measurement device
+              (goniometer) used.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device_type
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'Supper model q'
+         'Huber model r'
+         'Enraf-Nonius model s'
+         'home-made'
+
+save_
+
+save_diffrn_measurement.diffrn_id
+
+    _definition.id                '_diffrn_measurement.diffrn_id'
+    _description.text
+;             This data item is a pointer to _diffrn.id in the DIFFRN
+              category.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_measurement.id
+
+    _definition.id                '_diffrn_measurement.id'
+    _description.text
+;             The value of _diffrn_measurement.id must uniquely identify
+              the set of mechanical characteristics of the device used to
+              orient and/or position the sample used during the collection
+              of each diffraction data set.
+
+              If the value of _diffrn_measurement.id is not given, it is
+              implicitly equal to the value of
+              _diffrn_measurement.diffrn_id.
+
+              Either _diffrn_measurement.device or
+              _diffrn_measurement.id may be used to link to other
+              categories.  If the experimental setup admits multiple
+              devices, then _diffrn_measurement.id is used to provide
+              a unique link.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_measurement.method
+
+    _definition.id                '_diffrn_measurement.method'
+    _alias.definition_id          '_diffrn_measurement_method'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             Method used to measure intensities.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               method
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+        'profile data from theta/2theta (\q/2\q) scans'
+
+save_
+
+save_diffrn_measurement.number_of_axes
+
+    _definition.id                '_diffrn_measurement.number_of_axes'
+    _description.text
+;             The value of _diffrn_measurement.number_of_axes gives the
+              number of axes of the positioner for the goniometer or
+              other sample orientation or positioning device identified
+              by _diffrn_measurement.id.
+
+              The description of the axes should be provided by entries in
+              DIFFRN_MEASUREMENT_AXIS.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               number_of_axes
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
+
+save_
+
+save_diffrn_measurement.sample_detector_distance
+
+    _definition.id                '_diffrn_measurement.sample_detector_distance'
+    _description.text
+;             The value of _diffrn_measurement.sample_detector_distance gives
+              the unsigned distance in millimetres from the sample to the 
+              detector along the beam.  Normally this distance is derived
+              from the axis settings.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               sample_detector_distance
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _units.code                   millimetres
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_measurement.sample_detector_distance_derived
+
+    _definition.id
+        '_diffrn_measurement.sample_detector_distance_derived'
+    _description.text
+;             The value of _diffrn_measurement.sample_detector_distance_derived
+              is assumed to be 'yes', i.e. that value of 
+              _diffrn_measurement.sample_detector_distance
+              is derived from the axis settings rather than measured.               
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               sample_detector_distance_derived
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _type.ddl2_code               ucode
+    _enumeration.default          yes
+
+save_
+
+save_diffrn_measurement.sample_detector_voffset
+
+    _definition.id                '_diffrn_measurement.sample_detector_voffset'
+    _description.text
+;             The value of _diffrn_measurement.sample_detector_voffset gives
+              the signed distance in millimetres in the vertical
+              direction (positive for up) from the centre of
+              the beam to the centre of the detector. 
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               sample_detector_voffset
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.range            :
+    _units.code                   millimetres
+    _ddl2_enumeration_range.minimum .
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_measurement.specimen_support
+
+    _definition.id                '_diffrn_measurement.specimen_support'
+    _alias.definition_id          '_diffrn_measurement_specimen_support'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The physical device used to support the crystal during data
+              collection.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               specimen_support
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'glass capillary'
+         'quartz capillary'
+         'fiber'
+         'metal loop'
+
+save_
+
+save_diffrn_measurement.variant
+
+    _definition.id                '_diffrn_measurement.variant'
+    _description.text
+;            The value of _diffrn_measurement.variant gives the variant
+             to which the given DIFFRN_MEASUREMENT row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_MEASUREMENT_AXIS
+
+    _definition.id                diffrn_measurement_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_MEASUREMENT_AXIS category associate
+     axes with goniometers.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_measurement_axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_measurement_axis.measurement_device'
+         '_diffrn_measurement_axis.measurement_id'
+         '_diffrn_measurement_axis.axis_id'
+         '_diffrn_measurement_axis.variant'
+
+    _nx_mapping.details
+;    _diffrn_measurement_axis.axis_id AXISID
+    _diffrn_measurement_axis.measurement_device DEVICE
+    _diffrn_measurement_axis.measurement_id GONIOMETER
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID
+      /CBF_diffrn_id="DIFFRNID"
+      /sample:NXsample
+        /transformations:NXtransformations      
+          /AXISID=[]      
+      /instrument:NXinstrument
+        /CBF_diffrn_measurement__GONIOMETER:NXgoniometer
+          /CBF_diffrn_measurement__device="DEVICE"
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_measurement_axis.axis_id
+
+    _definition.id                '_diffrn_measurement_axis.axis_id'
+    _description.text
+;             This data item is a pointer to _axis.id in
+              the AXIS category.
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               axis_id
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_measurement_axis.diffrn_id
+
+    _definition.id                '_diffrn_measurement_axis.diffrn_id'
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_measurement_axis.id
+
+    _definition.id                '_diffrn_measurement_axis.id'
+    _description.text
+;             This data item is a pointer to _diffrn_measurement.id in
+              the DIFFRN_MEASUREMENT category.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               id
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _ddl2_item_related.related_name '_diffrn_measurement_axis.measurement_id'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_measurement_axis.measurement_device
+
+    _definition.id                '_diffrn_measurement_axis.measurement_device'
+    _description.text
+;             This data item is a pointer to _diffrn_measurement.device
+              in the DIFFRN_MEASUREMENT category.
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               measurement_device
+    _name.linked_item_id          '_diffrn_measurement.device'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_diffrn_measurement_axis.measurement_id
+
+    _definition.id                '_diffrn_measurement_axis.measurement_id'
+    _alias.definition_id          '_diffrn_measurement_axis.id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.0
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             This data item is a pointer to _diffrn_measurement.id in
+              the DIFFRN_MEASUREMENT category.
+
+              This item was previously named _diffrn_measurement_axis.id,
+              which is now a deprecated name.  The old name is
+              provided as an alias but should not be used for new work.
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               measurement_id
+    _name.linked_item_id          '_diffrn_measurement.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_measurement_axis.variant
+
+    _definition.id                '_diffrn_measurement_axis.variant'
+    _description.text
+;             The value of _diffrn_measurement_axis.variant gives the variant
+              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_RADIATION
+
+    _definition.id                diffrn_radiation
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-16
+    _description.text
+;             Data items in the DIFFRN_RADIATION category describe
+              the radiation used for measuring diffraction intensities,
+              its collimation and monochromatization before the sample.
+
+              Post-sample treatment of the beam is described by data
+              items in the DIFFRN_DETECTOR category.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_radiation
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_radiation.diffrn_id'
+         '_diffrn_radiation.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+    _diffrn_radiation.diffrn_id            'set1'
+
+    _diffrn_radiation.collimation          '0.3 mm double pinhole'
+    _diffrn_radiation.monochromator        'graphite'
+    _diffrn_radiation.type                 'Cu K\a'
+    _diffrn_radiation.wavelength_id         1
+;
+;   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_radiation.wavelength_id    1
+    _diffrn_radiation.type             'Cu K\a'
+    _diffrn_radiation.monochromator    'graphite'
+;
+;    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+
+    _nx_mapping.details
+;    _diffrn_radiation.collimation    COLLIMATION
+    _diffrn_radiation.diffrn_id      DIFFRNID
+    _diffrn_radiation.div_x_source   DIVX
+    _diffrn_radiation.div_y_source   DIVY
+    _diffrn_radiation.div_x_y_source DIVXY
+    _diffrn_radiation.filter_edge'   ABSEDGE
+    _diffrn_radiation.inhomogeneity  HWIDTH
+    _diffrn_radiation.monochromator  MONOCHROMATOR
+    _diffrn_radiation.polarisn_norm  POLNANG
+    _diffrn_radiation.polarisn_ratio POLRAT
+    _diffrn_radiation.polarizn_source_norm   POLSNANG
+    _diffrn_radiation.polarizn_source_ratio  POLSRAT
+    _diffrn_radiation.polarizn_Stokes_I  SVECI
+    _diffrn_radiation.polarizn_Stokes_Q  SVECQ
+    _diffrn_radiation.polarizn_Stokes_U  SVECU
+    _diffrn_radiation.polarizn_Stokes_V  SVECV
+    _diffrn_radiation.polarisn_norm_esd  POLNANGESD
+    _diffrn_radiation.polarisn_ratio_esd POLRATESD
+    _diffrn_radiation.polarizn_source_norm_esd   POLSNANGESD
+    _diffrn_radiation.polarizn_source_ratio_esd  POLSRATESD
+    _diffrn_radiation.polarizn_Stokes_I_esd  SVECIESD
+    _diffrn_radiation.polarizn_Stokes_Q_esd  SVECQESD
+    _diffrn_radiation.polarizn_Stokes_U_esd  SVECUESD
+    _diffrn_radiation.polarizn_Stokes_V_esd  SVECVESD
+    _diffrn_radiation.probe          RADIATION
+    _diffrn_radiation.type           SIEGBAHNTYPE
+    _diffrn_radiation.xray_symbol    IUPACXRAYSYMB
+    _diffrn_radiation.wavelength_id  ID
+    _diffrn_radiation_wavelength.id  ID
+    _diffrn_radiation_wavelength.wavelength    WAVELENGTH
+    _diffrn_radiation_wavelength.wt            WEIGHT
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.polarizn_Stokes_I_esd STOKESIESD
+    _diffrn_scan_frame.polarizn_Stokes_Q_esd STOKESQESD
+    _diffrn_scan_frame.polarizn_Stokes_U_esd STOKESUESD
+    _diffrn_scan_frame.polarizn_Stokes_V_esd STOKESVESD
+    _diffrn_scan_frame.frame_number FRAMENO
+
+    -->
+
+       /entry:NXentry
+         /CBF_scan_id="SCANID"
+         /sample:NXsample
+           /beam:NXbeam
+             /incident_divergence_x=DIVX
+               @units="degrees"
+             /incident_divergence_y=DIVY
+               @units="degrees"
+             /incident_divergence_xy=DIXXY
+               @units="degrees^2"
+             /CBF_diffrn_radiation_wavelength__wavelength_id=[WAVELENGTH_ID]
+             /incident_wavelength=[WAVELENGTH]
+               @units="A"
+             /weight=[WEIGHT]
+             /incident_polarisation_stokes_average=[SVECI,SVECQ,SVECU,SVECV]
+             /incident_polarisation_stokes_average_uncertainty=[SVECIESD,SVECQESD,SVECUESD,SVECVESD]
+             /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             /incident_polarisation_stokes_uncertainty=[STOKESIESD,STOKESQESD,STOKESUESD,STOKESVESD]
+               @units="Watts/meter^2"
+             /CBF_diffrn_radiation__polarisn_norm=POLNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio=POLRAT
+             /CBF_diffrn_radiation__polarisn_norm_uncertainty=POLNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarisn_ratio_uncertainty=POLRATESD
+             /CBF_diffrn_radiation__polarisn_source_norm=POLSNANG
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio=POLSRAT
+             /CBF_diffrn_radiation__polarisn_source_norm_uncertainty=POLSNANGESD
+               @units="deg"
+             /CBF_diffrn_radiation__polarizn_source_ratio_uncertainty=POLSRATESD
+             /CBF_diffrn_radiation__filter_edge=ABSEDGE
+                @units="angstroms"
+             /CBF_diffrn_radiation__inhomogeneity=HWIDTH
+                @units="mm"
+         /instrument:NXinstrument
+           /monochromator:NXmonochromator
+             /description="MONOCHROMATOR"
+           /source:NXsource
+             /probe="RADIATION"
+             /CBF_diffrn_radiation__type="SIEGBAHNTYPE"
+             /CBF_diffrn_radiation__xray_symbol="IUPACXRAYSYMB"
+
+         With the incident_polarisation_stokes array indexed by FRAMENO
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_radiation.beam_flux
+
+    _definition.id                '_diffrn_radiation.beam_flux'
+    _description.text
+;             The instantaneous flux spacially integrated over the portion
+              of the beam available to be incident on a sample (e.g. after 
+              collimation).  If the flux varies over the course of the 
+              experiment, the average over the time of the experiment should 
+              be reported.  This is sometimes referred to as total flux. 
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_second'
+    _units.code                   photons_per_second'
+
+save_
+
+save_diffrn_radiation.beam_flux_density
+
+    _definition.id                '_diffrn_radiation.beam_flux_density'
+    _description.text
+;             The instantaneous flux per unit area orhtogonal to the beam.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_density
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_second_per_micrometre_squared
+    _units.code                   photons_per_second_per_micrometre_squared
+
+save_
+
+save_diffrn_radiation.beam_flux_density_integrated
+
+    _definition.id
+        '_diffrn_radiation.beam_flux_density_integrated'
+    _description.text
+;             The time integral of the flux density.  The time over 
+              which the beam flux density is integrated is given in 
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_density_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_micrometre_squared
+    _units.code                   photons_per_micrometre_squared
+
+save_
+
+save_diffrn_radiation.beam_flux_integrated
+
+    _definition.id                '_diffrn_radiation.beam_flux_integrated'
+    _description.text
+;             The time integral of the flux spacially integrated over the 
+              portion of the beam available to be incident on a sample 
+              (e.g. after collimation).  The time over which the beam flux
+              is integrated is given in 
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons
+    _units.code                   photons
+
+save_
+
+save_diffrn_radiation.beam_flux_integration_time
+
+    _definition.id                '_diffrn_radiation.beam_flux_integration_time'
+    _description.text
+;             The time interval over which beam flux, beam incident flux
+              beam density is integrated.  
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_flux_integration_time
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+
+save_
+
+save_diffrn_radiation.beam_incident_flux
+
+    _definition.id                '_diffrn_radiation.beam_incident_flux'
+    _description.text
+;             The instantaneous flux spacially integrated over the portion of 
+              the beam actually incident on the sample.  If the incident flux 
+              varies over the course of the experiment, the average over the 
+              time of the experiment should be reported.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_incident_flux
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons_per_second
+    _units.code                   photons_per_second
+
+save_
+
+save_diffrn_radiation.beam_incident_flux_integrated
+
+    _definition.id
+        '_diffrn_radiation.beam_incident_flux_integrated'
+    _description.text
+;             The time integral of the flux spacially integrated over the
+              portion of the beam actually incident on the sample.  The 
+              time over which the beam flux is integrated is given in
+
+              _diffrn_radiation.beam_flux_integration_time
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_incident_flux_integrated
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              photons
+    _units.code                   photons
+
+save_
+
+save_diffrn_radiation.beam_width
+
+    _definition.id                '_diffrn_radiation.beam_width'
+    _description.text
+;             Full width at half maximum of the beam incident on the sample
+              in the plane of polarization (or horizontally if unpolarized).
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               beam_width
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              micrometres
+    _units.code                   micrometres
+
+save_
+
+save_diffrn_radiation.collimation
+
+    _definition.id                '_diffrn_radiation.collimation'
+    _alias.definition_id          '_diffrn_radiation_collimation'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The collimation or focusing applied to the radiation.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               collimation
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         '0.3 mm double-pinhole'
+         '0.5 mm'
+         'focusing mirrors'
+
+save_
+
+save_diffrn_radiation.diffrn_id
+
+    _definition.id                '_diffrn_radiation.diffrn_id'
+    _description.text
+;             This data item is a pointer to _diffrn.id in the DIFFRN
+              category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_radiation.div_x_source
+
+    _definition.id                '_diffrn_radiation.div_x_source'
+    _description.text
+;             Beam crossfire in degrees parallel to the laboratory X axis
+              (see AXIS category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard
+              deviation, e.s.d.)  of the directions of photons in 
+              the XZ plane around the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               div_x_source
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _units.code                   degrees
+
+save_
+
+save_diffrn_radiation.div_x_y_source
+
+    _definition.id                '_diffrn_radiation.div_x_y_source'
+    _description.text
+;             Beam crossfire correlation in degrees squared between the
+              crossfire laboratory X-axis component and the crossfire
+              laboratory Y-axis component (see AXIS category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the mean of the products of the deviations of the
+              direction of each photon in XZ plane times the deviations
+              of the direction of the same photon in the YZ plane
+              around the mean source beam direction.  This will be zero
+              for uncorrelated crossfire.
+
+              Note that for some synchrotrons, this value is specified in
+              milliradians squared, in which case a conversion is
+              needed. To convert a value in milliradians squared to a value
+              in degrees squared, multiply by 0.180^2^ and divide by \p^2^.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               div_x_y_source
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees_squared
+    _enumeration.default          0.0
+    _units.code                   degrees_squared
+
+save_
+
+save_diffrn_radiation.div_y_source
+
+    _definition.id                '_diffrn_radiation.div_y_source'
+    _description.text
+;             Beam crossfire in degrees parallel to the laboratory Y axis
+              (see AXIS category).
+
+              This is a characteristic of the X-ray beam as it illuminates
+              the sample (or specimen) after all monochromation and
+              collimation.
+
+              This is the standard uncertainty (estimated standard deviation,
+              e.s.d.) of the directions of photons in the YZ plane around 
+              the mean source beam direction.
+
+              Note that for some synchrotrons this value is specified
+              in milliradians, in which case a conversion is needed.
+              To convert a value in milliradians to a value in degrees,
+              multiply by 0.180 and divide by \p.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               div_y_source
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_radiation.filter_edge
+
+    _definition.id                '_diffrn_radiation.filter_edge'
+    _alias.definition_id          '_diffrn_radiation_filter_edge'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;              Absorption edge in \%angstr\"oms of the radiation filter used.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               filter_edge
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              angstroms
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_radiation.inhomogeneity
+
+    _definition.id                '_diffrn_radiation.inhomogeneity'
+    _alias.definition_id          '_diffrn_radiation_inhomogeneity'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             Half-width in millimetres of the incident beam in the
+              direction perpendicular to the diffraction plane.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               inhomogeneity
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_radiation.monochromator
+
+    _definition.id                '_diffrn_radiation.monochromator'
+    _alias.definition_id          '_diffrn_radiation_monochromator'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The method used to obtain monochromatic radiation. If a
+              monochromator crystal is used, the material and the
+              indices of the Bragg reflection are specified.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               monochromator
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite'
+
+save_
+
+save_diffrn_radiation.polarisn_norm
+
+    _definition.id                '_diffrn_radiation.polarisn_norm'
+    _alias.definition_id          '_diffrn_radiation_polarisn_norm'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_norm
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.range            -90.0:90.0
+    _units.code                   degrees
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         90.0                     90.0
+         -90.0                    90.0
+         -90.0                    -90.0
+
+save_
+
+save_diffrn_radiation.polarisn_norm_esd
+
+    _definition.id                '_diffrn_radiation.polarisn_norm_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_norm,
+              the angle in degrees, as viewed from the specimen, between the
+              perpendicular component of the polarization and the diffraction
+              plane. See _diffrn_radiation_polarisn_ratio.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_norm_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_norm'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarisn_ratio
+
+    _definition.id                '_diffrn_radiation.polarisn_ratio'
+    _alias.definition_id          '_diffrn_radiation_polarisn_ratio'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             Polarization ratio of the diffraction beam incident on the
+              crystal. This is the ratio of the perpendicularly polarized to
+              the parallel polarized component of the radiation. The
+              perpendicular component forms an angle of
+              _diffrn_radiation.polarisn_norm to the normal to the
+              diffraction plane of the sample (i.e. the plane containing
+              the incident and reflected beams).
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_ratio
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_radiation.polarisn_ratio_esd
+
+    _definition.id                '_diffrn_radiation.polarisn_ratio_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+              _diffrn_radiation.polarisn_ratio,
+              the polarization ratio of the diffraction beam incident on the
+              crystal. 
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_ratio_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarisn_ratio'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_source_norm
+
+    _definition.id                '_diffrn_radiation.polarizn_source_norm'
+    _description.text
+;             The angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
+
+              Note that this is the angle of polarization of the source
+              photons, either directly from a synchrotron beamline or
+              from a monochromator.
+
+              This differs from the value of
+              _diffrn_radiation.polarisn_norm
+              in that _diffrn_radiation.polarisn_norm refers to
+              polarization relative to the diffraction plane rather than
+              to the laboratory axis system.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane should be taken
+              as the XZ plane and the angle as 0.
+
+              See _diffrn_radiation.polarizn_source_ratio.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_source_norm
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.range            -90.0:90.0
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         90.0                     90.0
+         -90.0                    90.0
+         -90.0                    -90.0
+
+save_
+
+save_diffrn_radiation.polarizn_source_norm_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_source_norm_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_norm,
+              the angle in degrees, as viewed from the specimen, between
+              the normal to the polarization plane and the laboratory
+              Y-axis as defined in the AXIS category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_source_norm_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_norm'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_source_ratio
+
+    _definition.id                '_diffrn_radiation.polarizn_source_ratio'
+    _description.text
+;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+
+              In the case of an unpolarized beam, or a beam with true
+              circular polarization, in which no single plane of
+              polarization can be determined, the plane is to be taken
+              as the XZ plane and the normal is parallel to the Y axis.
+
+              Thus, if there was complete polarization in the plane of
+              polarization, the value of
+              _diffrn_radiation.polarizn_source_ratio would be 1, and
+              for an unpolarized beam
+              _diffrn_radiation.polarizn_source_ratio would have a
+              value of 0.
+
+              If the X axis has been chosen to lie in the plane of
+              polarization, this definition will agree with the definition
+              of 'MONOCHROMATOR' in the Denzo glossary, and values of near
+              1 should be expected for a bending-magnet source.  However,
+              if the X-axis were perpendicular to the polarization plane
+              (not a common choice), then the Denzo value would be the
+              negative of _diffrn_radiation.polarizn_source_ratio.
+
+              See http://www.hkl-xray.com for information on Denzo and
+              Otwinowski & Minor (1997).
+
+              This differs both in the choice of ratio and choice of
+              orientation from _diffrn_radiation.polarisn_ratio, which,
+              unlike _diffrn_radiation.polarizn_source_ratio, is
+              unbounded.
+
+              Reference: Otwinowski, Z. & Minor, W. (1997). 'Processing of
+              X-ray diffraction data collected in oscillation mode.' Methods
+              Enzymol. 276, 307-326.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_source_ratio
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            -1.0:1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1.0                      1.0
+         -1.0                     1.0
+         -1.0                     -1.0
+
+save_
+
+save_diffrn_radiation.polarizn_source_ratio_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_source_ratio_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_source_ratio,
+              (Ip-In)/(Ip+In), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared)
+              of the electric vector in the plane of the normal to the
+              plane of polarization.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_source_ratio_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_source_ratio'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_i
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_I'
+    _description.text
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_I
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _enumeration.default          1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_i_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_I_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_I_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_I'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_q
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_Q'
+    _description.text
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_Q
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_q_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_Q_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_Q_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_Q'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_u
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_U'
+    _description.text
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry at al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_U
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_u_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_U_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_U_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_U'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_v
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_V'
+    _description.text
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              scan.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200 -- 3205.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_V
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_radiation.polarizn_stokes_v_esd
+
+    _definition.id                '_diffrn_radiation.polarizn_Stokes_V_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_radiation.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarizn_Stokes_V_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_radiation.polarizn_Stokes_V'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_radiation.probe
+
+    _definition.id                '_diffrn_radiation.probe'
+    _alias.definition_id          '_diffrn_radiation_probe'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             Name of the type of radiation used. It is strongly
+              recommended that this be given so that the
+              probe radiation is clearly specified.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               probe
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               line
+
+    loop_
+      _enumeration_set.state
+         x-ray
+         neutron
+         electron
+         gamma
+
+save_
+
+save_diffrn_radiation.type
+
+    _definition.id                '_diffrn_radiation.type'
+    _alias.definition_id          '_diffrn_radiation_type'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The nature of the radiation. This is typically a description
+              of the X-ray wavelength in Siegbahn notation.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               type
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               line
+
+    loop_
+      _description_example.case
+         'CuK\a'
+         'Cu K\a~1~'
+         'Cu K-L~2,3~'
+         'white-beam'
+
+save_
+
+save_diffrn_radiation.variant
+
+    _definition.id                '_diffrn_radiation.variant'
+    _description.text
+;             The value of _diffrn_radiation.variant gives the variant
+              to which the given DIFFRN_RADIATION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_diffrn_radiation.wavelength_id
+
+    _definition.id                '_diffrn_radiation.wavelength_id'
+    _description.text
+;             This data item is a pointer to
+              _diffrn_radiation_wavelength.id in the
+              DIFFRN_RADIATION_WAVELENGTH category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               wavelength_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_radiation.xray_symbol
+
+    _definition.id                '_diffrn_radiation.xray_symbol'
+    _alias.definition_id          '_diffrn_radiation_xray_symbol'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           2.0.1
+    _alias.dictionary_uri         cif_core.dic
+    _description.text
+;             The IUPAC symbol for the X-ray wavelength for the probe
+              radiation.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               xray_symbol
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               line
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         K-L~3~                  'K\a~1~ in older Siegbahn notation'
+         K-L~2~                  'K\a~2~ in older Siegbahn notation'
+         K-M~3~                  'K\b~1~ in older Siegbahn notation'
+         K-L~2,3~                'use where K-L~3~ and K-L~2~ are not resolved'
+
+save_
+
+save_DIFFRN_REFLN
+
+    _definition.id                diffrn_refln
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    This category redefinition has been added to extend the key of
+     the standard DIFFRN_REFLN category.
+
+     Data items in the DIFFRN_REFLN category record details about
+     the intensities in the diffraction data set
+     identified by _diffrn_refln.diffrn_id.
+
+     The DIFFRN_REFLN data items refer to individual intensity
+     measurements and must be included in looped lists.
+
+     The DIFFRN_REFLNS data items specify the parameters that apply
+     to all intensity  measurements in the particular diffraction
+     data set identified by _diffrn_reflns.diffrn_id and
+     _diffrn_refln.frame_id
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_refln
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_refln.diffrn_id'
+         '_diffrn_refln.id'
+         '_diffrn_refln.frame_id'
+         '_diffrn_refln.variant'
+
+    _nx_mapping.details
+;
+    This category will be addressed at a future date.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_refln.diffrn_id
+
+    _definition.id                '_diffrn_refln.diffrn_id'
+    _description.text
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_refln.frame_id
+
+    _definition.id                '_diffrn_refln.frame_id'
+    _description.text
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               frame_id
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_refln.id
+
+    _definition.id                '_diffrn_refln.id'
+    _description.text
+;             This item is a placeholder for the definition in the
+              PDBx/mmCIF dictionary.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_refln.variant
+
+    _definition.id                '_diffrn_refln.variant'
+    _description.text
+;             The value of _diffrn_refln.variant gives the variant
+              to which the given DIFFRN_REFLN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_diffrn_reflns.diffrn_id
+
+    _definition.id                '_diffrn_reflns.diffrn_id'
+    _name.category_id             diffrn_reflns
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_SCAN
+
+    _definition.id                diffrn_scan
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN category describe the parameters of one
+     or more scans, relating axis positions to frames.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan.id'
+         '_diffrn_scan.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+      _diffrn_scan.id                   1
+      _diffrn_scan.date_start         '2001-11-18T03:26:42'
+      _diffrn_scan.date_end_estimated '2001-11-18T03:36:45'
+      _diffrn_scan.date_end           '2001-11-18T03:36:45'
+      _diffrn_scan.integration_time    3.0
+      _diffrn_scan.frame_id_start      mad_L2_000
+      _diffrn_scan.frame_id_end        mad_L2_200
+      _diffrn_scan.frames              201
+
+     loop_
+      _diffrn_scan_axis.scan_id
+      _diffrn_scan_axis.axis_id
+      _diffrn_scan_axis.angle_start
+      _diffrn_scan_axis.angle_range
+      _diffrn_scan_axis.angle_increment
+      _diffrn_scan_axis.displacement_start
+      _diffrn_scan_axis.displacement_range
+      _diffrn_scan_axis.displacement_increment
+
+       1 omega 200.0 20.1 0.1 . . .
+       1 kappa -40.0  0.0 0.0 . . .
+       1 phi   127.5  0.0 0.0 . . .
+       1 tranz  . . .   2.3 0.0 0.0
+
+      _diffrn_scan_frame.scan_id                   1
+      _diffrn_scan_frame.date               '2001-11-18T03:27:33'
+      _diffrn_scan_frame.integration_time    3.0
+      _diffrn_scan_frame.frame_id            mad_L2_018
+      _diffrn_scan_frame.frame_number        18
+
+     loop_
+      _diffrn_scan_frame_axis.frame_id
+      _diffrn_scan_frame_axis.axis_id
+      _diffrn_scan_frame_axis.angle
+      _diffrn_scan_frame_axis.angle_increment
+      _diffrn_scan_frame_axis.displacement
+      _diffrn_scan_frame_axis.displacement_increment
+
+       mad_L2_018 omega 201.8  0.1 . .
+       mad_L2_018 kappa -40.0  0.0 . .
+       mad_L2_018 phi   127.5  0.0 . .
+       mad_L2_018 tranz  .     .  2.3 0.0
+;
+;
+         Example 1. derived from a suggestion by R. M. Sweet.
+
+         The vector of each axis is not given here, because it is provided in
+         the AXIS category.  By making _diffrn_scan_axis.scan_id and
+         _diffrn_scan_axis.axis_id keys of the DIFFRN_SCAN_AXIS category,
+         an arbitrary number of scanning and fixed axes can be specified for a
+         scan.  In this example, three rotation axes and one translation axis
+         at nonzero values are specified, with one axis stepping.  There is no
+         reason why more axes could not have been specified to step. Range
+         information has been specified, but note that it can be calculated from
+         the  number of frames and the increment, so the data item
+         _diffrn_scan_axis.angle_range could be dropped.
+
+         Both the sweep data and the data for a single frame are specified.
+
+         Note that the information on how the axes are stepped is given twice,
+         once in terms of the overall averages in the value of
+         _diffrn_scan.integration_time and the values for DIFFRN_SCAN_AXIS,
+         and precisely for the given frame in the value for
+         _diffrn_scan_frame.integration_time and the values for
+         DIFFRN_SCAN_FRAME_AXIS.  If dose-related adjustments are made to
+         scan times and nonlinear stepping is done, these values may differ.
+         Therefore, in interpreting the data for a particular frame it is
+         important to use the frame-specific data.
+
+         There are three date/times in this set: *.date_start and
+         *. date_end_estimated, both of which are mandatory, because the former
+         is data which can be logged at the start of collection and the latter
+         is data that can be estimated at the same time, and *.date_end which
+         can only be logged exactly if the data collection completes normally.
+;
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+     loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 2300 1 increasing ELEMENT_X
+      ARRAY1 2 2300 2 increasing ELEMENT_Y
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.displacement_increment
+      ELEMENT_X ELEMENT_X 0.075 0.150
+      ELEMENT_Y ELEMENT_Y 0.075 0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+      ARRAY1 2 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+;
+         Example 2. a more extensive example (R. M. Sweet, P. J. Ellis &
+          H. J. Bernstein).
+
+          A detector is placed 240 mm along the Z axis from the goniometer.
+          This leads to a choice:  either the axes of
+          the detector are defined at the origin, and then a Z setting of -240
+          is entered, or the axes are defined with the necessary Z offset.
+          In this case, the setting is used and the offset is left as zero.
+          This axis is called DETECTOR_Z.
+
+          The axis for positioning the detector in the Y direction depends
+          on the detector Z axis.  This axis is called DETECTOR_Y.
+
+          The axis for positioning the detector in the X direction depends
+          on the detector Y axis (and therefore on the detector Z axis).
+          This axis is called DETECTOR_X.
+
+          This detector may be rotated around the Y axis.  This rotation axis
+          depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+          A coordinate system is defined on the face of the detector in terms of
+          2300 0.150 mm pixels in each direction.  The ELEMENT_X axis is used to
+          index the first array index of the data array and the ELEMENT_Y
+          axis is used to index the second array index.  Because the pixels
+          are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
+          0.075) in this coordinate system.
+;
+;    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+          loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1 0 0 0
+      ELEMENT_RAD      translation detector ELEMENT_ROT 0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.angle
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.angular_pitch
+     _array_structure_list_axis.radial_pitch
+      ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075   .
+      ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     # the actual pixels are 0.075 by 0.150 mm
+     # We give the coarser dimension here.
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+;
+         Example 3. Example 2 revised for a spiral scan (R. M. Sweet,
+          P. J. Ellis & H. J. Bernstein).
+
+         A detector is placed 240 mm along the Z axis from the
+         goniometer, as in Example 2 above, but in this example the
+         image plate is scanned in a spiral pattern from the outside edge in.
+
+         The axis for positioning the detector in the Y direction depends
+         on the detector Z axis.  This axis is called DETECTOR_Y.
+
+         The axis for positioning the detector in the X direction depends
+         on the detector Y axis (and therefore on the detector Z axis).
+         This axis is called DETECTOR_X.
+
+         This detector may be rotated around the Y axis.  This rotation axis
+         depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+         A coordinate system is defined on the face of the detector in
+         terms of a coupled rotation axis and radial scan axis to form
+         a spiral scan.  The rotation axis is called  ELEMENT_ROT  and the
+         radial axis is called ELEMENT_RAD.  A 150 micrometre radial pitch
+         and a 75 micrometre 'constant velocity' angular pitch are assumed.
+
+         Indexing is carried out first on the rotation axis and the radial axis
+         is made to be dependent on it.
+
+         The two axes are coupled to form an axis set ELEMENT_SPIRAL.
+;
+
+    _nx_mapping.details
+;    _diffrn_scan.id SCANID
+    _diffrn_scan.date_end ENDDATETIME
+    _diffrn_scan.date_end_estimated ENDDATETIMEEST
+    _diffrn_scan.date_start STARTDATETIME
+    _diffrn_scan.integration_time AVGCOUNTTIME
+    _diffrn_scan.frame_id_start FRAMESTARTID
+    _diffrn_scan.frame_id_end FRAMEENDID
+    _diffrn_scan.frames FRAMES
+    _diffrn_scan.time_period TIMEPER
+    _diffrn_scan.time_rstrt_incr RSTRTTIME
+
+    -->
+
+        /entry:NXentry
+          /CBF_scan_id="SCANID"
+          /end_time=ENDDATETIME
+          /end_time_estimated=ENDDATETIMEEST
+          /start_time=STARTDATETIME
+          /average_count_time=AVGCOUNTTIME
+            @units="sec"
+          /average_frame_time=TIMEPER
+            @units="sec"
+          /average_frame_restart_time=RSTRTTIME
+            @units="sec"
+          /instrument:NXinstrument
+           /DETECTORNAME:NXdetector_group
+           /DETECTORELEMENTNAME:NXdetector
+              /frame_start_number=FRAMESTARTNO
+              /frame_end_number=FRAMEENDNO
+
+    FRAMESTARTNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMESTARTID
+    FRAMEENDNO is the value of _diffrn_scan_frame.frame_number
+    for which the value of _diffrn_scan_frame.frame_id equals FRAMEENDID   
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan.date_end
+
+    _definition.id                '_diffrn_scan.date_end'
+    _description.text
+;             The date and time of the end of the scan.  Note that this
+              may be an estimate generated during the scan, before the
+              precise time of the end of the scan is known, in which
+              case _diffrn_scan.date_end_estimated should be used instead.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               date_end
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               yyyy-mm-dd
+
+save_
+
+save_diffrn_scan.date_end_estimated
+
+    _definition.id                '_diffrn_scan.date_end_estimated'
+    _description.text
+;             The estimated date and time of the end of the scan.  Note 
+              that this may be generated at the start or during the scan,
+              before the precise time of the end of the scan is known.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               date_end_estimated
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               yyyy-mm-dd
+
+save_
+
+save_diffrn_scan.date_start
+
+    _definition.id                '_diffrn_scan.date_start'
+    _description.text
+;             The date and time of the start of the scan.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               date_start
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               yyyy-mm-dd
+
+save_
+
+save_diffrn_scan.diffrn_id
+
+    _definition.id                '_diffrn_scan.diffrn_id'
+    _name.category_id             diffrn_scan
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_scan.frame_id_end
+
+    _definition.id                '_diffrn_scan.frame_id_end'
+    _description.text
+;             The value of this data item is the identifier of the
+              last frame in the scan.
+
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               frame_id_end
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan.frame_id_start
+
+    _definition.id                '_diffrn_scan.frame_id_start'
+    _description.text
+;             The value of this data item is the identifier of the
+              first frame in the scan.
+
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               frame_id_start
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan.frames
+
+    _definition.id                '_diffrn_scan.frames'
+    _description.text
+;             The value of this data item is the number of frames in
+              the scan.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               frames
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        .
+         1                        1
+
+save_
+
+save_diffrn_scan.id
+
+    _definition.id                '_diffrn_scan.id'
+    _description.text
+;             The value of _diffrn_scan.id uniquely identifies each
+              scan.  The identifier is used to tie together all the
+              information about the scan.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan.integration_time
+
+    _definition.id                '_diffrn_scan.integration_time'
+    _description.text
+;             Approximate average time in seconds to integrate each
+              step of the scan.  The precise time for integration
+              of each particular step must be provided in
+              _diffrn_scan_frame.integration_time, even
+              if all steps have the same integration time.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               integration_time
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan.time_period
+
+    _definition.id                '_diffrn_scan.time_period'
+    _description.text
+;             Approximate average time in seconds between the start
+              of each step of the scan.  The precise start-to-start
+              time increment of each particular step may be provided in
+              _diffrn_scan_frame.time_period.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               time_period
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan.time_rstrt_incr
+
+    _definition.id                '_diffrn_scan.time_rstrt_incr'
+    _description.text
+;             Approximate average time in seconds between the end
+              of integration of each step of the scan and the start
+              of integration of the next step.
+
+              In general, this will agree with
+              _diffrn_scan_frame.time_rstrt_incr.  The
+              sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period for this
+              frame.   If the individual frame values vary, then the value of
+              _diffrn_scan.time_rstrt_incr will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr (e.g.
+              the mean).
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               time_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan.variant
+
+    _definition.id                '_diffrn_scan.variant'
+    _description.text
+;             The value of _diffrn_scan.variant gives the variant
+              to which the given DIFFRN_SCAN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_AXIS
+
+    _definition.id                diffrn_scan_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_AXIS category describe the settings of
+     axes for particular scans.  Unspecified axes are assumed to be at
+     their zero points.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan_axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_axis.scan_id'
+         '_diffrn_scan_axis.axis_id'
+         '_diffrn_scan_axis.variant'
+
+    _nx_mapping.details
+;    _diffrn_scan_axis.axis_id AXISID-->
+    _diffrn_scan_axis.angle_start ANGSTART
+    _diffrn_scan_axis.angle_range ANGRANGE 
+    _diffrn_scan_axis.angle_increment ANGINC 
+    _diffrn_scan_axis.angle_rstrt_incr ANGRSTRT 
+    _diffrn_scan_axis.displacement_start DISPSTART 
+    _diffrn_scan_axis.displacement_range DISPRANGE 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_increment DISPINC 
+    _diffrn_scan_axis.displacement_rstrt_incr DISPRSTRT 
+    _diffrn_scan_axis.reference_angle ANG 
+    _diffrn_scan_axis.reference_displacement DISP 
+    _diffrn_scan_axis.scan_id SCANID
+
+    -->
+
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /CBF_diffrn_scan__SCANID:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_axis__angle_start=ANGSTART
+             @diffrn_scan_axis__angle_range=ANGRANGE
+             @diffrn_scan_axis__angle_increment=ANGINC
+             @diffrn_scan_axis__angle_rstrt_incr=ANGRSTRT
+             @diffrn_scan_axis__displacement_start=DISPSTART
+             @diffrn_scan_axis__displacement_range=DISPRANGE
+             @diffrn_scan_axis__displacement_increment=DISPINC
+             @diffrn_scan_axis__displacement_rstrt_incr=DISPRSTRT
+             @diffrn_scan_axis__reference_angle=ANG
+             @diffrn_scan_axis__reference_displacement=DISP
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan_axis.angle_increment
+
+    _definition.id                '_diffrn_scan_axis.angle_increment'
+    _description.text
+;             The increment for each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_increment. The
+              sum of the values of _diffrn_scan_frame_axis.angle and
+              _diffrn_scan_frame_axis.angle_increment is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_increment will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_increment (e.g.
+              the mean).
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               angle_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_axis.angle_range
+
+    _definition.id                '_diffrn_scan_axis.angle_range'
+    _description.text
+;             The total range covered during the scan from the starting position 
+              to the end of the final step for the specified axis in degrees.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               angle_range
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_axis.angle_rstrt_incr
+
+    _definition.id                '_diffrn_scan_axis.angle_rstrt_incr'
+    _description.text
+;             The increment after each step for the specified axis
+              in degrees.  In general, this will agree with
+              _diffrn_scan_frame_axis.angle_rstrt_incr.  The
+              sum of the values of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment
+              and  _diffrn_scan_frame_axis.angle_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.angle for this
+              next frame.   If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.angle_rstrt_incr will be
+              representative
+              of the ensemble of values of
+              _diffrn_scan_frame_axis.angle_rstrt_incr (e.g.
+              the mean).
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               angle_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_axis.angle_start
+
+    _definition.id                '_diffrn_scan_axis.angle_start'
+    _description.text
+;             The starting position for the specified axis in degrees.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               angle_start
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_axis.axis_id
+
+    _definition.id                '_diffrn_scan_axis.axis_id'
+    _description.text
+;             The value of this data item is the identifier of one of
+              the axes for the scan for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
+
+              This item is a pointer to _axis.id in the
+              AXIS category.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               axis_id
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_axis.diffrn_id
+
+    _definition.id                '_diffrn_scan_axis.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               diffrn_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_axis.displacement_increment
+
+    _definition.id                '_diffrn_scan_axis.displacement_increment'
+    _description.text
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_increment.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement and
+              _diffrn_scan_frame_axis.displacement_increment is the
+              angular setting of the axis at the end of the integration
+              time for a given frame.  If the individual frame values
+              vary, then the value of
+               _diffrn_scan_axis.displacement_increment will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_increment (e.g.
+               the mean).
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               displacement_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_axis.displacement_range
+
+    _definition.id                '_diffrn_scan_axis.displacement_range'
+    _description.text
+;             The range from the starting position for the specified axis
+              in millimetres.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               displacement_range
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_axis.displacement_rstrt_incr
+
+    _definition.id                '_diffrn_scan_axis.displacement_rstrt_incr'
+    _description.text
+;             The increment for each step for the specified axis
+              in millimetres.  In general, this will agree with
+              _diffrn_scan_frame_axis.displacement_rstrt_incr.
+              The sum of the values of
+              _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame relative to a given frame and
+              should equal _diffrn_scan_frame_axis.displacement
+              for this next frame.  If the individual frame values
+              vary, then the value of
+              _diffrn_scan_axis.displacement_rstrt_incr will be
+              representative of the ensemble of values of
+               _diffrn_scan_frame_axis.displacement_rstrt_incr (e.g.
+               the mean).
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               displacement_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_axis.displacement_start
+
+    _definition.id                '_diffrn_scan_axis.displacement_start'
+    _description.text
+;             The starting position for the specified axis in millimetres.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               displacement_start
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_axis.reference_angle
+
+    _definition.id                '_diffrn_scan_axis.reference_angle'
+    _description.text
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_angle.
+
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_angle will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_angle (e.g.
+              the mean).
+
+              If not specified, the value defaults to zero.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               reference_angle
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_axis.reference_displacement
+
+    _definition.id                '_diffrn_scan_axis.reference_displacement'
+    _description.text
+;             The setting of the specified axis in millimetres
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              In general, this will agree with
+              _diffrn_scan_frame_axis.reference_displacement.
+
+              If the individual frame values vary, then the value of
+              _diffrn_scan_axis.reference_displacement will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame_axis.reference_displacement (e.g.
+              the mean).
+
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               reference_displacement
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_axis.scan_id
+
+    _definition.id                '_diffrn_scan_axis.scan_id'
+    _description.text
+;             The value of this data item is the identifier of the
+              scan for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan.id.
+
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               scan_id
+    _name.linked_item_id          '_diffrn_scan.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_axis.variant
+
+    _definition.id                '_diffrn_scan_axis.variant'
+    _description.text
+;             The value of _diffrn_scan_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_COLLECTION
+
+    _definition.id                diffrn_scan_collection
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_COLLECTION category describe
+     the collection strategy for each scan.
+
+     This category is a preliminary version being developed as
+     synchrotron and XFEL collection strategies evolve.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan_collection
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_collection.scan_id'
+         '_diffrn_scan_collection.variant'
+
+    _description_example.case
+        'Example 1 - Describing a multi-wedge raster scan.'
+    _description_example.detail
+;        loop_
+        _diffrn_scan_collection.scan_id
+        _diffrn_scan_collection.details
+       
+        multi_wedge
+    ;   scan 20 micrometre beam in 100 micrometre steps on 31
+        by 46 alternating raster of 20 degree wedges 
+    ;
+;
+    _nx_mapping.details
+;    _diffrn_scan_collection.type  COLLECTIONTYPE
+    _diffrn_scan_collection.translation_width TRANSLATION_WIDTH
+
+    --> 
+
+    /entry:NXentry
+      /CBF_cbf:NXpdb
+        /image1:NXpdb
+          @NXpdb="CBF_cbfdb"
+          /diffrn_scan_collection:NXpdb
+            @NXpdb="CBF_cbfcat"
+              /type=["COLLECTIONTYP"]
+              /translation_width=["TRANSLATION_WIDTH"]
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan_collection.details
+
+    _definition.id                '_diffrn_scan_collection.details'
+    _description.text
+;             The value of _diffrn_scan_collection.details should give a
+              description of special aspects of each collection strategy.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+save_
+
+save_diffrn_scan_collection.diffrn_id
+
+    _definition.id                '_diffrn_scan_collection.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_collection.scan_id
+
+    _definition.id                '_diffrn_scan_collection.scan_id'
+    _description.text
+;             The value of _diffrn_scan_collection.scan_id identifies the scan
+              containing this frame.
+
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
+
+              In the case of a single-scan dataset, the value is implicit.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               scan_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_collection.translation_width
+
+    _definition.id                '_diffrn_scan_collection.translation_width'
+    _description.text
+;             The value of _diffrn_scan_collection.translation_width
+              gives the average single step translation in micrometres
+              in collection strategies for which this information is
+               appropriate, e.g. 'vector'.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               translation_width
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              micrometres
+    _enumeration.default          0.0
+    _units.code                   micrometres
+
+save_
+
+save_diffrn_scan_collection.type
+
+    _definition.id                '_diffrn_scan_collection.type'
+    _description.text
+;             The value of _diffrn_scan_collection.type identifies
+              the strategy used in this scan, e.g. `rotation', 'raster',
+              'vector', 'still', etc.
+
+              The default is 'rotation'. 
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               type
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _enumeration.default          rotation
+
+save_
+
+save_diffrn_scan_collection.variant
+
+    _definition.id                '_diffrn_scan_collection.variant'
+    _description.text
+;             The value of _diffrn_scan_collection.variant gives the variant
+              to which the given DIFFRN_SCAN_COLLECTION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME
+
+    _definition.id                diffrn_scan_frame
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME category describe
+     the relationships of particular frames to scans.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan_frame
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame.scan_id'
+         '_diffrn_scan_frame.frame_id'
+         '_diffrn_scan_frame.variant'
+
+    _nx_mapping.details
+;    _diffrn_scan_frame.date  DATETIME
+    _diffrn_scan_frame.frame_id ID
+    _diffrn_scan_frame.frame_number FRAMENUMBER
+    _diffrn_scan_frame.integration_time COUNTTIME
+    _diffrn_scan_frame.polarizn_Stokes_I STOKESI
+    _diffrn_scan_frame.polarizn_Stokes_Q STOKESQ
+    _diffrn_scan_frame.polarizn_Stokes_U STOKESU
+    _diffrn_scan_frame.polarizn_Stokes_V STOKESV
+    _diffrn_scan_frame.scan_id SCANID
+    _diffrn_scan_frame.time_period FRAMETIME
+    _diffrn_scan_frame.time_rstrt_incr RSTRTTIME
+
+    --> 
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+          /CBF_diffrn_scan_frame__date=["DATETIME"]
+          /CBF_diffrn_scan_frame__frame_id=["ID"]
+          /count_time=[COUNTIME]
+          /frame_time=[FRAMETIME]
+          /frame_restart_time=[RSTRTTIME]
+      /sample:NXsample
+        /beam:NXbeam
+          /incident_polarisation_stokes=[STOKESI,STOKESQ,STOKESU,STOKESV]
+             @units="Watts/meter^2"
+     where each array element is inserted at index FRAMENUMBER          
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan_frame.date
+
+    _definition.id                '_diffrn_scan_frame.date'
+    _description.text
+;             The date and time of the start of the frame being scanned.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               date
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               yyyy-mm-dd
+
+save_
+
+save_diffrn_scan_frame.diffrn_id
+
+    _definition.id                '_diffrn_scan_frame.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame.frame_id
+
+    _definition.id                '_diffrn_scan_frame.frame_id'
+    _description.text
+;             The value of this data item is the identifier of the
+              frame being examined.
+
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               frame_id
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame.frame_number
+
+    _definition.id                '_diffrn_scan_frame.frame_number'
+    _description.text
+;             The value of this data item is the number of the frame
+              within the scan, starting with 1.  It is not necessarily
+              the same as the value of _diffrn_scan_frame.frame_id,
+              but it may be.
+
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               frame_number
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0                        .
+         0                        0
+
+save_
+
+save_diffrn_scan_frame.integration_time
+
+    _definition.id                '_diffrn_scan_frame.integration_time'
+    _description.text
+;             The time in seconds to integrate this step of the scan.
+              This should be the precise time of integration of each
+              particular frame.  The value of this data item should
+              be given explicitly for each frame and not inferred
+              from the value of _diffrn_scan.integration_time.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               integration_time
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_i
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I'
+    _description.text
+;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+              squared) of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the first of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Note that, if the polarized intensity Ip+In is required,
+              (Ip+In)^2^ is the sum of Q^2^+U^2^+V^2^.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_I
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _enumeration.default          1.0
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_i_esd
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_I,
+              Ip+In+Inp, where Ip is the intensity (amplitude squared)
+              of the electric vector in the plane of polarization,
+              In is the intensity (amplitude squared) of the electric vector
+              in the plane of the normal to the plane of polarization,
+              and Inp is the intensity (amplitude squared) of the
+              non-polarized (incoherent) electric vector.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_I_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_I'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_q
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q'
+    _description.text
+;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the second of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_Q
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_q_esd
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_Q,
+              (Ip-In)*cos(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_Q_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_Q'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_u
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U'
+    _description.text
+;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the third of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)]
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_U
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_u_esd
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_U,
+              (Ip-In)*sin(2*theta), where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization, In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_U_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_U'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_v
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V'
+    _description.text
+;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+              circular polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y axis as defined in the
+              AXIS category.
+
+              This is an average or other representative sample of the
+              frame.
+
+              This is the fourth of the Stokes polarization parameters,
+              I, Q, U, V [also known as I, M, C, S; see Berry et al. (1977)].
+
+              If the absolute intensity is not known, the value 1.0
+              is assumed for I, and all four Stokes parameters are
+              dimensionless.  When the absolute intensity is known,
+              all four Stokes parameters are in units of watts per
+              square metre.
+
+              Reference:
+              Berry, H. H., Gabrielse, G. & Livingston, A. E. (1977).
+              'Measurement of the Stokes parameters of light',
+              Appl. Optics, 16:12, 3200--3205.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_V
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+
+save_
+
+save_diffrn_scan_frame.polarizn_stokes_v_esd
+
+    _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V_esd'
+    _description.text
+;             The standard uncertainty (estimated standard deviation, e.s.d.)
+              of _diffrn_scan_frame.polarizn_Stokes_V,
+              +/-2*sqrt(IpIn), with a + sign for right-handed circular
+              polarization, where Ip is the intensity
+              (amplitude squared) of the electric vector in the plane of
+              polarization and In is the intensity (amplitude squared) of
+              the electric vector in the plane of the normal to the
+              plane of polarization, and theta is the angle as viewed
+              from the specimen, between the normal to the polarization
+              plane and the laboratory Y-axis as defined in the
+              AXIS category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               polarizn_Stokes_V_esd
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _enumeration.range            0.0:
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         0.0                      .
+         0.0                      0.0
+
+    _ddl2_item_related.related_name '_diffrn_scan_frame.polarizn_Stokes_V'
+    _ddl2_item_related.function_code associated_value
+
+save_
+
+save_diffrn_scan_frame.scan_id
+
+    _definition.id                '_diffrn_scan_frame.scan_id'
+    _description.text
+;             The value of _diffrn_scan_frame.scan_id identifies the scan
+              containing this frame.
+
+              This item is a pointer to _diffrn_scan.id in the
+              DIFFRN_SCAN category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               scan_id
+    _name.linked_item_id          '_diffrn_scan.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame.time_period
+
+    _definition.id                '_diffrn_scan_frame.time_period'
+    _description.text
+;             The time in seconds between the start of this frame and the
+              start of the next frame, if any.  If there is no next frame,
+              a null value should be given.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               time_period
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan_frame.time_rstrt_incr
+
+    _definition.id                '_diffrn_scan_frame.time_rstrt_incr'
+    _description.text
+;             The time in seconds between the end of integration of this step of the scan
+              and the start of integration of the next step.
+
+              The sum of the values of _diffrn_scan_frame.integration_time
+              and  _diffrn_scan_frame.time_rstrt_incr is the
+              time from the start of integration of one frame and the start of
+              integration for the next frame and should equal the value of
+              _diffrn_scan_frame.time_period for this
+              frame.   The value of _diffrn_scan.time_rstrt_incr will be
+              representative of the ensemble of values of
+              _diffrn_scan_frame.time_rstrt_incr (e.g.
+              the mean).
+
+              If there is no next frame, a null value should be given.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               time_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan_frame.variant
+
+    _definition.id                '_diffrn_scan_frame.variant'
+    _description.text
+;             The value of _diffrn_scan_frame.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME_AXIS
+
+    _definition.id                diffrn_scan_frame_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME_AXIS category describe the
+     settings of axes for particular frames.  Unspecified axes are
+     assumed to be at their zero points.  If, for any given frame,
+     nonzero values apply for any of the data items in this category,
+     those values should be given explicitly in this category and not
+     simply inferred from values in DIFFRN_SCAN_AXIS.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan_frame_axis
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame_axis.frame_id'
+         '_diffrn_scan_frame_axis.axis_id'
+         '_diffrn_scan_frame_axis.variant'
+
+    _nx_mapping.details
+;    _diffrn_scan_frame_axis.axis_id AXISID
+    _diffrn_scan_frame_axis.angle ANGLE
+    _diffrn_scan_frame_axis.angle_increment ANGLEINCREMENT
+    _diffrn_scan_frame_axis.angle_rstrt_incr ANGLERSTRTINCREMENT
+    _diffrn_scan_frame_axis.displacement DISP 
+    _diffrn_scan_frame_axis.displacement_increment DISPINCREMENT
+    _diffrn_scan_frame_axis.displacement_rstrt_incr DISPRSTRTINCREMENT
+    _diffrn_scan_frame_axis.reference_angle REFANGLE
+    _diffrn_scan_frame_axis.reference_displacement REFDISP
+    { /entry:NXentry
+      /CBF_scan_id="SCANID"
+      /instrument:NXinstrument
+       /DETECTORNAME:NXdetector_group
+       /DETECTORELEMENTNAME:NXdetector
+    for AXISEQUIPMENT=="detector"}
+    {  /entry:NXentry
+         /sample:NXsample
+    for AXISEQUIPMENT=="goniometer"}
+    {  /entry:NXentry
+    for AXISEQUIPMENT=="general"}
+         /transformations:NXtransformations
+           /AXISID=[]
+             @diffrn_scan_frame_axis__angle_start=[ANGSTART]
+             @diffrn_scan_frame_axis__angle_range=[ANGRANGE]
+             @diffrn_scan_frame_axis__angle_increment=[ANGINC]
+             @diffrn_scan_frame_axis__angle_rstrt_incr=[ANGRSTRT]
+             @diffrn_scan_frame_axis__displacement_start=[DISPSTART]
+             @diffrn_scan_frame_axis__displacement_range=[DISPRANGE]
+             @diffrn_scan_frame_axis__displacement_increment=[DISPINC]
+             @diffrn_scan_frame_axis__displacement_rstrt_incr=[DISPRSTRT]
+             @diffrn_scan_frame_axis__reference_angle=[ANG]
+             @diffrn_scan_frame_axis__reference_displacement=[DISP]
+    note that @units="mm" or @units="deg" should also be specified.
+
+    The dimensions of the array depend on np (the number of frames = the
+    value of _diffrn_scan.frames)
+
+    either DISP OR ANGLE is inserted as the i-th element
+    counting from 1 in AXISID where i is the value of
+    _diffrn_scan_frame.frame_number for which the value
+    of _diffrn_scan_frame.frame_id agrees with the
+    value of _diffrn_scan_frame_axis.frame_id
+
+    The remaining tags similarly populate the attribute arrays
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan_frame_axis.angle
+
+    _definition.id                '_diffrn_scan_frame_axis.angle'
+    _description.text
+;             The setting of the specified axis in degrees for this frame.
+              This is the setting at the start of the integration time.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               angle
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_frame_axis.angle_increment
+
+    _definition.id                '_diffrn_scan_frame_axis.angle_increment'
+    _description.text
+;             The increment for this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle and
+              _diffrn_scan_frame_axis.angle_increment is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               angle_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_frame_axis.angle_rstrt_incr
+
+    _definition.id                '_diffrn_scan_frame_axis.angle_rstrt_incr'
+    _description.text
+;             The increment after this frame for the angular setting of
+              the specified axis in degrees.  The sum of the values
+              of _diffrn_scan_frame_axis.angle,
+              _diffrn_scan_frame_axis.angle_increment and
+              _diffrn_scan_frame_axis.angle_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.angle for this next frame.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               angle_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_frame_axis.axis_id
+
+    _definition.id                '_diffrn_scan_frame_axis.axis_id'
+    _description.text
+;             The value of this data item is the identifier of one of
+              the axes for the frame for which settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
+
+              This item is a pointer to _axis.id in the
+              AXIS category.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               axis_id
+    _name.linked_item_id          '_axis.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_axis.diffrn_id
+
+    _definition.id                '_diffrn_scan_frame_axis.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_axis.displacement
+
+    _definition.id                '_diffrn_scan_frame_axis.displacement'
+    _description.text
+;             The setting of the specified axis in millimetres for this
+              frame.  This is the setting at the start of the integration
+              time.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               displacement
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_frame_axis.displacement_increment
+
+    _definition.id
+        '_diffrn_scan_frame_axis.displacement_increment'
+    _description.text
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement and
+              _diffrn_scan_frame_axis.displacement_increment is the
+              angular setting of the axis at the end of the integration
+              time for this frame.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               displacement_increment
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_frame_axis.displacement_rstrt_incr
+
+    _definition.id
+        '_diffrn_scan_frame_axis.displacement_rstrt_incr'
+    _description.text
+;             The increment for this frame for the displacement setting of
+              the specified axis in millimetres.  The sum of the values
+              of _diffrn_scan_frame_axis.displacement,
+              _diffrn_scan_frame_axis.displacement_increment and
+              _diffrn_scan_frame_axis.displacement_rstrt_incr is the
+              angular setting of the axis at the start of the integration
+              time for the next frame and should equal
+              _diffrn_scan_frame_axis.displacement for this next frame.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               displacement_rstrt_incr
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _enumeration.default          0.0
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_frame_axis.frame_id
+
+    _definition.id                '_diffrn_scan_frame_axis.frame_id'
+    _description.text
+;             The value of this data item is the identifier of the
+              frame for which axis settings are being specified.
+
+              Multiple axes may be specified for the same value of
+              _diffrn_scan_frame.frame_id.
+
+              This item is a pointer to _diffrn_data_frame.id in the
+              DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               frame_id
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_axis.reference_angle
+
+    _definition.id                '_diffrn_scan_frame_axis.reference_angle'
+    _description.text
+;             The setting of the specified axis in degrees
+              against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be zero.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               reference_angle
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              degrees
+    _enumeration.default          0.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_scan_frame_axis.reference_displacement
+
+    _definition.id
+        '_diffrn_scan_frame_axis.reference_displacement'
+    _description.text
+;             The setting of the specified axis in millimetres for this
+              frame against which measurements of the reference beam centre
+              and reference detector distance should be made.
+
+              This is normally the same for all frames, but the
+              option is provided here of making changes when
+              needed.
+
+              If not provided, it is assumed to be equal to
+              _diffrn_scan_frame_axis.displacement.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               reference_displacement
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              millimetres
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_scan_frame_axis.variant
+
+    _definition.id                '_diffrn_scan_frame_axis.variant'
+    _description.text
+;             The value of _diffrn_scan_frame_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME_MONITOR
+
+    _definition.id                diffrn_scan_frame_monitor
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME_MONITOR category record
+     the values and details about each monitor for each frame of data
+     during a scan.
+
+     Each monitor value is uniquely identified by the combination of
+     the scan id given by _diffrn_scan_frame.scan_id,
+     the frame id given by _diffrn_scan_frame_monitor.frame_id,
+     the monitor's detector id given by
+     _diffrn_scan_frame_monitor.detector_id,
+     and a 1-based ordinal given by _diffrn_scan_frame_monitor.id.
+
+     If there is only one frame for the scan, the value of
+     _diffrn_scan_frame_monitor.frame_id may be omitted.
+
+     A single frame may have more than one monitor value, and each
+     monitor value may be the result of integration over the entire
+     frame integration time given by the value of
+     _diffrn_scan_frame.integration_time,
+     or many monitor values may be reported over shorter times given
+     by the value of _diffrn_scan_frame_monitor.integration_time.  If
+     only one monitor value for a given monitor is collected during
+     the integration time of the frame, the value of
+     _diffrn_scan_frame_monitor.id may be
+     omitted.
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_scan_frame_monitor
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame_monitor.id'
+         '_diffrn_scan_frame_monitor.detector_id'
+         '_diffrn_scan_frame_monitor.scan_id'
+         '_diffrn_scan_frame_monitor.frame_id'
+         '_diffrn_scan_frame_monitor.variant'
+
+    _description_example.case
+;     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+      P6MB BSM01 'metal foil and PIN diode' 1
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+      BSM01 MONITOR_Z
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+      SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_MONITOR
+     loop_
+     _diffrn_scan_frame_monitor.id
+     _diffrn_scan_frame_monitor.detector_id
+     _diffrn_scan_frame_monitor.scan_id
+     _diffrn_scan_frame_monitor.frame_id
+     _diffrn_scan_frame_monitor.integration_time
+     _diffrn_scan_frame_monitor.monitor_value
+      1  BSM01 SCAN1 FRAME1 2.0 23838345642
+      2  BSM01 SCAN1 FRAME1 2.0 23843170669
+      3  BSM01 SCAN1 FRAME1 2.0 23839478690
+      4  BSM01 SCAN1 FRAME1 2.0 23856642085
+      5  BSM01 SCAN1 FRAME1 2.0 23781717656
+      6  BSM01 SCAN1 FRAME1 2.0 23788850775
+      7  BSM01 SCAN1 FRAME1 2.0 23815576677
+      8  BSM01 SCAN1 FRAME1 2.0 23789299964
+      9  BSM01 SCAN1 FRAME1 2.0 23830195536
+      10 BSM01 SCAN1 FRAME1 2.0 23673082270
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+      FRAME1 MONITOR_Z 0.0 -220.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+      MONITOR_Z        translation detector . 0 0 1 0 0 0
+;
+    _description_example.detail
+;
+    Example 1. The beam intensity for frame FRAME1 is being tracked
+     by a beamstop monitor detector BSM01, made from metal foil and
+     a PIN diode, located 20 mm in front of a MAR345 detector and being
+     sampled every 2 seconds in a 20 second scan.
+;
+    _nx_mapping.details
+;    _diffrn_scan_frame_monitor.id MONID -->
+    _diffrn_scan_frame_monitor.detector_id DETECTORNAME -->
+    _diffrn_scan_frame_monitor.scan_id SCANID -->
+    _diffrn_scan_frame_monitor.frame_id FRAMEID -->
+    _diffrn_scan_frame_monitor.integration_time INTEGRATIONTIME -->
+    _diffrn_scan_frame_monitor.monitor_value MONITORVALUE -->
+
+    -->
+
+    /entry:NXentry
+      /CBF_scan_id="SCANID"
+        /instrument:NXinstrument
+          /CBF_diffrn_scan_frame_monitor__DETECTORNAME_MONID:NXmonitor
+            @CBF_detector_id="DETECTORNAME"
+            @CBF_diffrn_scan_frame_monitor__id="MONID"
+            /data=[MONITORVALUE]  
+            /count_time=[INTEGRATIONTIME] 
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_scan_frame_monitor.detector_id
+
+    _definition.id                '_diffrn_scan_frame_monitor.detector_id'
+    _description.text
+;             This data item is a pointer to _diffrn_detector.id in
+              the DIFFRN_DETECTOR category.
+
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               detector_id
+    _name.linked_item_id          '_diffrn_detector.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_monitor.diffrn_id
+
+    _definition.id                '_diffrn_scan_frame_monitor.diffrn_id'
+    _description.text
+;             This data item is a pointer to '_diffrn.id' in
+              the DIFFRN category.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_monitor.frame_id
+
+    _definition.id                '_diffrn_scan_frame_monitor.frame_id'
+    _description.text
+;             This item is a pointer to _diffrn_data_frame.id
+              in the DIFFRN_DATA_FRAME category.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               frame_id
+    _name.linked_item_id          '_diffrn_data_frame.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_monitor.id
+
+    _definition.id                '_diffrn_scan_frame_monitor.id'
+    _description.text
+;             This item is an integer identifier which, along with
+              _diffrn_scan_frame_monitor.detector_id,
+              _diffrn_scan_frame_monitor.scan_id, and
+              _diffrn_scan_frame_monitor.frame_id
+              should uniquely identify the monitor value being recorded.
+
+              If _array_data.binary_id is not explicitly given,
+              it defaults to 1.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _enumeration.range            1:
+    _enumeration.default          1
+    _units.code                   none
+
+    loop_
+      _ddl2_enumeration_range.minimum
+      _ddl2_enumeration_range.maximum
+         1                        1
+         1                        .
+
+save_
+
+save_diffrn_scan_frame_monitor.integration_time
+
+    _definition.id                '_diffrn_scan_frame_monitor.integration_time'
+    _description.text
+;             The precise time for integration of the monitor value given in
+              _diffrn_scan_frame_monitor.monitor_value
+              must be given in _diffrn_scan_frame_monitor.integration_time.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               integration_time
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _type.ddl2_units              seconds
+    _units.code                   seconds
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan_frame_monitor.monitor_value
+
+    _definition.id                '_diffrn_scan_frame_monitor.monitor_value'
+    _alias.definition_id          '_diffrn_scan_frame_monitor.value'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           1.8.2
+    _alias.dictionary_uri         cif_img.dic
+    _description.text
+;             The value reported by the monitor detector should be given in
+              _diffrn_scan_frame_monitor.monitor_value.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when
+              available, all digits of the  monitor should be recorded.
+
+              For convenience in automated validation, the deprecated
+              _diffrn_scan_frame_monitor.monitor_value
+              is given as an alias, but should be avoided for new data sets.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               monitor_value
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+
+save_
+
+save_diffrn_scan_frame_monitor.scan_id
+
+    _definition.id                '_diffrn_scan_frame_monitor.scan_id'
+    _description.text
+;             This item is a pointer to _diffrn_scan.id in
+              the DIFFRN_SCAN category.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               scan_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_diffrn_scan_frame_monitor.value
+
+    _definition.id                '_diffrn_scan_frame_monitor.value'
+    _description.text
+;             This is a deprecated version of
+              _diffrn_scan_frame_monitor.monitor_value.
+
+              The value is typed as float to allow of monitors for very
+              intense beams that cannot report all digits, but when available,
+              all digits of the monitor should be recorded.
+
+              DEPRECATED -- DO NOT USE
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               value
+    _name.ddl2_mandatory          no
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _type.ddl2_code               float
+    _units.code                   none
+    _ddl2_enumeration_range.minimum 0.0
+    _ddl2_enumeration_range.maximum .
+    _ddl2_item_related.related_name '_diffrn_scan_frame_monitor.monitor_value'
+    _ddl2_item_related.function_code replacedby
+
+save_
+
+save_diffrn_scan_frame_monitor.variant
+
+    _definition.id                '_diffrn_scan_frame_monitor.variant'
+    _description.text
+;             The value of _diffrn_scan_frame_monitor.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SOURCE
+
+    _definition.id                diffrn_source
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-09-16
+    _description.text
+;              Data items in the DIFFRN_SOURCE category record details of
+               the source of radiation used in the diffraction experiment.
+
+               This is a stub category for use of DIFFRN_SOURCE which is
+               specified in the mmCIF_PDBx dictionary
+;
+    _name.category_id             HEAD
+    _name.object_id               diffrn_source
+    _name.ddl2_mandatory          no
+    _category_key.name            '_diffrn_source.diffrn_id'
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         diffrn_group
+
+save_
+
+save_diffrn_source.diffrn_id
+
+    _definition.id                '_diffrn_source.diffrn_id'
+    _alias.definition_id          '_diffrn_source.diffrn_id'
+    _alias.deprecation_date       .
+    _alias.ddl2_version           5.384
+    _alias.dictionary_uri         mmcif_pdbx.dic
+    _description.text
+;              This data item is a pointer to _diffrn.id in the DIFFRN
+               category.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_source.source
+
+    _definition.id                '_diffrn_source.source'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_source.source'           .        5.384        mmcif_pdbx.dic
+         '_diffrn_radiation_source'        .        1.0          cifdic.c91
+         '_diffrn_source'                  .        2.0          cif_core.dic
+
+    _description.text
+;              The general class of the radiation source.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               source
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'sealed X-ray tube'
+         'nuclear reactor'
+         'spallation source'
+         'electron microscope'
+         'rotating-anode X-ray tube'
+         'synchrotron'
+
+save_
+
+save_diffrn_source.type
+
+    _definition.id                '_diffrn_source.type'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+      _alias.ddl2_version
+      _alias.dictionary_uri
+         '_diffrn_source.type'         .         5.384         mmcif_pdbx.dic
+         '_diffrn_source_type'         .         2.0.1         cif_core.dic
+
+    _description.text
+;              The make, model or name of the source of radiation.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               type
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+
+    loop_
+      _description_example.case
+         'NSLS beamline X8C'
+         'Rigaku RU200'
+
+save_
+
+save_MAP
+
+    _definition.id                map
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the MAP category record
+     the details of maps. Maps record values of parameters,
+     such as density, that are functions of position within
+     a cell or are functions of orthogonal coordinates in
+     three space.
+
+     A map is composed of one or more map segments
+     specified in the MAP_SEGMENT category.
+
+     Examples are given in the MAP_SEGMENT category.
+;
+    _name.category_id             HEAD
+    _name.object_id               map
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_map.id'
+         '_map.diffrn_id'
+         '_map.entry_id'
+         '_map.variant'
+
+    _description_example.case
+;        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+   ;
+        density calculated from F_calc derived from the ATOM_SITE
+        list
+   ;
+        rho_obs
+   ;
+        density combining the observed structure factors with the
+        calculated phases
+   ;
+;
+    _description_example.detail
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         map_group
+
+save_
+
+save_map.details
+
+    _definition.id                '_map.details'
+    _description.text
+;              The value of _map.details should give a
+               description of special aspects of each map.
+
+;
+    _name.category_id             map
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+;   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+    _description_example.detail
+;        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+    ;
+        density calculated from F_calc derived from the ATOM_SITE list
+    ;
+        rho_obs
+    ;
+        density combining the observed structure factors with the
+        calculated phases
+    ;
+;
+
+save_
+
+save_map.diffrn_id
+
+    _definition.id                '_map.diffrn_id'
+    _description.text
+;             This item is a pointer to _diffrn.id in the
+              DIFFRN category.
+;
+    _name.category_id             map
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map.entry_id
+
+    _definition.id                '_map.entry_id'
+    _description.text
+;             This item is a pointer to _entry.id in the
+              ENTRY category.
+;
+    _name.category_id             map
+    _name.object_id               entry_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map.id
+
+    _definition.id                '_map.id'
+    _description.text
+;             The value of _map.id must uniquely identify
+              each map for the given '_diffrn.id' or entry.id.
+;
+    _name.category_id             map
+    _name.object_id               id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map.variant
+
+    _definition.id                '_map.variant'
+    _description.text
+;             The value of _map.variant gives the variant
+              to which the given map row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             map
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_MAP_SEGMENT
+
+    _definition.id                map_segment
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the MAP_SEGMENT category record
+     the details about each segment (section or brick) of a map.
+;
+    _name.category_id             HEAD
+    _name.object_id               map_segment
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_map_segment.id'
+         '_map_segment.map_id'
+         '_map_segment.variant'
+
+    _description_example.case
+;        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+     ;
+        density calculated from F_calc derived from the ATOM_SITE list
+     ;
+        rho_obs
+     ;
+        density combining the observed structure factors with the
+        calculated phases
+     ;
+
+        loop_
+        _map_segment.map_id
+        _map_segment.id
+        _map_segment.array_id
+        _map_segment.binary_id
+        _map_segment.mask_array_id
+        _map_segment.mask_binary_id
+        rho_calc rho_calc map_structure 1 mask_structure 1
+        rho_obs  rho_obs  map_structure 2 mask_structure 1
+;
+    _description_example.detail
+;   Example 1. Identifying an observed density map
+                and a calculated density map, each consisting of one
+                segment, both using the same array structure
+                and mask.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         array_data_group
+         map_group
+
+save_
+
+save_map_segment.array_id
+
+    _definition.id                '_map_segment.array_id'
+    _description.text
+;             The value of _map_segment.array_id identifies the array 
+              structure into which the map is organized.
+
+              This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             map_segment
+    _name.object_id               array_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.array_section_id
+
+    _definition.id                '_map_segment.array_section_id'
+    _description.text
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
+;
+    _name.category_id             map_segment
+    _name.object_id               array_section_id
+    _name.linked_item_id          '_array_structure_list_section.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.binary_id
+
+    _definition.id                '_map_segment.binary_id'
+    _description.text
+;             The value of _map_segment.binary_id distinguishes the particular 
+              set of data organized according to _map_segment.array_id in 
+              which the data values of the map are stored.
+
+              This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
+;
+    _name.category_id             map_segment
+    _name.object_id               binary_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _units.code                   none
+
+save_
+
+save_map_segment.details
+
+    _definition.id                '_map_segment.details'
+    _description.text
+;             The value of _map_segment.details should give a
+              description of special aspects of each segment of a map.
+;
+    _name.category_id             map_segment
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case     'Example to be provided'
+    _description_example.detail
+;
+    . . .
+;
+
+save_
+
+save_map_segment.id
+
+    _definition.id                '_map_segment.id'
+    _description.text
+;             The value of _map_segment.id must uniquely
+              identify each segment of a map.
+;
+    _name.category_id             map_segment
+    _name.object_id               id
+    _name.linked_item_id          '_map.id'
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.map_id
+
+    _definition.id                '_map_segment.map_id'
+    _description.text
+;             This item is a pointer to _map.id
+              in the MAP category.
+;
+    _name.category_id             map_segment
+    _name.object_id               map_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.mask_array_id
+
+    _definition.id                '_map_segment.mask_array_id'
+    _description.text
+;             The value of _map_segment.mask_array_id, if given, describes
+              the array structure into which the mask for the map is
+              organized.  If no value is given, then all elements of
+              the map are valid.  If a value is given, then only
+              elements of the map for which the corresponding element
+              of the mask is non-zero are valid.  The value of
+              _map_segment.mask_array_id differs from the value of
+              _map_segment.array_id in order to permit the mask to be
+              given as, say, unsigned 8-bit integers, while the map is
+              given as a data type with more range.  However, the two
+              array structures must be aligned, using the same axes in
+              the same order with the same displacements and
+              increments.
+
+              This item is a pointer to _array_structure.id in the
+              ARRAY_STRUCTURE category.
+;
+    _name.category_id             map_segment
+    _name.object_id               mask_array_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.mask_array_section_id
+
+    _definition.id                '_map_segment.mask_array_section_id'
+    _description.text
+;             This item is a pointer to _array_structure_list_section.id
+              in the ARRAY_STRUCTURE_LIST_SECTION category.
+;
+    _name.category_id             map_segment
+    _name.object_id               mask_array_section_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_map_segment.mask_binary_id
+
+    _definition.id                '_map_segment.mask_binary_id'
+    _description.text
+;             The value of _map_segment.mask_binary_id identifies the 
+              particular set of data organized according to 
+              _map_segment.mask_array_id specifying the mask for the map.
+
+              This item is a pointer to _array_data.binary_id in the
+              ARRAY_DATA category.
+;
+    _name.category_id             map_segment
+    _name.object_id               mask_binary_id
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _type.ddl2_code               int
+    _units.code                   none
+
+save_
+
+save_map_segment.variant
+
+    _definition.id                '_map_segment.variant'
+    _description.text
+;             The value of _map_segment.variant gives the variant
+              to which the given map segment is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             map_segment
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_VARIANT
+
+    _definition.id                variant
+    _definition.scope             Category
+    _definition.class             Loop
+    _description.text
+;
+    Data items in the VARIANT category record
+     the details about sets of variants of data items.
+
+     There is sometimes a need to allow for multiple versions of the
+     same data items in order to allow for refinements and corrections
+     to earlier assumptions, observations and calculations.  In order
+     to allow data sets to contain more than one variant of the same
+     information, an optional *.variant data item as a pointer to
+     _variant.variant has been added to the key of every category,
+     as an implicit data item with a null (empty) default value.
+
+     All rows in a category with the same variant value are considered
+     to be related to one another and to all rows in other categories
+     with the same variant value.  For a given variant, all such rows
+     are also considered to be related to all rows with a null variant
+     value, except that a row with a null variant value for which all
+     other components of its key are identical to those entries in
+     another row with a non-null variant value is not related the
+     the rows with that non-null variant value.  This behaviour is
+     similar to the convention for identifying alternate conformers
+     in an atom list.
+
+     An optional role may be specified for a variant as the value of
+     _variant.role.  Possible roles are null, 'preferred',
+     'raw data', 'unsuccessful trial'.
+
+     variants may carry an optional timestamp as the value of
+     _variant.timestamp.
+
+     variants may be related to other variants from which they were
+     derived by the value of _variant.variant_of.
+
+     Further details about the variant may be specified as the value
+     of _variant.details.
+
+     In order to allow variant information from multiple datasets to
+     be combined, _variant.diffrn_id and/or _variant.entry_id may
+     be used.
+;
+    _name.category_id             HEAD
+    _name.object_id               variant
+    _name.ddl2_mandatory          no
+
+    loop_
+      _category_key.name
+         '_variant.variant'
+         '_variant.diffrn_id'
+         '_variant.entry_id'
+
+    _description_example.case
+;        loop_
+        _variant.variant
+        _variant.role
+        _variant.timestamp
+        _variant.variant_of
+        _variant.details
+            . "raw data" 2007-08-03T23:20:00 . .
+            indexed "preferred" 2007-08-04T01:17:28 .
+              "indexed cell and refined beam centre"
+
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        _diffrn_detector_element.variant
+        d1     d1_ccd_1  201.5 201.5  mm  .
+        d1     d1_ccd_2  -1.8  201.5  mm  .
+        d1     d1_ccd_3  201.6  -1.4  mm  .
+        d1     d1_ccd_4  -1.7   -1.5  mm  .
+        d1     d1_ccd_1  201.3 201.6  mm  indexed
+        d1     d1_ccd_2  -2.0  201.6  mm  indexed
+        d1     d1_ccd_3  201.3  -1.5  mm  indexed
+        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
+;
+    _description_example.detail
+;   Example 1. Distinguishing between a raw beam centre and a refined beam
+       centre inferred after indexing.  Detector d1 is composed of
+       four CCD detector elements, each 200 mm by 200 mm, arranged
+       in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+       Note that the beam centre is slightly displaced from each of the
+       detector elements, just beyond the lower right corner of 1,
+       the lower left corner of 2, the upper right corner of 3 and
+       the upper left corner of 4.  For each element, the detector
+       face coordinate system is assumed to have the fast axis
+       running from left to right and the slow axis running from
+       top to bottom with the origin at the top left corner.
+
+       After indexing and refinement, the centre is shifted by 0.2 mm
+       left and 0.1 mm down.
+;
+
+    loop_
+      _ddl2_category_group.id
+         inclusive_group
+         variant_group
+
+save_
+
+save_variant.details
+
+    _definition.id                '_variant.details'
+    _description.text
+;             A description of special aspects of the variant.
+;
+    _name.category_id             variant
+    _name.object_id               details
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               text
+    _description_example.case
+        'indexed cell and refined beam centre'
+
+save_
+
+save_variant.diffrn_id
+
+    _definition.id                '_variant.diffrn_id'
+    _description.text
+;             This item is a pointer to _diffrn.id in the
+              diffrn category.
+;
+    _name.category_id             variant
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_variant.entry_id
+
+    _definition.id                '_variant.entry_id'
+    _description.text
+;             This item is a pointer to _entry.id in the
+              entry category
+;
+    _name.category_id             variant
+    _name.object_id               entry_id
+    _name.ddl2_mandatory          yes
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+save_variant.role
+
+    _definition.id                '_variant.role'
+    _description.text
+;             The value of _variant.role  specified a role
+              for this variant.  Possible roles are null, 'preferred',
+              'raw data', and 'unsuccessful trial'.
+
+              A null value for _variant.role leaves the
+              precise role of the variant unspecified.  No inference should
+              be made that the variant with the latest time stamp is
+              preferred.
+;
+    _name.category_id             variant
+    _name.object_id               role
+    _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               uline
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         'preferred'
+;    A value of 'preferred' indicates that rows of any categories specifying
+     this variant should be used in preference to rows with the same key
+     specifying other variants or the null variant.  It is an error to specify
+     two variants that appear in the same category with the same key as being
+     preferred, but it is not an error to specify more than one variant as
+     preferred in other cases.
+;
+         'raw data'
+;    A value of 'raw data' indicates data prior to any corrections, 
+     calculations or refinements.  It is not necessarily an error for raw data
+     also to be a variant of an earlier variant.  It may be replacement raw 
+     data for earlier data believed to be erroneous.
+;
+         'unsuccessful trial'
+;    A value of 'unsuccessful trial' indicates data that should not be used
+     for further calculation.
+;
+
+save_
+
+save_variant.timestamp
+
+    _definition.id                '_variant.timestamp'
+    _description.text
+;             The date and time identifying a variant.  This is not 
+              necessarily the precise time of the measurement or calculation
+              of the individual related data items, but a timestamp that 
+              reflects the order in which the variants were defined.
+;
+    _name.category_id             variant
+    _name.object_id               timestamp
+    _name.ddl2_mandatory          no
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _type.ddl2_code               yyyy-mm-dd
+
+save_
+
+save_variant.variant
+
+    _definition.id                '_variant.variant'
+    _description.text
+;             The value of _variant.variant must uniquely identify
+              each variant for the given diffraction experiment and/or entry
+
+              This item has been made implicit and given a default value of 
+              null.
+;
+    _name.category_id             variant
+    _name.object_id               variant
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+    _enumeration.default          .
+
+save_
+
+save_variant.variant_of
+
+    _definition.id                '_variant.variant_of'
+    _description.text
+;            The value of _variant.variant_of gives the variant
+             from which this variant was derived.  If this value is not given,
+             the variant is assumed to be derived from the default null 
+             variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             variant
+    _name.object_id               variant_of
+    _name.ddl2_mandatory          implicit
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
+
+save_
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.8.9                    2025-09-16
+;   Addition of missing diffrn.id pointers
+
+    + Add _diffrn_detector_element.diffrn_id
+    + Add _diffrn_measurement_axis.diffrn_id
+    + Add _diffrn_scan.diffrn_id
+    + Add _diffrn_scan_axis.diffrn_id
+    + Add _diffrn_scan_collection.diffrn_id
+    + Add _diffrn_scan_frame.diffrn_id
+    + Add _diffrn_scan_frame_axis.diffrn_id
+    + Add _diffrn_scan_frame_axis.diffrn_id
+    + Add _diffrn_scan_frame_monitor.diffrn_id
+     (DDLm conversion) Specified Set categories ["diffrn_radiation", "diffrn_measurement", "diffrn_detector", "diffrn", "diffrn_source"]
+
+;
+         1.8.8.2                  2025-06-10
+;
+       Pick up minor type corrections from 1.8.9 dcitionary
+;
+         1.8.8.1                  2025-05-25
+;
+       Minor corrections to 1.8.8 found while working on 1.8.9
+;
+         1.8.8                    2024-01-20
+;   Additional flux tags and change to ddl2 version being the master
+    instead of the html version being the master.  Make changes to
+    support conversions to DDLm and back to DDL2.  Mark tags aliased
+    from mmCIF_PDBx dictionary.
+
+    + Change from use of _item.type_code to _item_type.code
+    + Fix extraneous single quote after _array_data_external_data.file_compression
+    + Change 'photons per second' to photons_per_second in units
+    + Add micrometres, photons, photons_per_second, and 
+      photons_per_seconf_per_micrometre_squared to units
+    + Add stub DIFFRN category
+    + Add _diffrn.id
+    + Add  _diffrn_radiation.beam_flux_density
+    + Add _diffrn_radiation.beam_flux_density_integrated
+    + Add  _diffrn_radiation.beam_flux_integrated
+    + Add _diffrn_radiation.beam_flux_integration_time
+    + Add _diffrn_radiation.beam_incident_flux
+    + Add _diffrn_radiation.beam_incident_flux_integrated
+    + Add stub DIFFRN_SOURCE category
+    + Add _diffrn_source.diffrn_id
+    + Add _diffrn_source.source
+    + Add _diffrn_source.type
+;
+         1.8.7                    2023-01-26
+;   Various additions
+
+    + Add _array_data_external_data.file_compression
+      2022-06-09 (jrh).
+    + Fix incorrect _diffrn_scan_axis.angle_range
+      example and clarify definition 2022-06-09 (jrh)
+    + Clarify wording describing _array_intensities.overload 
+      2022-12-31 (ab) 
+;
+         1.8.6                    2022-05-11
+;
+       Add missing archive tags to external data tags, clarify use of
+        those tags and correct typos (jrh, hjb)
+
+        + Add _array_data_external_data.archive_format
+        + Add _array_data_external_data.archive_path
+;
+         1.8.5                    2021-07-09
+;
+       Handling of external data (jrh, ab, hjb)
+
+        + Remove preliminary versions of external data tags in ARRAY_DATA
+        + Add ARRAY_DATA_EXTERNAL_DATA
+        + Add _array_data.external_data_id
+        + Add _array_data_external_data.format
+        + Add _array_data_external_data.frame
+        + Add _array_data_external_data.id
+        + Add _array_data_external_data.path
+        + Add _array_data_external_data.uri
+        + Add _array_data_external_data.variant
+        + Add _array_data_external_data.version
+;
+         1.8.4                    2021-04-15
+;   Copy-editing refinements (bm)
+
+    + Add _item_related.related_name and
+      "_item_related.function_code replacedby" to deprecated items.
+    + Add "_item_default.value  ." to *_variant items
+    + Change uses of \%Angstroms to \%angstr\"oms
+    + Change category save frames to upper case names
+    + Fix misssing superscript terminating ^
+
+    Preliminary version of external data tags (jrh)
+
+    + Add _array_data.external_format
+    + Add _array_data.external_version
+    + Add _array_data.external_location_uri
+    + Add _array_data.external_path
+    + Add _array_data.external_frame
+    + Add _array_data.external_archive_path
+    + Add _array_data.external_archive_format
+
+    Note the second block of mads is a preliminary version.  When they are
+    done they may well be removed from here and reappear in a 1.8.5
+    dictionary.
+
+;
+         1.8.3                    2021-02-28
+;   Correction as per Brian McMahon
+
+    + Fix _item.name for _array_structure_list.array_section_id
+    + Remove spurious _item_aliases.alias_name from
+      _diffrn_radiation.polarisn_ratio_esd
+    + Remove spurious reference to _diffrn_scan_frame.time_rstrt_incr
+    + Provide missing _diffrn_scan_frame_monitor.monitor_value definition
+    + Deprecate _diffrn_scan_frame_monitor.value
+;
+         1.8.2                    2021-02-21
+;
+       Corrections and additions for ITVG 2021
+
+        + Add McStas as an axis coordinate system
+        + Add _array_intensities.underload as optional
+        + Add _diffrn_scan_collection.details as optional
+        + Add _diffrn_scan_collection.variant as optional
+;
+         1.8.1                    2021-01-30
+;
+       Copy-paste error corrections (JRH)
+
+        + Fix double underscore in _diffrn_data_frame.center_derived
+        + Fix wrong _item.name in _diffrn_scan.date_end_estimated
+        + Fix wrong _item.mandatory_code in _diffrn_scan_frame_monitor.frame_id
+        + Fix wrong _item.mandatory_code in _variant.variant_of
+;
+         1.8.0                    2021-01-24
+;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+
+    + Add _diffrn_data_frame.center_derived as optional
+    + Add _diffrn_measurement.sample_detector_distance_derived as optional
+    + Change _diffrn_scan.date_start to mandatory
+    + Add _diffrn_scan.date_end_estimated as mandatory
+    + Fix .array_id and .binary_id columns to be implicit in all cases to
+      facilitate mini_cbfs
+
+;
+         1.7.11                   2018-12-03
+;
+       Changes for CBFlib 0.9.6 release (HJB)
+
+        + Remove _array_structure_list.array_section_id
+        + Revisions to _category.NX_mapping_details in most categories for
+        array sections.
+        + Change to uniform use of entry:NXentry
+        + Change to uniform use of identification of NXdetector by detector
+        element
+        + Change to uniform use of data_ARRAYID_BINARYID
+        + Add _array_structure_list.array_section_id
+        + Add _map_segment.mask_array_section_id
+        + Add _diffrn_scan_collection.scan_id
+        + Add _diffrn_scan_collection.type
+        + Add _diffrn_scan_collection.translation_width
+        + Add _diffrn_radiation.beam_width
+        + Add _diffrn_radiation.beam_height
+        + Add _diffrn_radiation.beam_flux
+;
+         1.7.10                   2014-04-25
+;
+       Additions of esd's to polarization tags.  Change to NeXus mapping to use
+        NXtransformations instead of NXpoise (HJB)
+
+         + Add _diffrn_radiation.polarisn_norm_esd,
+         _diffrn_radiation.polarisn_ratio_esd,
+         _diffrn_radiation.polarizn_source_norm_esd,
+         _diffrn_radiation.polarizn_source_ratio_esd,
+         _diffrn_radiation.polarizn_Stokes_I_esd,
+         _diffrn_radiation.polarizn_Stokes_Q_esd,
+         _diffrn_radiation.polarizn_Stokes_U_esd,
+         _diffrn_radiation.polarizn_Stokes_V_esd,
+         _diffrn_scan_frame.polarizn_Stokes_I_esd,
+         _diffrn_scan_frame.polarizn_Stokes_Q_esd,
+         _diffrn_scan_frame.polarizn_Stokes_U_esd,
+         _diffrn_scan_frame.polarizn_Stokes_V_esd.
+         + Change NeXus mapping for ARRAY_STRUCTURE_LIST
+         ARRAY_STRUCTURE_LIST_AXIS, AXIS,
+         DIFFRN_DETECTOR_AXIS, DIFFRN_MEASUREMENT_AXIS,
+         DIFFRN_SCAN_FRAME_AXIS.
+;
+         1.7.9                    2014-04-05
+;  Corrections to Stokes parameter description. (HJB)
+
+    + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
+    and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
+        component.
+
+    + Provide missing factor of 2 in _diffrn_radiation.polarizn_Stokes_V
+    description and _diffrn_scan_frame.polarizn_Stokes_V description.
+
+;
+         1.7.8                    2014-02-22
+;  Minor changes to NeXus mapping. (HJB)
+
+       + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
+       NXdetector base class terminology
+
+       + Add _diffrn_detector.gain_setting to handle
+       the reverse mapping from NeXus of the equivalent field in NXdetector.
+;
+         1.7.7                    2014-02-22
+;  Major changes to NeXus mapping to conform to JS functional
+    mapping prototype, add Stoke parameter tags for polarization
+    and beam intensity, and add an new tag for FEL axes (HJB)
+
+       + Add
+       _axis.equipment_component,
+       _diffrn_radiation.polarizn_Stokes_I,
+       _diffrn_radiation.polarizn_Stokes_Q,
+       _diffrn_radiation.polarizn_Stokes_U,
+       _diffrn_radiation.polarizn_Stokes_V,
+       _diffrn_scan_frame.polarizn_Stokes_I,
+       _diffrn_scan_frame.polarizn_Stokes_Q,
+       _diffrn_scan_frame.polarizn_Stokes_U,
+       _diffrn_scan_frame.polarizn_Stokes_V.
+       + Remove erroneous type code from _diffrn_scan_frame_monitor.value.
+       + Update dictionary version
+;
+         1.7.6                    2013-10-29
+;
+       To avoid a conflict with PDB software, remove the null value
+         enumeration for _variant.role (HJB)
+;
+         1.7.5                    2013-10-27
+;
+       At request of JW for the PDB move _category.NX_mapping_details
+        to be adjacent to other category tags. (HJB)
+;
+         1.7.4                    2013-10-23
+;
+       Minor cleanup and remove spurious tag
+
+         +  remove spurious _array_structure_list_section.array_set_id
+         references. (JS)
+         +  Change case of category names to conform to PDB conventions. (JW)
+;
+         1.7.3                    2013-10-15
+;  Major cleanup of dictionary typos, misplaced loops, etc
+       by John Westbrook
+
+    +  Change _item.mandatory_code of all *.variant to implicit
+    +  Add _diffrn_refln.id and _diffrn_refln.diffrn_id
+    +  Correct many _item.name values that were wrong or missing
+       quote marks
+
+;
+         1.7.2                    2013-10-07
+;  Add FEL detector positioning tags and change back to NXgoniometer
+
+    +  Add
+       _axis.rotation_axis and
+       _axis.rotation and
+    +  Change NXsample back to NXgoniometer
+
+;
+         1.7.1                    2013-08-10
+;  Minor cleanup (HJB)
+
+    +  Correction to description of
+         _diffrn_data_frame.array_section_id
+    +  Change NXgoniometer to NXsample
+    +  Fix typos in NeXus mappings
+
+;
+         1.7                      2013-06-18
+;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+
+    +  Define new ARRAY_STRUCTURE_LIST_SECTION category
+    +  Add new _category.NX_mapping_details DDL tag to carry
+       details on NeXus category mappings.
+    +  Define new tags _array_structure_list_section.array_id,
+       _array_structure_list_section.id,
+       _array_structure_list_section.index,
+       _array_structure_list_section.end,
+       _array_structure_list_section.start,
+       _array_structure_list_section.stride,
+       _array_structure_list_section.variant,
+       _diffrn_data_frame.array_section_id,
+       _diffrn_detector.layer_thickness,
+       _map_segment.array_section_id,
+       _map_segment.mask_array_section_id
+
+;
+         1.6.4                    2011-07-02
+;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+
+    +  Define new tags _diffrn_scan.time_period,
+       _diffrn_scan.time_rstrt_incr,
+       _diffrn_scan_frame.time_period,
+       _diffrn_scan_frame.time_rstrt_incr 
+    +  fix bad category name in loop in _diffrn_detector.id
+    +  remove stray text field terminator at line 4642
+    +  fix unquoted tag as a value in _diffrn_scan_frame_monitor.id
+    +  make formerly mandatory and implicit deprecated items non-mandatory
+
+;
+         1.6.3                    2010-08-26
+;
+       Cumulative corrections from 1.6.0, 1, 2 drafts (HJB)
+
+         +  Move descriptive dictionary comments into
+         _datablock.description with category tree described
+         +  add default _array_data.array_id value of 1
+         +  add option of CBF_BACKGROUND_OFFSET_DELTA compression
+         +  add VARIANT category and tags
+         +  add DIFFRN_SCAN_FRAME_MONITOR category
+;
+         1.5.4                    2007-07-28
+;  Typographics corrections (HJB)
+
+     + Corrected embedded degree characters to \%
+     + Corrected embedded Aring to \%A
+     + Added trailing ^ for a power
+     + Removed 2 cases of a space after an underscore
+       in tag name.
+;
+         1.5.3                    2007-07-08
+;  Changes to support SLS miniCBF and suggestions
+   from the 24 May 07 BNL imgCIF workshop (HJB)
+
+     + Added new data items
+       '_array_data.header_contents',
+       '_array_data.header_convention',
+       '_diffrn_data_frame.center_fast',
+       '_diffrn_data_frame.center_slow',
+       '_diffrn_data_frame.center_units',
+       '_diffrn_measurement.sample_detector_distance',
+       '_diffrn_measurement.sample_detector_voffset
+     + Deprecated data items
+       '_diffrn_detector_element.center[1]',
+       '_diffrn_detector_element.center[2]'
+     + Added comments and example on miniCBF
+     + Changed all array_id data items to implicit
+;
+         1.5.2                    2007-05-06
+;
+       Further clarifications of the coordinate system. (HJB)
+;
+         1.5.1                    2007-04-26
+;
+       Improve definition of X-axis to cover the case of no goniometer
+        and clean up more line folds (HJB)
+;
+         1.5                      2007-07-25
+;  This is a cumulative list of the changes proposed since the
+   imgCIF workshop in Hawaii in July 2006.  It is the result
+   of contributions by H. J. Bernstein, A. Hammersley,
+   J. Wright and W. Kabsch.
+
+   2007-02-19 Consolidated changes (edited by HJB)
+     + Added new data items
+       '_array_structure.compression_type_flag',
+       '_array_structure_list_axis.fract_displacement',
+       '_array_structure_list_axis.displacement_increment',
+       '_array_structure_list_axis.reference_angle',
+       '_array_structure_list_axis.reference_displacement',
+       '_axis.system',
+       '_diffrn_detector_element.reference_center_fast',
+       '_diffrn_detector_element.reference_center_slow',
+       '_diffrn_scan_axis.reference_angle',
+       '_diffrn_scan_axis.reference_displacement',
+       '_map.details', '_map.diffrn_id',
+       '_map.entry_id', '_map.id',
+       '_map_segment.array_id', '_map_segment.binary_id',
+       '_map_segment.mask_array_id', '_map_segment.mask_binary_id',
+       '_map_segment.id', '_map_segment.map_id',
+       '_map_segment.details.
+     + Change type of 
+       '_array_structure.byte_order' and
+       '_array_structure.compression_type'
+       to ucode to make these values case-insensitive
+     + Add values 'packed_v2' and 'byte_offset' to enumeration of values for
+       '_array_structure.compression_type'
+     + Add to definitions for the binary data type to handle new compression
+       types, maps, and a variety of new axis types.
+    2007-07-25 Cleanup of typos for formal release (HJB)
+     + Corrected text fields for reference_ tag descriptions that
+       were off by one column
+     + Fix typos in comments listing fract_ tags
+     + Changed name of release from 1.5_DRAFT to 1.5
+     + Fix unclosed text fields in various map definitions
+
+;
+         1.4                      2006-07-04
+;  This is a change to reintegrate all changes made in the course of
+   publication of ITVG, by the RCSB from April 2005 through
+   August 2008 and changes for the 2006 imgCIF workshop in
+   Hawaii.
+
+   2006-07-04 Consolidated changes for the 2006 imgCIF workshop (edited by HJB)
+     + Correct type of '_array_structure_list.direction' from 'int' to 'code'.
+     + Added new data items suggested by CN
+       '_diffrn_data_frame.details'
+       '_array_intensities.pixel_fast_bin_size',
+       '_array_intensities.pixel_slow_bin_size and
+       '_array_intensities.pixel_binning_method
+     + Added deprecated item for completeness
+       '_diffrn_frame_data.details'
+     + Added entry for missing item in contents list
+       '_array_structure_list_axis.displacement'
+     + Added new MIME type X-BASE32K based on work by VL, KM, GD, HJB
+     + Correct description of MIME boundary delimiter to start in
+       column 1.
+     + General cleanup of text fields to conform to changes for ITVG
+       by removing empty lines at start and finish of text field.
+     + Amend example for ARRAY_INTENSITIES to include binning.
+     + Add local copy of type specification (as 'code') for all children
+       of '_diffrn.id'.
+     + For consistency, change all references to 'pi' to '\p' and all
+       references to 'Angstroms' to '\%Angstroms'.
+     + Clean up all powers to use IUCr convention of '^power^', as in
+       '10^3^' for '10**3'.
+     + Update 'yyyy-mm-dd' type regex to allow truncation from the right
+       and improve comments to explain handling of related mmCIF
+       'yyyy-mm-dd:hh:mm' type, and use of 'Z' for GMT time zone.
+
+   2005-03-08 and
+   2004-08-08 fixed cases where _item_units.code  used
+              instead of _item_type.code (JDW)
+   2004-04-15 fixed item ordering in
+               _diffrn_measurement_axis.measurement_id
+               added sub_category 'vector' (JDW)
+;
+         1.3.2                    2005-06-25
+;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+              to those of current mmCIF; float modified by allowing integers
+              terminated by a point as valid. The 'time' part of
+              yyyy-mm-dd types made optional in the regexp. (BM)
+
+   2005-06-17 Minor corrections as for proofs for IT G Chapter 4.6
+   (NJA)
+
+   2005-02-21  Minor corrections to spelling and punctuation
+   (NJA)
+
+   2005-01-08 Changes as per Nicola Ashcroft.
+   + Updated example 1 for DIFFRN_MEASUREMENT to agree with mmCIF.
+   + Spelled out "micrometres" for "um" and "millimetres" for "mm".
+   + Removed phrase "which may be stored" from ARRAY_STRUCTURE
+     description.
+   + Removed unused 'byte-offsets' compressions and updated
+     cites to ITVG for '_array_structure.compression_type'.
+   (HJB)
+;
+         1.3.1                    2003-08-13
+;
+       Changes as per Frances C. Bernstein.
+       + Identify initials.
+       + Adopt British spelling for centre in text.
+       + Set \p and \%Angstrom and powers.
+       + Clean up commas and unclear wordings.
+       + Clean up tenses in history.
+       Changes as per Gotzon Madariaga.
+       + Fix the ARRAY_DATA example to align '_array_data.binary_id'
+       and X-Binary-ID.
+       + Add a range to '_array_intensities.gain_esd'.
+       + In the example of DIFFRN_DETECTOR_ELEMENT,
+       '_diffrn_detector_element.id' and
+       '_diffrn_detector_element.detector_id' interchanged.
+       + Fix typos for direction, detector and axes.
+       + Clarify description of polarisation.
+       + Clarify axes in '_diffrn_detector_element.center[1]'
+        '_diffrn_detector_element.center[2]'.
+       + Add local item types for items that are pointers.
+       (HJB)
+;
+         1.3.0                    2003-07-24
+;
+   Changes as per Brian McMahon.
+   + Consistently quote tags embedded in text.
+   + Clean up introductory comments.
+   + Adjust line lengths to fit in 80 character window.
+   + Fix several descriptions in AXIS category which
+     referred to '_axis.type' instead of the current item.
+   + Fix erroneous use of deprecated item
+     '_diffrn_detector_axis.id' in examples for
+     DIFFRN_SCAN_AXIS.
+   + Add deprecated items '_diffrn_detector_axis.id'
+     and '_diffrn_measurement_axis.id'.
+   (HJB)
+;
+         1.2.4                    2003-07-14
+;
+   Changes as per I. David Brown.
+   + Enhance descriptions in DIFFRN_SCAN_AXIS to make them less
+     dependent on the descriptions in DIFFRN_SCAN_FRAME_AXIS.
+   + Provide a copy of the deprecated DIFFRN_FRAME_DATA
+     category for completeness.
+   (HJB)
+;
+         1.2.3                    2003-07-03
+;
+       Cleanup to conform to ITVG.
+       + Correct sign error in ..._cubed units.
+       + Correct '_diffrn_radiation.polarisn_norm' range.
+       (HJB)
+;
+         1.2.2                    2003-03-10
+;
+       Correction of typos in various DIFFRN_SCAN_AXIS descriptions.
+       (HJB)
+;
+         1.2.1                    2003-02-22
+;
+       Correction of ATOM_ for ARRAY_ typos in various descriptions.
+       (HJB)
+;
+         1.2                      2003-02-07
+;
+       Corrections to encodings (remove extraneous hyphens) remove
+       extraneous underscore in '_array_structure.encoding_type'
+       enumeration.  Correct typos in items units list.  (HJB)
+;
+         1.1.3                    2001-04-19
+;
+       Another typo corrections by Wilfred Li, and cleanup by HJB.
+;
+         1.1.2                    2001-03-06
+;
+       Several typo corrections by Wilfred Li.
+;
+         1.1.1                    2001-02-16
+;
+       Several typo corrections by JW.
+;
+         1.1                      2001-02-06
+;
+   Draft resulting from discussions on header for use at NSLS.  (HJB)
+
+   + Change DIFFRN_FRAME_DATA to DIFFRN_DATA_FRAME.
+
+   + Change '_diffrn_detector_axis.id' to '_diffrn_detector_axis.detector_id'.
+
+   + Add '_diffrn_measurement_axis.measurement_device' and change
+     '_diffrn_measurement_axis.id' to
+     '_diffrn_measurement_axis.measurement_id'.
+
+   + Add '_diffrn_radiation.div_x_source', '_diffrn_radiation.div_y_source',
+    '_diffrn_radiation.div_x_y_source',
+    '_diffrn_radiation.polarizn_source_norm',
+   '_diffrn_radiation.polarizn_source_ratio', '_diffrn_scan.date_end',
+   '_diffrn_scan.date_start', '_diffrn_scan_axis.angle_rstrt_incr',
+   '_diffrn_scan_axis.displacement_rstrt_incr',
+   '_diffrn_scan_frame_axis.angle_increment',
+   '_diffrn_scan_frame_axis.angle_rstrt_incr',
+   '_diffrn_scan_frame_axis.displacement',
+   '_diffrn_scan_frame_axis.displacement_increment',and
+   '_diffrn_scan_frame_axis.displacement_rstrt_incr'.
+
+   + Add '_diffrn_measurement.device' to category key.
+
+   + Update yyyy-mm-dd to allow optional time with fractional seconds
+     for time stamps.
+
+   + Fix typos caught by RS.
+
+   + Add ARRAY_STRUCTURE_LIST_AXIS category, and use concept of axis sets to
+     allow for coupled axes, as in spiral scans.
+
+   + Add examples for fairly complete headers thanks to R. Sweet and P.
+     Ellis.
+;
+         1.0                      2000-12-21
+;
+       Release version - few typos and tidying up.  (BM & HJB)
+
+       + Move ITEM_TYPE_LIST, ITEM_UNITS_LIST and DICTIONARY_HISTORY to end
+       of dictionary.
+
+       + Alphabetize dictionary.
+;
+         0.7.1                    2000-09-29
+;
+       Cleanup fixes.  (JW)
+
+       + Correct spelling of DIFFRN_MEASUREMENT_AXIS in '_axis.id'
+
+       + Correct ordering of uses of '_item.mandatory_code' and
+       '_item_default.value'.
+;
+         0.7.0                    2000-09-09
+;
+   Respond to comments by I. David Brown.  (HJB)
+
+   + Add further comments on '\n' and '\t'.
+
+   + Update ITEM_UNITS_LIST by taking section from mmCIF dictionary
+     and adding metres.  Change 'meter' to 'metre' throughout.
+
+   + Add missing enumerations to '_array_structure.compression_type'
+     and make 'none' the default.
+
+   + Remove parent-child relationship between
+     '_array_structure_list.index' and '_array_structure_list.precedence'.
+
+   + Improve alphabetization.
+
+   + Fix '_array_intensities.gain_esd' related function.
+
+   + Improve comments in AXIS.
+
+   + Fix DIFFRN_FRAME_DATA example.
+
+   + Remove erroneous DIFFRN_MEASUREMENT example.
+
+   + Add '_diffrn_measurement_axis.id' to the category key.
+;
+         0.6.0                    1999-01-14
+;
+   Remove redundant information for ENC_NONE data.  (HJB)
+
+   + After the D5 remove binary section identifier, size and
+     compression type.
+
+   + Add Control-L to header.
+;
+         0.5.1                    1999-01-03
+;
+       Cleanup of typos and syntax errors.  (HJB)
+
+       + Cleanup example details for DIFFRN_SCAN category.
+
+       + Add missing quote marks for '_diffrn_scan.id' definition.
+;
+         0.5                      1999-01-01
+;
+   Modifications for axis definitions and reduction of binary header.  (HJB)
+
+   + Restore '_diffrn_detector.diffrn_id' to DIFFRN_DETECTOR KEY.
+
+   + Add AXIS category.
+
+   + Bring in complete DIFFRN_DETECTOR and DIFFRN_MEASUREMENT categories
+     from cif_mm.dic for clarity.
+
+   + Change '_array_structure.encoding_type' from type code to uline and
+     added X-Binary-Element-Type to MIME header.
+
+   + Add detector beam centre '_diffrn_detector_element.center[1]' and
+     '_diffrn_detector_element.center[2]'.
+
+   + Correct item name of '_diffrn_refln.frame_id'.
+
+   + Replace reference to '_array_intensities.undefined' by
+     '_array_intensities.undefined_value'.
+
+   + Replace references to '_array_intensity.scaling' with
+     '_array_intensities.scaling'.
+
+   + Add DIFFRN_SCAN... categories.
+;
+         0.4                      1998-08-11
+;
+       Modifications to the 0.3 imgCIF draft.  (HJB)
+
+       + Reflow comment lines over 80 characters and corrected typos.
+
+       + Update examples and descriptions of MIME encoded data.
+
+       + Change name to cbfext98.dic.
+;
+         0.3                      1998-07-04
+;
+   Modifications for imgCIF.  (HJB)
+
+   + Add binary type, which is a text field containing a variant on
+     MIME encoded data.
+
+   + Change type of '_array_data.data' to binary and specify internal
+     structure of raw binary data.
+
+   + Add '_array_data.binary_id', and make
+     '_diffrn_frame_data.binary_id' and '_array_intensities.binary_id'
+     into pointers to this item.
+;
+         0.2                      1997-12-02
+;
+   Modifications to the CBF draft.  (JW)
+
+   + Add category hierarchy for describing frame data developed from
+     discussions at the BNL imgCIF Workshop Oct 1997.   The following
+     changes are made in implementing the workshop draft.  Category
+     DIFFRN_array_data is renamed to DIFFRN_FRAME_DATA.  Category
+     DIFFRN_FRAME_TYPE is renamed to DIFFRN_DETECTOR_ELEMENT.   The
+     parent item for '_diffrn_frame_data.array_id' is changed from
+     '_array_structure_list.array_id' to '_array_structure.id'. Item
+     '_diffrn_detector.array_id' is deleted.
+   + Add data item '_diffrn_frame_data.binary_id' to identify data
+     groups within a binary section.  The formal identification of the
+     binary section is still fuzzy.
+;
+         0.1                      1997-01-24
+;
+   First draft of this dictionary in DDL 2.1 compliant format by John
+   Westbrook (JW).  This version is adapted from the Crystallographic
+   Binary File (CBF) Format Draft Proposal provided by Andy Hammersley
+   (AH).
+
+   Modifications to the CBF draft.  (JW)
+
+   + In this version the array description has been cast in the categories
+     ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  These categories
+     have been generalized to describe array data  of arbitrary dimension.
+
+   + Array data in this description are contained in the category
+     ARRAY_DATA.  This departs from the CBF notion of data existing
+     in some special comment. In this description, data are handled as an
+     ordinary data item encapsulated in a character data type.   Although
+     data this manner deviates from CIF conventions, it does not violate
+     any DDL 2.1 rules.  DDL 2.1 regular expressions can be used to define
+     the binary representation which will permit some level of data
+     validation.  In this version, the placeholder type code "any" has
+     been used. This translates to a regular expression which will match
+     any pattern.
+
+     It should be noted that DDL 2.1 already supports array data objects
+     although these have not been used in the current mmCIF dictionary.
+     It may be possible to use the DDL 2.1 ITEM_STRUCTURE and
+     ITEM_STRUCTURE_LIST categories to provide the information that is
+     carried in by the ARRAY_STRUCTURE and ARRAY_STRUCTURE_LIST.  By
+     moving the array structure to the DDL level it would be possible to
+     define an array type as well as a regular expression defining the
+     data format.
+
+   + Multiple array sections can be properly handled within a single
+     datablock.
+;
+
+    loop_
+      _ddl2_regex_type.code
+      _ddl2_regex_type.construct
+      _ddl2_regex_type.detail
+      _ddl2_regex_type.primitive_code
+         code
+;
+       [_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*
+;
+;              code item types/single words ...
+;
+         char
+         ucode
+;
+       [_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*
+;
+;              code item types/single words (case insensitive) ...
+;
+         uchar
+         line
+;
+       [][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
+;
+;              char item types / multi-word items ...
+;
+         char
+         uline
+;
+       [][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
+;
+;              char item types / multi-word items (case insensitive)...
+;
+         uchar
+         text
+;
+       [][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
+;
+;              text item types / multi-line text ...
+;
+         char
+         binary
+;
+       [][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*\
+       \n--CIF-BINARY-FORMAT-SECTION----
+;
+;              binary items are presented as MIME-like ascii-encoded
+               sections in an imgCIF.  In a CBF, raw octet streams
+               are used to convey the same information.
+;
+         char
+         int
+;
+       -?[0-9]+
+;
+;              int item types are the subset of numbers that are the negative
+               or positive integers.
+;
+         numb
+         float
+;
+       -?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?
+;
+;              float item types are the subset of numbers that are the floating
+               point numbers.
+;
+         numb
+         any
+;
+       .*
+;
+;              A catch all for items that may take any form...
+;
+         char
+         yyyy-mm-dd
+;
+[0-9]?[0-9]?[0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9]((T[0-2][0-9](:[0-5][0-9](:[0-5][0-9](.[0-9]+)?)?)?)?([+-][0-5][0-9]:[0-5][0-9]))?
+;
+;
+               Standard format for CIF date and time strings (see
+               http://www.iucr.org/iucr-top/cif/spec/datetime.html),
+               consisting of a yyyy-mm-dd date optionally followed by
+               the character 'T' followed by a 24-hour clock time,
+               optionally followed by a signed time-zone offset.
+
+               The IUCr standard has been extended to allow for an optional
+               decimal fraction on the seconds of time.
+
+               Time is local time if no time-zone offset is given.
+
+               Note that this type extends the mmCIF yyyy-mm-dd type
+               but does not conform to the mmCIF yyyy-mm-dd:hh:mm
+               type that uses a ':' in place of the 'T' specified
+               by the IUCr standard.  For reading, both forms should
+               be accepted,  but for writing, only the IUCr form should
+               be used.
+
+               For maximal compatibility, the special time zone
+               indicator 'Z' (for 'Zulu') should be accepted on
+               reading in place of '+00:00' for GMT.
+;
+         char
+
+    loop_
+      _ddl2_units_list.code
+      _ddl2_units_list.detail
+         metres
+;
+         metres
+;
+         centimetres
+;
+         centimetres (metres * 10^( -2)^)
+;
+         millimetres
+;
+         millimetres (metres * 10^( -3)^)
+;
+         micrometres
+;
+         micrometres (metres * 10^( -6)^)
+;
+         nanometres
+;
+         nanometres  (metres * 10^( -9)^)
+;
+         angstroms
+;
+         \%angstr\"oms   (metres * 10^(-10)^)
+;
+         picometres
+;
+         picometres  (metres * 10^(-12)^)
+;
+         femtometres
+;
+         femtometres (metres * 10^(-15)^)
+;
+         reciprocal_metres
+;
+         reciprocal metres (metres^(-1)^)
+;
+         reciprocal_centimetres
+;
+         reciprocal centimetres ((metres * 10^( -2)^)^(-1)^)
+;
+         reciprocal_millimetres
+;
+         reciprocal millimetres ((metres * 10^( -3)^)^(-1)^)
+;
+         reciprocal_nanometres
+;
+         reciprocal nanometres  ((metres * 10^( -9)^)^(-1)^)
+;
+         reciprocal_angstroms
+;
+         reciprocal \%angstr\"oms   ((metres * 10^(-10)^)^(-1)^)
+;
+         reciprocal_picometres
+;
+         reciprocal picometres  ((metres * 10^(-12)^)^(-1)^)
+;
+         nanometres_squared
+;
+         nanometres squared (metres * 10^( -9)^)^2^
+;
+         angstroms_squared
+;
+         \%angstr\"oms squared  (metres * 10^(-10)^)^2^
+;
+         8pi2_angstroms_squared
+;
+         8\p^2^ * \%angstr\"oms squared (metres * 10^(-10)^)^2^
+;
+         picometres_squared
+;
+         picometres squared (metres * 10^(-12)^)^2^
+;
+         nanometres_cubed
+;
+         nanometres cubed (metres * 10^( -9)^)^3^
+;
+         angstroms_cubed
+;
+         \%angstr\"oms cubed  (metres * 10^(-10)^)^3^
+;
+         picometres_cubed
+;
+         picometres cubed (metres * 10^(-12)^)^3^
+;
+         kilopascals
+;
+         kilopascals
+;
+         gigapascals
+;
+         gigapascals
+;
+         hours
+;
+         hours
+;
+         minutes
+;
+         minutes
+;
+         seconds
+;
+         seconds
+;
+         microseconds
+;
+         microseconds
+;
+         degrees
+;
+         degrees (of arc)
+;
+         degrees_squared
+;
+         degrees (of arc) squared
+;
+         degrees_per_minute
+;
+         degrees (of arc) per minute
+;
+         celsius
+;
+         degrees (of temperature) Celsius
+;
+         kelvins
+;
+         degrees (of temperature) Kelvin
+;
+         counts
+;
+         counts
+;
+         counts_per_photon
+;
+         counts per photon
+;
+         electrons
+;
+         electrons
+;
+         electrons_squared
+;
+         electrons squared
+;
+         electrons_per_nanometres_cubed
+;
+         electrons per nanometres cubed (electrons/(metres * 10^( -9)^)^(-3)^)
+;
+         electrons_per_angstroms_cubed
+;
+         electrons per \%angstr\"oms cubed (electrons/(metres *
+         10^(-10)^)^(-3)^)
+;
+         electrons_per_picometres_cubed
+;
+         electrons per picometres cubed (electrons/(metres * 10^(-12)^)^(-3)^)
+;
+         kilowatts
+;
+         kilowatts
+;
+         milliamperes
+;
+         milliamperes
+;
+         kilovolts
+;
+         kilovolts
+;
+         pixels_per_element
+;
+         (image) pixels per (array) element
+;
+         arbitrary
+;
+         arbitrary system of units.
+;
+
+    loop_
+      _ddl2_sub_category_list.description
+      _ddl2_sub_category_list.id
+         '              The collection of elements of a matrix.'         matrix
+         '              The collection of elements of a vector.'         vector
+
+    loop_
+      _ddl2_category_group_list.description
+      _ddl2_category_group_list.id
+      _ddl2_category_group_list.parent_id
+;             Categories that belong to the dictionary extension.
+;
+         inclusive_group          .
+;             Categories that describe array data.
+;
+         array_data_group         inclusive_group
+;             Categories that describe axes.
+;
+         axis_group               inclusive_group
+;             Categories that describe details of the diffraction experiment.
+;
+         diffrn_group             inclusive_group
+;             Categories that describe details of map data.
+;
+         map_group                inclusive_group
+;             Categories that describe details of variants.
+;
+         variant_group            inclusive_group


### PR DESCRIPTION
The current version of the DDL2 cif_img dictionary is 1.8.9.1, and dictionary standards have had some updates (e.g. semantic versioning, units for all numerical values). This pull request provides an automatically translated 1.8.9.1 version which is also suitable for import by other DDLm dictionaries wishing to refer to raw image data.