### PR TITLE
Removal of variant-related definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,17 @@ The DDLm version was automatically obtained from the DDL2 version by running the
 commands:
 
 ```
-julia ddl_to_ddl.jl -c multi_block_core.dic -i --short --strict -t CIF_IMG -o cif_img.dic cif_img_1.8.9.1.dic ddl2
+julia ddl_to_ddl.jl -c multi_block_core.dic -i --short --strict -t CIF_IMG -o cif_img.dic cbf_imgcif_dictionary/ddl2/cif_img.dic ddl2
 ```
 
 using the `ddl_to_ddl.jl` and `remove_category.jl` tools and associated DDL
 translation dictionaries from the `https://github.com/jamesrhester/ddl_to_ddl`
 repository and the `multi_block_core.dic` found in the [COMCIFS Multi-Block
-dictionary repository](https://github.com/COMCIFS/cif_multiblock).  A [local
+dictionary repository](https://github.com/COMCIFS/cif_multiblock).  A [COMCIFS
 fork of the DDL2 imgCIF
 dictionary](https://github.com/COMCIFS/cbf_imgcif_dictionary) was used as the
-DDL2 dictionary source.
+DDL2 dictionary source.  Currently this fork contains some corrections for
+minor errors in the original.
 
 The `ddl_to_ddl.jl` command above does the following:
 
@@ -106,5 +107,5 @@ separate data blocks.
 `ddl2` version can be recovered by running
 
 ```
-julia ddl_to_ddl.jl -o cif_img_ddl2.dic cif_img_expanded.dic ddlm
+julia ddl_to_ddl.jl -o cif_img_ddl2.dic expanded/cif_img_expanded.dic ddlm
 ```

--- a/README.md
+++ b/README.md
@@ -9,52 +9,96 @@ in the [wwPDB repository](https://github.com/wwpdb-dictionaries/cbf_imgcif_dicti
 
 The present repository holds a DDLm version of the DDL2 imgCIF dictionary found in the
 main branch of that repository. The DDLm version here may be used as a data name reference
-for DDLm-based work.
+for DDLm-based work and as an imported dictionary for DDLm dictionaries that interact with
+image-based data.
 
-## Caveats
+## Caveats and Considerations
 
-Ideally, DDL2 and DDLm dictionaries can be used interchangeably as a reference when reading and writing data names (the data names themselves are identical). The following
-caveats to this ideal situation apply:
+Ideally, DDL2 and DDLm dictionaries can be used interchangeably as a reference
+when reading and writing data names (the data names themselves are
+identical). The following caveats to this ideal situation currently apply:
 
-(none at preset)
+1. The DDLm imgCIF dictionary inherits `DIFFRN`-linked
+categories from the [multi-block dictionary](https://github.com/COMCIFS/cif_multiblock)
+rather than [PDBx/mmCIF](https://mmcif.wwpdb.org). That is,
+unlike mmCIF, `DIFFRN_DETECTOR`, `DIFFRN_RADIATION` and `DIFFRN_MEASUREMENT` do
+*not* include a data name linked to `_diffrn.id` as a key data name. An issue
+will only arise where multiple `_diffrn.id`s form part of a single dataset, which is
+rare in the macromolecular context. In the case that there are multiple
+`_diffrn.id`s, data for each `_diffrn.id` should be presented in separate data
+blocks where DDLm dictionary tools are used, and merged into a single data block where
+DDL2-based tools are used. In
+addition, DDLm requires that identical items (detectors/sources/goniometers) in
+the above categories should be
+named identically for each `_diffrn.id`.
+
+2. `cif_img_variant.dic` includes the `VARIANT` category. Data names in this category
+are currently excluded from the main PDBx/mmCIF dictionary and so have been separated
+out here as well. The `VARIANT` category in this dictionary does not include `_diffrn.id`
+or `_entry.id` as key data names.
+
+3. `expanded/cif_img_expanded.dic` includes additional non-DDLm attributes in some data
+name definitions to permit round-tripping back to DDL2 (see below). It is not suitable
+as a DDLm dictionary import target or for use with automated tools, but is useful as a
+human-readable reference for additional information, e.g. regular expressions that
+certain data name values should match.
 
 ## Deriving the DDLm version from the DDL2 version
 
-The DDLm version was automatically obtained from the DDL2 version by running the
-command:
+The DDLm version was automatically obtained from the DDL2 version by running the following
+commands:
 
 ```
 julia ddl_to_ddl.jl -c multi_block_core.dic -i --short --strict -t CIF_IMG -o cif_img.dic cif_img_1.8.9.1.dic ddl2
 ```
 
-using the `ddl_to_ddl.jl` tool and associated translation dictionaries from the
-`https://github.com/jamesrhester/ddl_to_ddl` repository and the `multi_block_core.dic`
-found in the [COMCIFS Multi-Block dictionary repository](https://github.com/COMCIFS/cif_multiblock).
+using the `ddl_to_ddl.jl` and `remove_category.jl` tools and associated DDL
+translation dictionaries from the `https://github.com/jamesrhester/ddl_to_ddl`
+repository and the `multi_block_core.dic` found in the [COMCIFS Multi-Block
+dictionary repository](https://github.com/COMCIFS/cif_multiblock).  A [local
+fork of the DDL2 imgCIF
+dictionary](https://github.com/COMCIFS/cbf_imgcif_dictionary) was used as the
+DDL2 dictionary source.
 
-In particular, the translation options above perform the following:
+The `ddl_to_ddl.jl` command above does the following:
 
 1. All DDLm attributes are "calculated" from DDL2 attributes according to
-translation dictionaries included in the `ddl_to_ddl` repository.
+translation dictionaries included in the `ddl_to_ddl` repository. Additional
+non-canonical data attributes (prefixed with `ddl2`) are included in the
+translated DDLm dictionary to preserve information not captured by DDLm
+attributes. For details see the `ddl_to_ddl` tool. The additional attributes
+are later dropped (see below).
 
-2. Additional non-canonical data attributes (prefixed with `ddl2`)
-are included in the translated DDLm dictionary to preserve information not
-captured by DDLm attributes. For details see the `ddl_to_ddl` tool.
-
-3. Any common categories defined to be of class `Set` in `cif_core.dic` are
+2. Any common categories defined to be of class `Set` in `multi_block_core.dic` are
 restated to be `Set` categories in the translated dictionary
 
-4. The dictionary title is changed to `cif_img` to conform to DDLm style.
+3. The dictionary title is changed to `cif_img` to conform to DDLm style.
 
-5. (`--short`): The import of the MultiBlock dictionary will not specify a directory for simplicity
-in testing. This implies that all dictionaries are in the same directory.
+4. (`--short`): The import of `multi_block_core.dic` in the emitted DDLm
+dictionary will not specify a directory for simplicity in testing. This implies
+that all dictionaries are in the same directory.
 
-6. (`--strict`): Modifications to satisfy DDLm style and strict semantic requirements:
+5. (`--strict`): Modifications to satisfy DDLm style and strict semantic requirements:
     1. All DDL2-specific categories generated at (2) are dropped
     2. Data names defined as aliases have any separate definition blocks removed
     3. Version numbers enhanced to conform to semantic versioning
     4. Version numbers re-ordered to be ascending order
     5. Aliases defined in both `cif_img.dic` and the imported dictionary are removed from
        `cif_img.dic`
+
+```
+julia remove_category.jl -s -k _variant.variant cif_img.dic variant
+```
+
+The `remove_category.jl` command creates `cif_img_variant.dic` and alters `cif_img.dic` as follows:
+
+1. All data names linked to `_variant.variant` are moved to the new dictionary
+2. The category `variant` is moved to the new dictionary
+3. Mentions of `variant`-type data names and the `variant` category are removed
+from the dictionary description
+4. The new dictionary makes `VARIANT` a `Set` category with single key data name
+`_variant.variant`. This means that alternate variants by default should be presented in
+separate data blocks.
 
 ## Rederiving the DDL2 version
 

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -5,12 +5,13 @@ data_CIF_IMG
     _dictionary.title             CIF_IMG
     _dictionary.class             Instance
     _dictionary.version           1.8.9
-    _dictionary.date              2026-05-03
+    _dictionary.date              2026-05-14
     _dictionary.uri               https://github.com/COMCIFS/imgCIF/cif_img.dic
-    _dictionary.ddl_conformance   3.14.0
-    _dictionary.namespace         Ddlm
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         CifCore
     _description.text
-;##############################################################################
+;
+##############################################################################
 #                                                                            #
 #                       Image CIF Dictionary (imgCIF)                        #
 #             and Crystallographic Binary File Dictionary (CBF)              #
@@ -60,7 +61,6 @@ data_CIF_IMG
 #                  _array_data.external_data_id
 #                  _array_data.header_contents
 #                  _array_data.header_convention
-#                  _array_data.variant
 #
 
 #        category  ARRAY_DATA_EXTERNAL_DATA 
@@ -73,7 +73,6 @@ data_CIF_IMG
 #                  _array_data_external_data.id
 #                  _array_data_external_data.path
 #                  _array_data_external_data.uri
-#                  _array_data_external_data.variant
 #                  _array_data_external_data.version
 #
 
@@ -82,7 +81,6 @@ data_CIF_IMG
 #                  _array_element_size.array_id
 #                  _array_element_size.index
 #                  _array_element_size.size
-#                  _array_element_size.variant
 #
 
 #        category  ARRAY_INTENSITIES 
@@ -101,7 +99,6 @@ data_CIF_IMG
 #                  _array_intensities.scaling
 #                  _array_intensities.undefined_value
 #                  _array_intensities.underload
-#                  _array_intensities.variant
 #
 
 #        category  ARRAY_STRUCTURE 
@@ -111,7 +108,6 @@ data_CIF_IMG
 #                  _array_structure.compression_type_flag
 #                  _array_structure.encoding_type
 #                  _array_structure.id
-#                  _array_structure.variant
 #
 
 #        category  ARRAY_STRUCTURE_LIST 
@@ -123,7 +119,6 @@ data_CIF_IMG
 #                  _array_structure_list.direction
 #                  _array_structure_list.index
 #                  _array_structure_list.precedence
-#                  _array_structure_list.variant
 #
 
 #        category  ARRAY_STRUCTURE_LIST_SECTION 
@@ -134,7 +129,6 @@ data_CIF_IMG
 #                  _array_structure_list_section.index
 #                  _array_structure_list_section.start
 #                  _array_structure_list_section.stride
-#                  _array_structure_list_section.variant
 #
 
 #        category  ARRAY_STRUCTURE_LIST_AXIS 
@@ -151,7 +145,6 @@ data_CIF_IMG
 #                  _array_structure_list_axis.radial_pitch
 #                  _array_structure_list_axis.reference_angle
 #                  _array_structure_list_axis.reference_displacement
-#                  _array_structure_list_axis.variant
 #
 
 #        category  AXIS 
@@ -170,7 +163,6 @@ data_CIF_IMG
 #                  _axis.vector[1]
 #                  _axis.vector[2]
 #                  _axis.vector[3]
-#                  _axis.variant
 #
 
 #        category  DIFFRN 
@@ -191,7 +183,6 @@ data_CIF_IMG
 #                  _diffrn_data_frame.diffrn_id
 #                  _diffrn_data_frame.id
 #                  _diffrn_data_frame.details
-#                  _diffrn_data_frame.variant
 #
 
 #        category  DIFFRN_DETECTOR 
@@ -205,7 +196,6 @@ data_CIF_IMG
 #                  _diffrn_detector.layer_thickness
 #                  _diffrn_detector.number_of_axes
 #                  _diffrn_detector.type
-#                  _diffrn_detector.variant
 #
 
 #        category  DIFFRN_DETECTOR_AXIS 
@@ -213,7 +203,6 @@ data_CIF_IMG
 #                  _diffrn_detector_axis.axis_id
 #                  _diffrn_detector_axis.detector_id
 #                  _diffrn_detector_axis.diffrn_id
-#                  _diffrn_detector_axis.variant
 #
 
 #        category  DIFFRN_DETECTOR_ELEMENT 
@@ -224,7 +213,6 @@ data_CIF_IMG
 #                  _diffrn_detector_element.reference_center_fast
 #                  _diffrn_detector_element.reference_center_slow
 #                  _diffrn_detector_element.reference_center_units
-#                  _diffrn_detector_element.variant
 #
 
 #        category  DIFFRN_MEASUREMENT 
@@ -241,7 +229,6 @@ data_CIF_IMG
 #                  _diffrn_measurement.sample_detector_distance
 #                  _diffrn_measurement.sample_detector_voffset
 #                  _diffrn_measurement.specimen_support
-#                  _diffrn_measurement.variant
 #
 
 #        category  DIFFRN_MEASUREMENT_AXIS 
@@ -249,7 +236,6 @@ data_CIF_IMG
 #                  _diffrn_measurement_axis.axis_id
 #                  _diffrn_measurement_axis.measurement_device
 #                  _diffrn_measurement_axis.measurement_id
-#                  _diffrn_measurement_axis.variant
 #
 
 #        category  DIFFRN_RADIATION 
@@ -283,7 +269,6 @@ data_CIF_IMG
 #                  _diffrn_radiation.polarizn_Stokes_V_esd
 #                  _diffrn_radiation.probe
 #                  _diffrn_radiation.type
-#                  _diffrn_radiation.variant
 #                  _diffrn_radiation.wavelength_id
 #                  _diffrn_radiation.xray_symbol
 #
@@ -292,7 +277,6 @@ data_CIF_IMG
 #
 #                  _diffrn_refln.diffrn_id
 #                  _diffrn_refln.frame_id
-#                  _diffrn_refln.variant
 #
 
 #        category  DIFFRN_SCAN 
@@ -308,7 +292,6 @@ data_CIF_IMG
 #                  _diffrn_scan.frames
 #                  _diffrn_scan.time_period
 #                  _diffrn_scan.time_rstrt_incr
-#                  _diffrn_scan.variant
 #
 
 #        category  DIFFRN_SCAN_AXIS 
@@ -326,7 +309,6 @@ data_CIF_IMG
 #                  _diffrn_scan_axis.reference_angle
 #                  _diffrn_scan_axis.reference_displacement
 #                  _diffrn_scan_axis.scan_id
-#                  _diffrn_scan_axis.variant
 #
 
 #        category  DIFFRN_SCAN_COLLECTION 
@@ -336,7 +318,6 @@ data_CIF_IMG
 #                  _diffrn_scan_collection.scan_id
 #                  _diffrn_scan_collection.type
 #                  _diffrn_scan_collection.translation_width
-#                  _diffrn_scan_collection.variant
 #
 
 #        category  DIFFRN_SCAN_FRAME 
@@ -357,7 +338,6 @@ data_CIF_IMG
 #                  _diffrn_scan_frame.scan_id
 #                  _diffrn_scan_frame.time_period
 #                  _diffrn_scan_frame.time_rstrt_incr
-#                  _diffrn_scan_frame.variant
 #
 
 #        category  DIFFRN_SCAN_FRAME_AXIS 
@@ -373,7 +353,6 @@ data_CIF_IMG
 #                  _diffrn_scan_frame_axis.reference_angle
 #                  _diffrn_scan_frame_axis.reference_displacement
 #                  _diffrn_scan_frame_axis.frame_id
-#                  _diffrn_scan_frame_axis.variant
 #
 
 #        category  DIFFRN_SCAN_FRAME_MONITOR 
@@ -385,7 +364,6 @@ data_CIF_IMG
 #                  _diffrn_scan_frame_monitor.integration_time
 #                  _diffrn_scan_frame_monitor.monitor_value
 #                  _diffrn_scan_frame_monitor.scan_id
-#                  _diffrn_scan_frame_monitor.variant
 #
 
 #        category  DIFFRN_SOURCE 
@@ -401,7 +379,6 @@ data_CIF_IMG
 #                  _map.diffrn_id
 #                  _map.entry_id
 #                  _map.id
-#                  _map.variant
 #
 
 #        category  MAP_SEGMENT 
@@ -415,18 +392,9 @@ data_CIF_IMG
 #                  _map_segment.id
 #                  _map_segment.map_id
 #                  _map_segment.details
-#                  _map_segment.variant
 #
 
-#        category  VARIANT 
 #
-#                  _variant.details
-#                  _variant.diffrn_id
-#                  _variant.entry_id
-#                  _variant.role
-#                  _variant.timestamp
-#                  _variant.variant
-#                  _variant.variant_of
 #
 
 #       ***DEPRECATED*** data items 
@@ -722,42 +690,8 @@ data_CIF_IMG
 |                || +---------------------------------------------------------------------------------------------+ ||
 |                |+-------------------------------------------------------------------------------------------------+|
 |----------------+---------------------------------------------------------------------------------------------------|
-|VARIANT_GROUP   |Categories that describe variants                                                                  |
-|                |---------------------------------------------------------------------------------------------------|
-|                |+-------------------------------------------------------------------------------------------------+|
-|                || VARIANT | Data items in the VARIANT category record the details about sets of variants of data  ||
-|                ||         | items.                                                                                ||
-|                ||         |                                                                                       ||
-|                ||         | There is sometimes a need to allow for multiple versions of the same data items in    ||
-|                ||         | order to allow for refinements and corrections to earlier assumptions, observations   ||
-|                ||         | and calculations. In order to allow data sets to contain more than one variant of the ||
-|                ||         | same information, an optional ...variant data item as a pointer to _variant.variant   ||
-|                ||         | has been added to the key of every category, as an implicit data item with a null     ||
-|                ||         | (empty) default value.                                                                ||
-|                ||         |                                                                                       ||
-|                ||         | All rows in a category with the same variant value are considered to be related to    ||
-|                ||         | one another and to all rows in other categories with the same variant value. For a    ||
-|                ||         | given variant, all such rows are also considered to be related to all rows with a     ||
-|                ||         | null variant value, except that a row with a null variant value is for which all      ||
-|                ||         | other components of its key are identical to those entries in another row with a      ||
-|                ||         | non-null variant value is not related the the rows with that non-null variant value.  ||
-|                ||         | This behavior is similar to the convention for identifying alternate conformers in an ||
-|                ||         | atom list.                                                                            ||
-|                ||         |                                                                                       ||
-|                ||         | An optional role may be specified for a variant as the value of _variant.role.        ||
-|                ||         | Possible roles are null, "preferred", "raw data", "unsuccessful trial".               ||
-|                ||         |                                                                                       ||
-|                ||         | variants may carry an optional timestamp as the value of _variant.timestamp.          ||
-|                ||         |                                                                                       ||
-|                ||         | variants may be related to other variants from which they were derived by the value   ||
-|                ||         | of _variant.variant_of                                                                ||
-|                ||         |                                                                                       ||
-|                ||         | Further details about the variant may be specified as the value of _variant.details.  ||
-|                ||         |                                                                                       ||
-|                ||         | In order to allow variant information from multiple datasets to be combined,          ||
-|                ||         | _variant.diffrn_id and/or _variant.entry_id may be used.                              ||
-|                |+-------------------------------------------------------------------------------------------------+|
-+--------------------------------------------------------------------------------------------------------------------+
+
+
 ;
 
 save_CIF_IMG_HEAD
@@ -765,7 +699,7 @@ save_CIF_IMG_HEAD
     _definition.id                CIF_IMG_HEAD
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     The HEAD category is the parent category of all definitions in the
@@ -782,10 +716,10 @@ save_
 
 save_ARRAY_DATA
 
-    _definition.id                ARRAY_DATA
+    _definition.id                array_data
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_DATA category are the containers for
@@ -807,13 +741,12 @@ save_ARRAY_DATA
      dictionary will need to be populated.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_DATA
+    _name.object_id               array_data
 
     loop_
       _category_key.name
          '_array_data.array_id'
          '_array_data.binary_id'
-         '_array_data.variant'
 
     loop_
       _description_example.case
@@ -949,9 +882,10 @@ save_
 save_array_data.array_id
 
     _definition.id                '_array_data.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 
               If not given, it defaults to 1.
@@ -971,9 +905,10 @@ save_
 save_array_data.binary_id
 
     _definition.id                '_array_data.binary_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is an integer identifier which, along with
+;
+             This item is an integer identifier which, along with
               _array_data.array_id, should uniquely identify the
               particular block of array data.
 
@@ -1003,9 +938,10 @@ save_
 save_array_data.data
 
     _definition.id                '_array_data.data'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_data.data contains the array data
+;
+             The value of _array_data.data contains the array data
               encapsulated in a STAR string.  The value of this item is 
               required unless a value is given for 
                _array_data.external_data_id instead, in which 
@@ -1252,9 +1188,10 @@ save_
 save_array_data.external_data_id
 
     _definition.id                '_array_data.external_data_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_data_external_data.id in the
+;
+             This item is a pointer to _array_data_external_data.id in the
               ARRAY_DATA_EXTERNAL_DATA category.
 
               If not given, then the actual array data should be specified as
@@ -1277,9 +1214,10 @@ save_
 save_array_data.header_contents
 
     _definition.id                '_array_data.header_contents'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a text field for use in minimal CBF files to carry
+;
+             This item is a text field for use in minimal CBF files to carry
               essential header information to be kept with image data
               in _array_data.data when the tags that normally carry the
               structured metadata for the image have not been populated.
@@ -1300,9 +1238,10 @@ save_
 save_array_data.header_convention
 
     _definition.id                '_array_data.header_convention'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is an identifier for the convention followed in
+;
+             This item is an identifier for the convention followed in
               constructing the contents of _array_data.header_contents
 
               The permitted values are of an image creator identifier
@@ -1321,37 +1260,12 @@ save_array_data.header_convention
 
 save_
 
-save_array_data.variant
-
-    _definition.id                '_array_data.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_data.variant gives the variant
-              to which the given ARRAY_DATA row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_data
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_DATA_EXTERNAL_DATA
 
-    _definition.id                ARRAY_DATA_EXTERNAL_DATA
+    _definition.id                array_data_external_data
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_DATA_EXTERNAL_DATA category optionally
@@ -1359,7 +1273,7 @@ save_ARRAY_DATA_EXTERNAL_DATA
     use in  ARRAY_DATA that are found external to the cif_img file.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_DATA_EXTERNAL_DATA
+    _name.object_id               array_data_external_data
     _category_key.name            '_array_data_external_data.id'
 
 save_
@@ -1367,7 +1281,7 @@ save_
 save_array_data_external_data.archive_format
 
     _definition.id                '_array_data_external_data.archive_format'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     The type of single-file archive in which image data or multi-image
@@ -1396,7 +1310,7 @@ save_
 save_array_data_external_data.archive_path
 
     _definition.id                '_array_data_external_data.archive_path'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     The location of the image or multi-image image container,
@@ -1414,7 +1328,7 @@ save_
 save_array_data_external_data.file_compression
 
     _definition.id                '_array_data_external_data.file_compression'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     The type of compression used for the file corresponding to
@@ -1441,7 +1355,7 @@ save_
 save_array_data_external_data.format
 
     _definition.id                '_array_data_external_data.format'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     The format in which raw array data referenced by
@@ -1519,7 +1433,7 @@ save_
 save_array_data_external_data.frame
 
     _definition.id                '_array_data_external_data.frame'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
 
@@ -1557,9 +1471,10 @@ save_
 save_array_data_external_data.id
 
     _definition.id                '_array_data_external_data.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_data_external_data.id must uniquely identify
+;
+             The value of _array_data_external_data.id must uniquely identify
               each item of array_data_external_data.              
 
               This item has been made implicit and given a default value of 1
@@ -1579,7 +1494,7 @@ save_
 save_array_data_external_data.path
 
     _definition.id                '_array_data_external_data.path'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     An optional format-dependent path that is used to locate the
@@ -1607,7 +1522,7 @@ save_
 save_array_data_external_data.uri
 
     _definition.id                '_array_data_external_data.uri'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     A URI describing the location of an image external to the current data block
@@ -1621,34 +1536,10 @@ save_array_data_external_data.uri
 
 save_
 
-save_array_data_external_data.variant
-
-    _definition.id                '_array_data_external_data.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_data_external_data.variant gives the variant
-              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_data_external_data
-    _name.object_id               variant
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_array_data_external_data.version
 
     _definition.id                '_array_data_external_data.version'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     An identifier for the version of the file format described by
@@ -1665,26 +1556,26 @@ save_
 
 save_ARRAY_ELEMENT_SIZE
 
-    _definition.id                ARRAY_ELEMENT_SIZE
+    _definition.id                array_element_size
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_ELEMENT_SIZE category record the physical
      size of array elements along each array dimension.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_ELEMENT_SIZE
+    _name.object_id               array_element_size
 
     loop_
       _category_key.name
          '_array_element_size.array_id'
          '_array_element_size.index'
-         '_array_element_size.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
        _array_element_size.array_id
        _array_element_size.index
        _array_element_size.size
@@ -1692,7 +1583,8 @@ save_ARRAY_ELEMENT_SIZE
         image_1   2    1.22e-6
 ;
     _description_example.detail
-;      Example 1. A regular 2D array with a uniform element dimension
+;
+      Example 1. A regular 2D array with a uniform element dimension
                     of 1220 nanometres.
 ;
 
@@ -1701,9 +1593,10 @@ save_
 save_array_element_size.array_id
 
     _definition.id                '_array_element_size.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_element_size
@@ -1718,9 +1611,10 @@ save_
 save_array_element_size.index
 
     _definition.id                '_array_element_size.index'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure_list.index in
+;
+             This item is a pointer to _array_structure_list.index in
               the ARRAY_STRUCTURE_LIST category.
 ;
     _name.category_id             array_element_size
@@ -1738,9 +1632,10 @@ save_
 save_array_element_size.size
 
     _definition.id                '_array_element_size.size'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The size in metres of an image element in this
+;
+             The size in metres of an image element in this
               dimension. This supposes that the elements are arranged
               on a regular grid.
 ;
@@ -1754,37 +1649,12 @@ save_array_element_size.size
 
 save_
 
-save_array_element_size.variant
-
-    _definition.id                '_array_element_size.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_element_size.variant gives the variant
-              to which the given ARRAY_ELEMENT_SIZE row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_element_size
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_INTENSITIES
 
-    _definition.id                ARRAY_INTENSITIES
+    _definition.id                array_intensities
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_INTENSITIES category record the
@@ -1802,16 +1672,16 @@ save_ARRAY_INTENSITIES
      and _array_intensities.gain will not be used.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_INTENSITIES
+    _name.object_id               array_intensities
 
     loop_
       _category_key.name
          '_array_intensities.array_id'
          '_array_intensities.binary_id'
-         '_array_intensities.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _array_intensities.array_id
         _array_intensities.linearity
         _array_intensities.gain
@@ -1824,7 +1694,7 @@ save_ARRAY_INTENSITIES
 ;
     _description_example.detail
 ;
-    Example 1
+        Example 1
 ;
 
 save_
@@ -1832,9 +1702,10 @@ save_
 save_array_intensities.array_id
 
     _definition.id                '_array_intensities.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_intensities
@@ -1851,9 +1722,10 @@ save_
 save_array_intensities.binary_id
 
     _definition.id                '_array_intensities.binary_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_data.binary_id in the
+;
+             This item is a pointer to _array_data.binary_id in the
               ARRAY_DATA category.
 ;
     _name.category_id             array_intensities
@@ -1872,9 +1744,10 @@ save_
 save_array_intensities.details
 
     _definition.id                '_array_intensities.details'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             A description of special aspects of the calculation of array 
+;
+             A description of special aspects of the calculation of array 
               intensities.
 ;
     _name.category_id             array_intensities
@@ -1890,9 +1763,10 @@ save_
 save_array_intensities.gain
 
     _definition.id                '_array_intensities.gain'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Detector 'gain'. The factor by which linearized
+;
+             Detector 'gain'. The factor by which linearized
               intensity count values should be divided to produce
               true photon counts.
 ;
@@ -1909,9 +1783,10 @@ save_
 save_array_intensities.gain_esd
 
     _definition.id                '_array_intensities.gain_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of detector 'gain'.
 ;
     _name.category_id             array_intensities
@@ -1928,9 +1803,10 @@ save_
 save_array_intensities.linearity
 
     _definition.id                '_array_intensities.linearity'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The intensity linearity scaling method used to convert
+;
+             The intensity linearity scaling method used to convert
               from the raw intensity to the stored element value:
 
              'linear' is linear.
@@ -1976,19 +1852,23 @@ save_array_intensities.linearity
          linear
              .
          offset
-;            The value defined by  _array_intensities.offset should
+;
+            The value defined by  _array_intensities.offset should
              be added to each element value.
 ;
          scaling
-;            The value defined by _array_intensities.scaling should be
+;
+            The value defined by _array_intensities.scaling should be
              multiplied with each element value.
 ;
          scaling_offset
-;            The combination of the scaling and offset
+;
+            The combination of the scaling and offset
              with the scale factor applied before the offset value.
 ;
          sqrt_scaled
-;            The square root of raw intensities multiplied by
+;
+            The square root of raw intensities multiplied by
              _array_intensities.scaling is calculated and stored,
              perhaps rounded to the nearest integer. Thus,
              linearization involves dividing the stored
@@ -1996,7 +1876,8 @@ save_array_intensities.linearity
              result.
 ;
          logarithmic_scaled
-;            The logarithm base 10 of raw intensities multiplied by
+;
+            The logarithm base 10 of raw intensities multiplied by
              _array_intensities.scaling  is calculated and stored,
              perhaps rounded to the nearest integer. Thus,
              linearization involves dividing the stored values by
@@ -2004,7 +1885,8 @@ save_array_intensities.linearity
              power of this number.
 ;
          raw
-;            The array consists of raw values to which no corrections have
+;
+            The array consists of raw values to which no corrections have
              been applied.  While the handling of the data is similar to
              that given for 'linear' data with no offset, the meaning of
              the data differs in that the number of incident photons is
@@ -2020,9 +1902,10 @@ save_
 save_array_intensities.offset
 
     _definition.id                '_array_intensities.offset'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Offset value to add to array element values in the manner
+;
+             Offset value to add to array element values in the manner
               described by the item _array_intensities.linearity.
 ;
     _name.category_id             array_intensities
@@ -2038,9 +1921,10 @@ save_
 save_array_intensities.overload
 
     _definition.id                '_array_intensities.overload'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The saturation intensity level for this data array, i.e. the
+;
+             The saturation intensity level for this data array, i.e. the
               value at or above which correct intensities may not be recorded.
 
               The valid pixel values are those less than
@@ -2060,9 +1944,10 @@ save_
 save_array_intensities.pixel_binning_method
 
     _definition.id                '_array_intensities.pixel_binning_method'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_intensities.pixel_binning_method specifies
+;
+             The value of _array_intensities.pixel_binning_method specifies
               the method used to derive array elements from multiple pixels.
 ;
     _name.category_id             array_intensities
@@ -2076,22 +1961,26 @@ save_array_intensities.pixel_binning_method
       _enumeration_set.state
       _enumeration_set.detail
          hardware
-;              The element intensities were derived from the raw data of one
+;
+              The element intensities were derived from the raw data of one
                or more pixels by use of hardware in the detector, e.g. by use
                of shift registers in a CCD to combine pixels into super-pixels.
 ;
          software
-;              The element intensities were derived from the raw data of more
+;
+              The element intensities were derived from the raw data of more
                than one pixel by use of software.
 ;
          combined
-;              The element intensities were derived from the raw data of more
+;
+              The element intensities were derived from the raw data of more
                than one pixel by use of both hardware and software, as when
                hardware binning is used in one direction and software in the
                other.
 ;
          none
-;              In both directions, the data have not been binned.  The
+;
+              In both directions, the data have not been binned.  The
                number of pixels is equal to the number of elements.
 
                When the value of _array_intensities.pixel_binning_method is
@@ -2099,7 +1988,8 @@ save_array_intensities.pixel_binning_method
                and _array_intensities.pixel_slow_bin_size both must be 1.
 ;
          unspecified
-;              The method used to derive element intensities is not specified.
+;
+              The method used to derive element intensities is not specified.
 ;
 
     _enumeration.default          unspecified
@@ -2109,9 +1999,10 @@ save_
 save_array_intensities.pixel_fast_bin_size
 
     _definition.id                '_array_intensities.pixel_fast_bin_size'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_intensities.pixel_fast_bin_size specifies
+;
+             The value of _array_intensities.pixel_fast_bin_size specifies
               the number of pixels that compose one element in the direction
               of the most rapidly varying array dimension.
 
@@ -2138,9 +2029,10 @@ save_
 save_array_intensities.pixel_slow_bin_size
 
     _definition.id                '_array_intensities.pixel_slow_bin_size'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_intensities.pixel_slow_bin_size specifies
+;
+             The value of _array_intensities.pixel_slow_bin_size specifies
               the number of pixels that compose one element in the direction
               of the second most rapidly varying array dimension.
 
@@ -2167,9 +2059,10 @@ save_
 save_array_intensities.scaling
 
     _definition.id                '_array_intensities.scaling'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Multiplicative scaling value to be applied to array data
+;
+             Multiplicative scaling value to be applied to array data
               in the manner described by the item
               _array_intensities.linearity.
 ;
@@ -2186,9 +2079,10 @@ save_
 save_array_intensities.undefined_value
 
     _definition.id                '_array_intensities.undefined_value'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             A value to be substituted for undefined values in
+;
+             A value to be substituted for undefined values in
               the data array.
 ;
     _name.category_id             array_intensities
@@ -2204,9 +2098,10 @@ save_
 save_array_intensities.underload
 
     _definition.id                '_array_intensities.underload'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The lowest value at which pixels for this detector are
+;
+             The lowest value at which pixels for this detector are
               measured.
 
               The valid pixel values are those less than 
@@ -2224,52 +2119,23 @@ save_array_intensities.underload
 
 save_
 
-save_array_intensities.variant
-
-    _definition.id                '_array_intensities.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_intensities.variant gives the variant
-              to which the given ARRAY_INTENSITIES row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_intensities
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_STRUCTURE
 
-    _definition.id                ARRAY_STRUCTURE
+    _definition.id                array_structure
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_STRUCTURE category record the organization and
      encoding of array data that may be stored in the ARRAY_DATA category.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_STRUCTURE
-
-    loop_
-      _category_key.name
-         '_array_structure.id'
-         '_array_structure.variant'
-
+    _name.object_id               array_structure
+    _category_key.name            '_array_structure.id'
     _description_example.case
-;     loop_
+;
+     loop_
     _array_structure.id
     _array_structure.encoding_type
     _array_structure.compression_type
@@ -2283,9 +2149,10 @@ save_
 save_array_structure.byte_order
 
     _definition.id                '_array_structure.byte_order'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The order of bytes for integer values which require more
+;
+             The order of bytes for integer values which require more
               than 1 byte.
 
               (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
@@ -2305,11 +2172,13 @@ save_array_structure.byte_order
       _enumeration_set.state
       _enumeration_set.detail
          big_endian
-;       The first byte in the byte stream of the bytes which make up an
+;
+       The first byte in the byte stream of the bytes which make up an
         integer value is the most significant byte of an integer.
 ;
          little_endian
-;       The last byte in the byte stream of the bytes which make up an
+;
+       The last byte in the byte stream of the bytes which make up an
         integer value is the most significant byte of an integer.
 ;
 
@@ -2318,9 +2187,10 @@ save_
 save_array_structure.compression_type
 
     _definition.id                '_array_structure.compression_type'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Type of data-compression method used to compress the array
+;
+             Type of data-compression method used to compress the array
               data.
 ;
     _name.category_id             array_structure
@@ -2334,29 +2204,35 @@ save_array_structure.compression_type
       _enumeration_set.state
       _enumeration_set.detail
          byte_offset
-;       Using the 'byte_offset' compression scheme as per A. Hammersley
+;
+       Using the 'byte_offset' compression scheme as per A. Hammersley
         and the CBFlib manual, section 3.3.3
 ;
          canonical
-;       Using the 'canonical' compression scheme (International Tables
+;
+       Using the 'canonical' compression scheme (International Tables
         for Crystallography Volume G, Section 5.6.3.1) and CBFlib
         manual section 3.3.1
 ;
          nibble_offset
-;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+;
+       Using the 'nibble_offset' compression scheme as per H. Bernstein
         and the CBFlib manual, section 3.3.4
 ;
          none
-;       Data are stored in normal format as defined by
+;
+       Data are stored in normal format as defined by
         _array_structure.encoding_type and
         _array_structure.byte_order.
 ;
          packed
-;       Using the 'packed' compression scheme, a CCP4-style packing
+;
+       Using the 'packed' compression scheme, a CCP4-style packing
         as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
          packed_v2
-;       Using the 'packed' compression scheme, version 2, as per
+;
+       Using the 'packed' compression scheme, version 2, as per
         J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
 
@@ -2367,9 +2243,10 @@ save_
 save_array_structure.compression_type_flag
 
     _definition.id                '_array_structure.compression_type_flag'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Flags modifying the type of data-compression method used to 
+;
+             Flags modifying the type of data-compression method used to 
               compress the arraydata.
 ;
     _name.category_id             array_structure
@@ -2383,12 +2260,14 @@ save_array_structure.compression_type_flag
       _enumeration_set.state
       _enumeration_set.detail
          uncorrelated_sections
-;       When applying packed or packed_v2 compression on an array with
+;
+       When applying packed or packed_v2 compression on an array with
         uncorrelated sections, do not average in points from the prior
         section.
 ;
          flat
-;       When applying packed or packed_v2 compression on an array that
+;
+       When applying packed or packed_v2 compression on an array that
         treats the entire image as a single line set the maximum number
         of bits for an offset to 65 bits.
 
@@ -2401,9 +2280,10 @@ save_
 save_array_structure.encoding_type
 
     _definition.id                '_array_structure.encoding_type'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Data encoding of a single element of array data.
+;
+             Data encoding of a single element of array data.
 
               The type 'unsigned 1-bit integer' is used for
               packed Boolean arrays for masks.  Each element
@@ -2442,9 +2322,10 @@ save_
 save_array_structure.id
 
     _definition.id                '_array_structure.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_structure.id must uniquely identify
+;
+             The value of _array_structure.id must uniquely identify
               each item of array data.              
 
               This item has been made implicit and given a default value of 1
@@ -2461,54 +2342,30 @@ save_array_structure.id
 
 save_
 
-save_array_structure.variant
-
-    _definition.id                '_array_structure.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_structure.variant gives the variant
-              to which the given ARRAY_STRUCTURE row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_structure
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_STRUCTURE_LIST
 
-    _definition.id                ARRAY_STRUCTURE_LIST
+    _definition.id                array_structure_list
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;    Data items in the ARRAY_STRUCTURE_LIST category record the size
+;
+    Data items in the ARRAY_STRUCTURE_LIST category record the size
      and organization of each array dimension.
 
      The relationship to physical axes may be given.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST
+    _name.object_id               array_structure_list
 
     loop_
       _category_key.name
          '_array_structure_list.array_id'
          '_array_structure_list.index'
-         '_array_structure_list.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
        _array_structure_list.array_id
        _array_structure_list.index
        _array_structure_list.dimension
@@ -2519,7 +2376,8 @@ save_ARRAY_STRUCTURE_LIST
         image_1   2    1200    2     decreasing  ELEMENY_Y
 ;
     _description_example.detail
-;       Example 1. An image array of 1300 x 1200 elements.  The raster
+;
+       Example 1. An image array of 1300 x 1200 elements.  The raster
                     order of the image is left to right (increasing) in the
                     first dimension and bottom to top (decreasing) in
                     the second dimension.
@@ -2530,9 +2388,10 @@ save_
 save_array_structure_list.array_id
 
     _definition.id                '_array_structure_list.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list
@@ -2549,9 +2408,10 @@ save_
 save_array_structure_list.array_section_id
 
     _definition.id                '_array_structure_list.array_section_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure_list_section.id in the
+;
+             This item is a pointer to _array_structure_list_section.id in the
               ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             array_structure_list
@@ -2566,9 +2426,10 @@ save_
 save_array_structure_list.axis_set_id
 
     _definition.id                '_array_structure_list.axis_set_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This is a descriptor for the physical axis or set of axes
+;
+             This is a descriptor for the physical axis or set of axes
               corresponding to an array index.
 
               This data item is related to the axes of the detector
@@ -2584,8 +2445,9 @@ save_array_structure_list.axis_set_id
 ;
     _name.category_id             array_structure_list
     _name.object_id               axis_set_id
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _name.linked_item_id          '_array_structure_list_axis.axis_set_id'
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Word
 
@@ -2594,9 +2456,10 @@ save_
 save_array_structure_list.dimension
 
     _definition.id                '_array_structure_list.dimension'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The number of elements stored in the array structure in 
+;
+             The number of elements stored in the array structure in 
               this dimension.
 ;
     _name.category_id             array_structure_list
@@ -2613,9 +2476,10 @@ save_
 save_array_structure_list.direction
 
     _definition.id                '_array_structure_list.direction'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the direction in which this array index changes.
+;
+             Identifies the direction in which this array index changes.
 ;
     _name.category_id             array_structure_list
     _name.object_id               direction
@@ -2628,10 +2492,12 @@ save_array_structure_list.direction
       _enumeration_set.state
       _enumeration_set.detail
          increasing
-;       Indicates the index changes from 1 to the maximum dimension.
+;
+       Indicates the index changes from 1 to the maximum dimension.
 ;
          decreasing
-;       Indicates the index changes from the maximum dimension to 1.
+;
+       Indicates the index changes from the maximum dimension to 1.
 ;
 
 save_
@@ -2639,9 +2505,10 @@ save_
 save_array_structure_list.index
 
     _definition.id                '_array_structure_list.index'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the one-based index of the row or column in the
+;
+             Identifies the one-based index of the row or column in the
               array structure.
 ;
     _name.category_id             array_structure_list
@@ -2658,9 +2525,10 @@ save_
 save_array_structure_list.precedence
 
     _definition.id                '_array_structure_list.precedence'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the rank order in which this array index changes
+;
+             Identifies the rank order in which this array index changes
               with respect to other array indices.  The precedence of 1
               indicates the index which changes fastest.
 ;
@@ -2675,37 +2543,12 @@ save_array_structure_list.precedence
 
 save_
 
-save_array_structure_list.variant
-
-    _definition.id                '_array_structure_list.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_structure_list.variant gives the variant
-              to which the given ARRAY_STRUCTURE_LIST row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_structure_list
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_STRUCTURE_LIST_AXIS
 
-    _definition.id                ARRAY_STRUCTURE_LIST_AXIS
+    _definition.id                array_structure_list_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the ARRAY_STRUCTURE_LIST_AXIS category describe
@@ -2726,22 +2569,22 @@ save_ARRAY_STRUCTURE_LIST_AXIS
      of an array.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST_AXIS
+    _name.object_id               array_structure_list_axis
 
     loop_
       _category_key.name
          '_array_structure_list_axis.axis_set_id'
          '_array_structure_list_axis.axis_id'
-         '_array_structure_list_axis.variant'
 
 save_
 
 save_array_structure_list_axis.angle
 
     _definition.id                '_array_structure_list_axis.angle'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in degrees for the first
+;
+             The setting of the specified axis in degrees for the first
                data point of the array index with the corresponding value
                of _array_structure_list.axis_set_id.  If the index is
                specified as 'increasing', this will be the centre of the
@@ -2763,9 +2606,10 @@ save_
 save_array_structure_list_axis.angle_increment
 
     _definition.id                '_array_structure_list_axis.angle_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The pixel-centre-to-pixel-centre increment in the angular
+;
+             The pixel-centre-to-pixel-centre increment in the angular
                setting of the specified axis in degrees.  This is not
                meaningful in the case of 'constant velocity' spiral scans
                and should not be specified for this case.
@@ -2787,9 +2631,10 @@ save_
 save_array_structure_list_axis.angular_pitch
 
     _definition.id                '_array_structure_list_axis.angular_pitch'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The pixel-centre-to-pixel-centre distance for a one-step
+;
+             The pixel-centre-to-pixel-centre distance for a one-step
                change in the setting of the specified axis in millimetres.
 
                This is meaningful only for 'constant velocity' spiral scans
@@ -2814,9 +2659,10 @@ save_
 save_array_structure_list_axis.axis_id
 
     _definition.id                '_array_structure_list_axis.axis_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes in the set of axes for which settings are being
               specified.
 
@@ -2839,9 +2685,10 @@ save_
 save_array_structure_list_axis.axis_set_id
 
     _definition.id                '_array_structure_list_axis.axis_set_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
                set of axes for which axis settings are being specified.
 
                Multiple axes may be specified for the same value of
@@ -2856,9 +2703,8 @@ save_array_structure_list_axis.axis_set_id
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_set_id
-    _name.linked_item_id          '_array_structure_list.axis_set_id'
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 
@@ -2867,9 +2713,10 @@ save_
 save_array_structure_list_axis.displacement
 
     _definition.id                '_array_structure_list_axis.displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in millimetres for the first
+;
+             The setting of the specified axis in millimetres for the first
                data point of the array index with the corresponding value
                of _array_structure_list.axis_set_id.  If the index is
                specified as 'increasing', this will be the centre of the
@@ -2892,9 +2739,10 @@ save_array_structure_list_axis.displacement_increment
 
     _definition.id
         '_array_structure_list_axis.displacement_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The pixel-centre-to-pixel-centre increment for the displacement
+;
+             The pixel-centre-to-pixel-centre increment for the displacement
                setting of the specified axis in millimetres.
 ;
     _name.category_id             array_structure_list_axis
@@ -2912,9 +2760,10 @@ save_array_structure_list_axis.fract_displacement
 
     _definition.id
         '_array_structure_list_axis.fract_displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis as a decimal fraction of 
+;
+             The setting of the specified axis as a decimal fraction of 
                the axis unit vector for the first data point of the array 
                index with the corresponding value of 
                _array_structure_list.axis_set_id.  
@@ -2939,9 +2788,10 @@ save_array_structure_list_axis.fract_displacement_increment
 
     _definition.id
         '_array_structure_list_axis.fract_displacement_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The pixel-centre-to-pixel-centre increment for the displacement
+;
+             The pixel-centre-to-pixel-centre increment for the displacement
                setting of the specified axis as a decimal fraction of the
                axis unit vector.
 ;
@@ -2959,9 +2809,10 @@ save_
 save_array_structure_list_axis.radial_pitch
 
     _definition.id                '_array_structure_list_axis.radial_pitch'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The radial distance from one 'cylinder' of pixels to the
+;
+             The radial distance from one 'cylinder' of pixels to the
                next in millimetres.  If the scan is a 'constant velocity'
                scan with differing angular displacements between pixels,
                the value of this item may differ significantly from the
@@ -2981,9 +2832,10 @@ save_
 save_array_structure_list_axis.reference_angle
 
     _definition.id                '_array_structure_list_axis.reference_angle'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_structure_list_axis.reference_angle
+;
+             The value of _array_structure_list_axis.reference_angle
                specifies the setting of the angle of this axis used for 
                determining a reference beam centre and a reference detector 
                distance.  It is normally expected to be identical to the 
@@ -3004,9 +2856,10 @@ save_array_structure_list_axis.reference_displacement
 
     _definition.id
         '_array_structure_list_axis.reference_displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _array_structure_list_axis.reference_displacement
+;
+             The value of _array_structure_list_axis.reference_displacement
                specifies the setting of the displacement of this axis used 
                for determining a reference beam centre and a reference detector
                distance.  It is normally expected to be identical to the value
@@ -3023,39 +2876,15 @@ save_array_structure_list_axis.reference_displacement
 
 save_
 
-save_array_structure_list_axis.variant
-
-    _definition.id                '_array_structure_list_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;            The value of _array_structure_list_axis.variant gives the variant
-              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_structure_list_axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_ARRAY_STRUCTURE_LIST_SECTION
 
-    _definition.id                ARRAY_STRUCTURE_LIST_SECTION
+    _definition.id                array_structure_list_section
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
+;
+   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
     the dimension-by-dimension start, end and stride of each section of an
     array that is to be referenced.
 
@@ -3078,17 +2907,18 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     by the stride.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               ARRAY_STRUCTURE_LIST_SECTION
+    _name.object_id               array_structure_list_section
 
     loop_
       _category_key.name
          '_array_structure_list_section.id'
          '_array_structure_list_section.array_id'
          '_array_structure_list_section.index'
-         '_array_structure_list_section.variant'
 
     _description_example.case
-;     loop_
+;
+
+     loop_
     _array_structure_list.array_id
     _array_structure_list.index
     _array_structure_list.dimension
@@ -3109,9 +2939,11 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
     "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
     "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+
 ;
     _description_example.detail
-;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+;
+       Example 1. An image array, myarray, of 1300 x 1200 elements, and
                     700 frames is defined in ARRAY_STRUCTURE_LIST, and
                     the array section identifier
 
@@ -3128,9 +2960,10 @@ save_
 save_array_structure_list_section.array_id
 
     _definition.id                '_array_structure_list_section.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list_section
@@ -3147,9 +2980,10 @@ save_
 save_array_structure_list_section.end
 
     _definition.id                '_array_structure_list_section.end'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the ending ordinal, numbered from 1, for an array
+;
+             Identifies the ending ordinal, numbered from 1, for an array
               element of index _array_structure_list_section.index in the
               section.
 
@@ -3176,9 +3010,10 @@ save_
 save_array_structure_list_section.id
 
     _definition.id                '_array_structure_list_section.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Uniquely identifies the array section chosen.
+;
+             Uniquely identifies the array section chosen.
 
               To avoid confusion array section IDs that contain parentheses
               should conform to the default syntax
@@ -3197,9 +3032,10 @@ save_
 save_array_structure_list_section.index
 
     _definition.id                '_array_structure_list_section.index'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure_list.index
+;
+             This item is a pointer to _array_structure_list.index
               in the ARRAY_STRUCTURE_LIST category.
 
               Identifies the one-based index of the row, column, sheet ...
@@ -3225,9 +3061,10 @@ save_
 save_array_structure_list_section.start
 
     _definition.id                '_array_structure_list_section.start'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the starting ordinal, numbered from 1,
+;
+             Identifies the starting ordinal, numbered from 1,
               for an array element of index _array_structure_list_section.index
               in the section.
 
@@ -3264,9 +3101,10 @@ save_
 save_array_structure_list_section.stride
 
     _definition.id                '_array_structure_list_section.stride'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Identifies the incremental steps to be taken when moving
+;
+             Identifies the incremental steps to be taken when moving
               element to element in the section in that particular
               dimension.  The value of _array_structure_list_section.stride
               may be positive or negative.  If the stride is zero, the section
@@ -3284,39 +3122,15 @@ save_array_structure_list_section.stride
 
 save_
 
-save_array_structure_list_section.variant
-
-    _definition.id                '_array_structure_list_section.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _array_structure_list_section.variant gives the
-              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
-              is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             array_structure_list_section
-    _name.object_id               variant
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_AXIS
 
-    _definition.id                AXIS
+    _definition.id                axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;   Data items in the AXIS category record the information required
+;
+   Data items in the AXIS category record the information required
      to describe the various goniometer, detector, source and other
      axes needed to specify a data collection or the axes defining the
      coordinate system of an image.  
@@ -3653,13 +3467,12 @@ save_AXIS
      Brookhaven National Laboratory.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               AXIS
+    _name.object_id               axis
 
     loop_
       _category_key.name
          '_axis.id'
          '_axis.equipment'
-         '_axis.variant'
 
     loop_
       _description_example.case
@@ -3675,7 +3488,8 @@ save_AXIS
         kappa rotation goniometer omega    -.64279  0       -.76604
         phi   rotation goniometer kappa    1        0        0
 ;
-;      Example 1.
+;
+      Example 1.
 
         This example shows the axis specification of the axes of a
         kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
@@ -3706,7 +3520,8 @@ save_AXIS
         roty      rotation    detector twotheta  0     1     0   0 0 -68
         rotz      rotation    detector roty      0     0     1   0 0 -68
 ;
-;      Example 2.
+;
+      Example 2.
 
         This example shows the axis specification of the axes of a
         detector, source and gravity.  The order has been changed as a
@@ -3742,7 +3557,8 @@ save_AXIS
         CELL_B_AXIS 0.01 0.02
         CELL_C_AXIS 0.01 0.02
 ;
-;      Example 3.
+;
+      Example 3.
 
         This example shows the axis specification of the axes for a map,
         using fractional coordinates.  Each cell edge has been divided
@@ -3785,7 +3601,8 @@ save_AXIS
         Y 7.5e-8 1.5e-7
         Z 7.5e-8 1.5e-7
 ;
-;      Example 4.
+;
+      Example 4.
 
         This example shows the axis specification of the axes for a map,
         this time as orthogonal \%angstr\"oms, using the same coordinate system 
@@ -4217,7 +4034,8 @@ save_AXIS
     AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
     AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
 ;
-;       Example 5.
+;
+       Example 5.
 
     This example shows an excerpt from the axis specification of an FEL detector
     provided by N. Sauter and A. Brewster.
@@ -5035,7 +4853,8 @@ save_AXIS
                         AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
 
 ;
-;       Example 6.
+;
+       Example 6.
 
     This example shows an excerpt from the axis specification of an FEL detector
     provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
@@ -5078,9 +4897,10 @@ save_
 save_axis.depends_on
 
     _definition.id                '_axis.depends_on'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _axis.depends_on specifies the next outermost
+;
+            The value of _axis.depends_on specifies the next outermost
               axis upon which this axis depends, unless
               _axis.rotation_axis is specified, in which case,
               _axis.rotation_axis is next outermost and
@@ -5101,9 +4921,10 @@ save_
 save_axis.equipment
 
     _definition.id                '_axis.equipment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of  _axis.equipment specifies the type of
+;
+            The value of  _axis.equipment specifies the type of
               equipment using the axis:  'goniometer', 'detector',
              'gravity', 'source' or 'general'.
 ;
@@ -5130,9 +4951,10 @@ save_
 save_axis.equipment_component
 
     _definition.id                '_axis.equipment_component'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of  _axis.equipment_component specifies
+;
+            The value of  _axis.equipment_component specifies
               an arbitrary identifier of a component of the equipment to which
               the axis belongs, such as 'detector_arm' or 'detector_module'.
 
@@ -5149,9 +4971,10 @@ save_
 save_axis.id
 
     _definition.id                '_axis.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _axis.id must uniquely identify
+;
+            The value of _axis.id must uniquely identify
               each axis relevant to the experiment.  Note that multiple
               pieces of equipment may share the same axis (e.g. a twotheta
               arm), so the category key for AXIS also includes the
@@ -5169,9 +4992,10 @@ save_
 save_axis.offset[1]
 
     _definition.id                '_axis.offset[1]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [1] element of the three-element vector used to specify
+;
+             The [1] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
@@ -5190,9 +5014,10 @@ save_
 save_axis.offset[2]
 
     _definition.id                '_axis.offset[2]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [2] element of the three-element vector used to specify
+;
+             The [2] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
@@ -5211,9 +5036,10 @@ save_
 save_axis.offset[3]
 
     _definition.id                '_axis.offset[3]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [3] element of the three-element vector used to specify
+;
+             The [3] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
@@ -5232,9 +5058,10 @@ save_
 save_axis.rotation
 
     _definition.id                '_axis.rotation'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _axis.rotation specifies
+;
+            The value of _axis.rotation specifies
               the fixed base rotation angle for _axis.rotation_axis
               to which the value of any frame-by-frame setting, if any, should
               be added.  Normally, only the fixed value would be given.
@@ -5253,9 +5080,10 @@ save_
 save_axis.rotation_axis
 
     _definition.id                '_axis.rotation_axis'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _axis.rotation_axis specifies
+;
+            The value of _axis.rotation_axis specifies
               an optional additional dependency for this axis to be applied
               after applying _axis.depends_on.
 
@@ -5273,9 +5101,10 @@ save_
 save_axis.system
 
     _definition.id                '_axis.system'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of  _axis.system specifies the coordinate
+;
+            The value of  _axis.system specifies the coordinate
               system used to define the axis: 'laboratory', 'McStas', 'direct', 
              'orthogonal', 'reciprocal' or 'abstract'.
 ;
@@ -5323,9 +5152,10 @@ save_
 save_axis.type
 
     _definition.id                '_axis.type'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _axis.type specifies the type of
+;
+            The value of _axis.type specifies the type of
               axis:  'rotation' or 'translation' (or 'general' when
               the type is not relevant, as for gravity).
 ;
@@ -5347,37 +5177,13 @@ save_axis.type
 
 save_
 
-save_axis.variant
-
-    _definition.id                '_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;            The value of _axis.variant gives the variant
-              to which the given AXIS row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_axis.vector[1]
 
     _definition.id                '_axis.vector[1]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [1] element of the three-element vector used to specify
+;
+             The [1] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
@@ -5396,9 +5202,10 @@ save_
 save_axis.vector[2]
 
     _definition.id                '_axis.vector[2]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [2] element of the three-element vector used to specify
+;
+             The [2] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
@@ -5417,9 +5224,10 @@ save_
 save_axis.vector[3]
 
     _definition.id                '_axis.vector[3]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The [3] element of the three-element vector used to specify
+;
+             The [3] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
@@ -5437,12 +5245,13 @@ save_
 
 save_DIFFRN
 
-    _definition.id                DIFFRN
+    _definition.id                diffrn
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              Data items in the DIFFRN category record details about the
+;
+              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
 
                This is a stub category for the cif_img dicionary to
@@ -5451,7 +5260,7 @@ save_DIFFRN
                dictionary
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN
+    _name.object_id               diffrn
     _category_key.name            '_diffrn.id'
 
 save_
@@ -5459,9 +5268,10 @@ save_
 save_diffrn.id
 
     _definition.id                '_diffrn.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              This data item uniquely identifies a set of diffraction
+;
+              This data item uniquely identifies a set of diffraction
                data.
 ;
     _name.category_id             diffrn
@@ -5475,12 +5285,13 @@ save_
 
 save_DIFFRN_DATA_FRAME
 
-    _definition.id                DIFFRN_DATA_FRAME
+    _definition.id                diffrn_data_frame
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            Data items in the DIFFRN_DATA_FRAME category record
+;
+            Data items in the DIFFRN_DATA_FRAME category record
               the details about each frame of data.
 
               The items in this category were previously in a
@@ -5489,16 +5300,16 @@ save_DIFFRN_DATA_FRAME
               as aliases but should not be used for new work.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_DATA_FRAME
+    _name.object_id               diffrn_data_frame
 
     loop_
       _category_key.name
          '_diffrn_data_frame.id'
          '_diffrn_data_frame.detector_element_id'
-         '_diffrn_data_frame.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _diffrn_data_frame.id
         _diffrn_data_frame.detector_element_id
         _diffrn_data_frame.array_id
@@ -5509,7 +5320,8 @@ save_DIFFRN_DATA_FRAME
         frame_1   d1_ccd_4  array_1  4
 ;
     _description_example.detail
-;     Example 1. a frame containing data from four frame elements.
+;
+     Example 1. a frame containing data from four frame elements.
 
                        Each frame element has a common array configuration
                        'array_1' described in ARRAY_STRUCTURE and related
@@ -5527,9 +5339,10 @@ save_diffrn_data_frame.array_id
     _alias.definition_id          '_diffrn_frame_data.array_id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            This item is a pointer to _array_structure.id in the
+;
+            This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             diffrn_data_frame
@@ -5546,9 +5359,10 @@ save_
 save_diffrn_data_frame.array_section_id
 
     _definition.id                '_diffrn_data_frame.array_section_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            This item is a pointer to _array_structure_list_section.id
+;
+            This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             diffrn_data_frame
@@ -5567,9 +5381,10 @@ save_diffrn_data_frame.binary_id
     _alias.definition_id          '_diffrn_frame_data.binary_id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            This item is a pointer to _array_data.binary_id in the
+;
+            This item is a pointer to _array_data.binary_id in the
               ARRAY_DATA category.
 ;
     _name.category_id             diffrn_data_frame
@@ -5588,9 +5403,10 @@ save_
 save_diffrn_data_frame.center_derived
 
     _definition.id                '_diffrn_data_frame.center_derived'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_data_frame.center_derived
+;
+             The value of _diffrn_data_frame.center_derived
               is assumed to be 'yes', i.e. that values of
               _diffrn_data_frame.center_fast and
               _diffrn_data_frame.center_slow 
@@ -5609,9 +5425,10 @@ save_
 save_diffrn_data_frame.center_fast
 
     _definition.id                '_diffrn_data_frame.center_fast'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _diffrn_data_frame.center_fast is 
+;
+            The value of _diffrn_data_frame.center_fast is 
               the fast index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_data_frame.center_units along the fast
@@ -5639,9 +5456,10 @@ save_
 save_diffrn_data_frame.center_slow
 
     _definition.id                '_diffrn_data_frame.center_slow'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_data_frame.center_slow is
+;
+             The value of _diffrn_data_frame.center_slow is
               the slow index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_data_frame.center_units along the slow
@@ -5667,9 +5485,10 @@ save_
 save_diffrn_data_frame.center_units
 
     _definition.id                '_diffrn_data_frame.center_units'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_data_frame.center_units
+;
+             The value of _diffrn_data_frame.center_units
               specifies the units in which the values of 
               _diffrn_data_frame.center_fast and
               _diffrn_data_frame.center_slow
@@ -5711,9 +5530,10 @@ save_diffrn_data_frame.details
 ;\
 https://github.com/dials/cbflib/raw/refs/heads/main/doc/cif_img_1.4_4Jul06_draft.dic
 ;
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_data_frame.details should give a
+;
+             The value of _diffrn_data_frame.details should give a
               description of special aspects of each frame of data.
 
               This is an appropriate location in which to record
@@ -5737,30 +5557,31 @@ https://github.com/dials/cbflib/raw/refs/heads/main/doc/cif_img_1.4_4Jul06_draft
     _description_example.case
 ;
     HEADER_BYTES = 512;
-    DIM = 2;
-    BYTE_ORDER = big_endian;
-    TYPE = unsigned_short;
-    SIZE1 = 3072;
-    SIZE2 = 3072;
-    PIXEL_SIZE = 0.102588;
-    BIN = 2x2;
-    DETECTOR_SN = 901;
-    TIME = 29.945155;
-    DISTANCE = 200.000000;
-    PHI = 85.000000;
-    OSC_START = 85.000000;
-    OSC_RANGE = 1.000000;
-    WAVELENGTH = 0.979381;
-    BEAM_CENTER_X = 157.500000;
-    BEAM_CENTER_Y = 157.500000;
-    PIXEL SIZE = 0.102588;
-    OSCILLATION RANGE = 1;
-    EXPOSURE TIME = 29.9452;
-    TWO THETA = 0;
-    BEAM CENTRE = 157.5 157.5;
+        DIM = 2;
+        BYTE_ORDER = big_endian;
+        TYPE = unsigned_short;
+        SIZE1 = 3072;
+        SIZE2 = 3072;
+        PIXEL_SIZE = 0.102588;
+        BIN = 2x2;
+        DETECTOR_SN = 901;
+        TIME = 29.945155;
+        DISTANCE = 200.000000;
+        PHI = 85.000000;
+        OSC_START = 85.000000;
+        OSC_RANGE = 1.000000;
+        WAVELENGTH = 0.979381;
+        BEAM_CENTER_X = 157.500000;
+        BEAM_CENTER_Y = 157.500000;
+        PIXEL SIZE = 0.102588;
+        OSCILLATION RANGE = 1;
+        EXPOSURE TIME = 29.9452;
+        TWO THETA = 0;
+        BEAM CENTRE = 157.5 157.5;
 ;
     _description_example.detail
-;              Example of header information extracted from an ADSC Quantum
+;
+              Example of header information extracted from an ADSC Quantum
                315 detector header by CBFlib_0.7.6.  Image provided by Chris
                Nielsen of ADSC from a data collection at SSRL beamline 1-5.
 ;
@@ -5773,9 +5594,10 @@ save_diffrn_data_frame.detector_element_id
     _alias.definition_id          '_diffrn_frame_data.detector_element_id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn_detector_element.id
+;
+             This item is a pointer to _diffrn_detector_element.id
               in the DIFFRN_DETECTOR_ELEMENT category.
 ;
     _name.category_id             diffrn_data_frame
@@ -5791,9 +5613,10 @@ save_
 save_diffrn_data_frame.diffrn_id
 
     _definition.id                '_diffrn_data_frame.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to '_diffrn.id'
+;
+             This item is a pointer to '_diffrn.id'
               in the DIFFRN category.
 ;
     _name.category_id             diffrn_data_frame
@@ -5812,9 +5635,10 @@ save_diffrn_data_frame.id
     _alias.definition_id          '_diffrn_frame_data.id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_data_frame.id must uniquely identify
+;
+             The value of _diffrn_data_frame.id must uniquely identify
               each complete frame of data.
 ;
     _name.category_id             diffrn_data_frame
@@ -5826,37 +5650,12 @@ save_diffrn_data_frame.id
 
 save_
 
-save_diffrn_data_frame.variant
-
-    _definition.id                '_diffrn_data_frame.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_data_frame.variant gives the variant
-              to which the given DIFFRN_DATA_FRAME row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_data_frame
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_DETECTOR
 
-    _definition.id                DIFFRN_DETECTOR
+    _definition.id                diffrn_detector
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -5864,21 +5663,22 @@ save_DIFFRN_DETECTOR
      any analyser and post-sample collimation.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_DETECTOR
+    _name.object_id               diffrn_detector
 
     loop_
       _category_key.name
          '_diffrn_detector.diffrn_id'
          '_diffrn_detector.id'
-         '_diffrn_detector.variant'
 
     _description_example.case
-;    _diffrn_detector.diffrn_id             'd1'
+;
+    _diffrn_detector.diffrn_id             'd1'
     _diffrn_detector.detector              'multiwire'
     _diffrn_detector.type                  'Siemens'
 ;
     _description_example.detail
-;   Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
                 structure corresponding to PDB entry 5HVP.
 ;
 
@@ -5891,9 +5691,10 @@ save_diffrn_detector.details
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             A description of special aspects of the radiation detector.
+;
+             A description of special aspects of the radiation detector.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               details
@@ -5908,9 +5709,10 @@ save_
 save_diffrn_detector.diffrn_id
 
     _definition.id                '_diffrn_detector.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in the DIFFRN
+;
+             This data item is a pointer to '_diffrn.id' in the DIFFRN
               category.
 
               The value of _diffrn.id uniquely defines a set of
@@ -5939,9 +5741,10 @@ save_diffrn_detector.dtime
          '_diffrn_detector_dtime'                                             .
          ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.dic
 
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The deadtime in microseconds of the detector(s) used to
+;
+             The deadtime in microseconds of the detector(s) used to
               measure the diffraction intensities.
 ;
     _name.category_id             diffrn_detector
@@ -5958,9 +5761,10 @@ save_
 save_diffrn_detector.gain_setting
 
     _definition.id                '_diffrn_detector.gain_setting'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The gain setting for detector.   This is a text string usually
+;
+             The gain setting for detector.   This is a text string usually
               reflecting a detector setting that may have a simple or very
               complex relationship with the value of
               _array_intensities.gain
@@ -5983,9 +5787,10 @@ save_
 save_diffrn_detector.id
 
     _definition.id                '_diffrn_detector.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector.id must uniquely identify
+;
+             The value of _diffrn_detector.id must uniquely identify
               each detector used to collect each diffraction data set.
 
               If the value of _diffrn_detector.id is not given, it is
@@ -6004,9 +5809,10 @@ save_
 save_diffrn_detector.layer_thickness
 
     _definition.id                '_diffrn_detector.layer_thickness'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The thickness in mm of the sensing layer of the detector
+;
+             The thickness in mm of the sensing layer of the detector
               for use in angular corrections.
 ;
     _name.category_id             diffrn_detector
@@ -6023,9 +5829,10 @@ save_
 save_diffrn_detector.number_of_axes
 
     _definition.id                '_diffrn_detector.number_of_axes'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector.number_of_axes gives the
+;
+             The value of _diffrn_detector.number_of_axes gives the
               number of axes of the positioner for the detector identified
               by _diffrn_detector.id.
 
@@ -6052,59 +5859,34 @@ save_diffrn_detector.number_of_axes
 
 save_
 
-save_diffrn_detector.variant
-
-    _definition.id                '_diffrn_detector.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_detector.variant gives the variant
-              to which the given DIFFRN_DETECTOR row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_detector
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_DETECTOR_AXIS
 
-    _definition.id                DIFFRN_DETECTOR_AXIS
+    _definition.id                diffrn_detector_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR_AXIS category associate
      axes with detectors.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_DETECTOR_AXIS
+    _name.object_id               diffrn_detector_axis
 
     loop_
       _category_key.name
          '_diffrn_detector_axis.detector_id'
          '_diffrn_detector_axis.axis_id'
-         '_diffrn_detector_axis.variant'
 
 save_
 
 save_diffrn_detector_axis.axis_id
 
     _definition.id                '_diffrn_detector_axis.axis_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _axis.id in
+;
+             This data item is a pointer to _axis.id in
                the AXIS category.
 ;
     _name.category_id             diffrn_detector_axis
@@ -6123,9 +5905,10 @@ save_diffrn_detector_axis.detector_id
     _alias.definition_id          '_diffrn_detector_axis.id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn_detector.id in
+;
+             This data item is a pointer to _diffrn_detector.id in
               the DIFFRN_DETECTOR category.
 
               This item was previously named _diffrn_detector_axis.id
@@ -6145,9 +5928,10 @@ save_
 save_diffrn_detector_axis.diffrn_id
 
     _definition.id                '_diffrn_detector_axis.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_axis
@@ -6160,37 +5944,12 @@ save_diffrn_detector_axis.diffrn_id
 
 save_
 
-save_diffrn_detector_axis.variant
-
-    _definition.id                '_diffrn_detector_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;            The value of _diffrn_detector_axis.variant gives the variant
-             to which the given DIFFRN_DETECTOR_AXIS row is related.
-
-             If this value is not given, the variant is assumed to be
-             the default null variant.
-
-             This item is a pointer to _variant.variant in the
-             VARIANT category.
-;
-    _name.category_id             diffrn_detector_axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_DETECTOR_ELEMENT
 
-    _definition.id                DIFFRN_DETECTOR_ELEMENT
+    _definition.id                diffrn_detector_element
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR_ELEMENT category record
@@ -6203,16 +5962,16 @@ save_DIFFRN_DETECTOR_ELEMENT
      detector element.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_DETECTOR_ELEMENT
+    _name.object_id               diffrn_detector_element
 
     loop_
       _category_key.name
          '_diffrn_detector_element.id'
          '_diffrn_detector_element.detector_id'
-         '_diffrn_detector_element.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _diffrn_detector_element.detector_id
         _diffrn_detector_element.id
         _diffrn_detector_element.reference_center_fast
@@ -6224,7 +5983,8 @@ save_DIFFRN_DETECTOR_ELEMENT
         d1     d1_ccd_4  -1.7   -1.5  mm
 ;
     _description_example.detail
-;      Example 1. Detector d1 is composed of four CCD detector elements,
+;
+      Example 1. Detector d1 is composed of four CCD detector elements,
         each 200 mm by 200 mm, arranged in a square, in the pattern
 
                    1     2
@@ -6245,9 +6005,10 @@ save_
 save_diffrn_detector_element.center[1]
 
     _definition.id                '_diffrn_detector_element.center[1]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector_element.center[1] is the X
+;
+             The value of _diffrn_detector_element.center[1] is the X
               component of the distortion-corrected beam centre in
               millimetres from the (0, 0) (lower-left) corner of the
               detector element viewed from the sample side.
@@ -6280,9 +6041,10 @@ save_
 save_diffrn_detector_element.center[2]
 
     _definition.id                '_diffrn_detector_element.center[2]'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector_element.center[2] is the Y
+;
+             The value of _diffrn_detector_element.center[2] is the Y
               component of the distortion-corrected beam centre in
               millimetres from the (0, 0) (lower-left) corner of the
               detector element viewed from the sample side.
@@ -6315,9 +6077,10 @@ save_
 save_diffrn_detector_element.detector_id
 
     _definition.id                '_diffrn_detector_element.detector_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn_detector.id
+;
+             This item is a pointer to _diffrn_detector.id
               in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             diffrn_detector_element
@@ -6332,9 +6095,10 @@ save_
 save_diffrn_detector_element.diffrn_id
 
     _definition.id                '_diffrn_detector_element.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn.id
+;
+             This item is a pointer to _diffrn.id
               in the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_element
@@ -6350,9 +6114,10 @@ save_
 save_diffrn_detector_element.id
 
     _definition.id                '_diffrn_detector_element.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;            The value of _diffrn_detector_element.id must uniquely
+;
+            The value of _diffrn_detector_element.id must uniquely
              identify each element of a detector.
 ;
     _name.category_id             diffrn_detector_element
@@ -6368,9 +6133,10 @@ save_diffrn_detector_element.reference_center_fast
 
     _definition.id
         '_diffrn_detector_element.reference_center_fast'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector_element.reference_center_fast is 
+;
+             The value of _diffrn_detector_element.reference_center_fast is 
               the fast index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_detector_element.reference_center_units along the fast
@@ -6402,9 +6168,10 @@ save_diffrn_detector_element.reference_center_slow
 
     _definition.id
         '_diffrn_detector_element.reference_center_slow'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector_element.reference_center_slow is
+;
+             The value of _diffrn_detector_element.reference_center_slow is
               the slow index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_detector_element.reference_center_units along the slow
@@ -6434,9 +6201,10 @@ save_diffrn_detector_element.reference_center_units
 
     _definition.id
         '_diffrn_detector_element.reference_center_units'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_detector_element.reference_center_units
+;
+             The value of _diffrn_detector_element.reference_center_units
               specifies the units in which the values of 
               _diffrn_detector_element.reference_center_fast and
               _diffrn_detector_element.reference_center_slow
@@ -6469,37 +6237,12 @@ save_diffrn_detector_element.reference_center_units
 
 save_
 
-save_diffrn_detector_element.variant
-
-    _definition.id                '_diffrn_detector_element.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_detector_element.variant gives the variant
-              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-               VARIANT category.
-;
-    _name.category_id             diffrn_detector_element
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_MEASUREMENT
 
-    _definition.id                DIFFRN_MEASUREMENT
+    _definition.id                diffrn_measurement
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -6508,14 +6251,13 @@ save_DIFFRN_MEASUREMENT
      diffraction data were measured.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_MEASUREMENT
+    _name.object_id               diffrn_measurement
 
     loop_
       _category_key.name
          '_diffrn_measurement.device'
          '_diffrn_measurement.diffrn_id'
          '_diffrn_measurement.id'
-         '_diffrn_measurement.variant'
 
     loop_
       _description_example.case
@@ -6531,7 +6273,8 @@ save_DIFFRN_MEASUREMENT
       detector angle 22.5 degrees
     ;
 ;
-;    Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+    Example 1. based on PDB entry 5HVP and laboratory records for the
                  structure corresponding to PDB entry 5HVP
 ;
 ;
@@ -6539,7 +6282,8 @@ save_DIFFRN_MEASUREMENT
     _diffrn_measurement.device_type     'Philips PW1100/20 diffractometer'
     _diffrn_measurement.method          'theta/2theta (\q/2\q)'
 ;
-;     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+;
+     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
                   [Acta Cryst. (1991), C47, 2276-2277].
 ;
 
@@ -6552,9 +6296,10 @@ save_diffrn_measurement.details
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             A description of special aspects of the intensity
+;
+             A description of special aspects of the intensity
               measurement.
 ;
     _name.category_id             diffrn_measurement
@@ -6564,7 +6309,8 @@ save_diffrn_measurement.details
     _type.container               Single
     _type.contents                Text
     _description_example.case
-;                                 440 frames, 0.20 degrees, 150 sec, detector
+;
+                                 440 frames, 0.20 degrees, 150 sec, detector
                                   distance 12 cm, detector angle 22.5 degrees
 ;
 
@@ -6577,9 +6323,10 @@ save_diffrn_measurement.device_details
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             A description of special aspects of the device used to
+;
+             A description of special aspects of the device used to
               measure the diffraction intensities.
 ;
     _name.category_id             diffrn_measurement
@@ -6589,7 +6336,8 @@ save_diffrn_measurement.device_details
     _type.container               Single
     _type.contents                Text
     _description_example.case
-;                                 commercial goniometer modified locally to
+;
+                                 commercial goniometer modified locally to
                                   allow for 90\% \t arc
 ;
 
@@ -6598,9 +6346,10 @@ save_
 save_diffrn_measurement.diffrn_id
 
     _definition.id                '_diffrn_measurement.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn.id in the DIFFRN
+;
+             This data item is a pointer to _diffrn.id in the DIFFRN
               category.
 ;
     _name.category_id             diffrn_measurement
@@ -6616,9 +6365,10 @@ save_
 save_diffrn_measurement.id
 
     _definition.id                '_diffrn_measurement.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_measurement.id must uniquely identify
+;
+             The value of _diffrn_measurement.id must uniquely identify
               the set of mechanical characteristics of the device used to
               orient and/or position the sample used during the collection
               of each diffraction data set.
@@ -6649,9 +6399,10 @@ save_diffrn_measurement.method
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Method used to measure intensities.
+;
+             Method used to measure intensities.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               method
@@ -6667,9 +6418,10 @@ save_
 save_diffrn_measurement.number_of_axes
 
     _definition.id                '_diffrn_measurement.number_of_axes'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_measurement.number_of_axes gives the
+;
+             The value of _diffrn_measurement.number_of_axes gives the
               number of axes of the positioner for the goniometer or
               other sample orientation or positioning device identified
               by _diffrn_measurement.id.
@@ -6691,9 +6443,10 @@ save_
 save_diffrn_measurement.sample_detector_distance
 
     _definition.id                '_diffrn_measurement.sample_detector_distance'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_measurement.sample_detector_distance gives
+;
+             The value of _diffrn_measurement.sample_detector_distance gives
               the unsigned distance in millimetres from the sample to the 
               detector along the beam.  Normally this distance is derived
               from the axis settings.
@@ -6712,9 +6465,10 @@ save_diffrn_measurement.sample_detector_distance_derived
 
     _definition.id
         '_diffrn_measurement.sample_detector_distance_derived'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_measurement.sample_detector_distance_derived
+;
+             The value of _diffrn_measurement.sample_detector_distance_derived
               is assumed to be 'yes', i.e. that value of 
               _diffrn_measurement.sample_detector_distance
               is derived from the axis settings rather than measured.               
@@ -6732,9 +6486,10 @@ save_
 save_diffrn_measurement.sample_detector_voffset
 
     _definition.id                '_diffrn_measurement.sample_detector_voffset'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_measurement.sample_detector_voffset gives
+;
+             The value of _diffrn_measurement.sample_detector_voffset gives
               the signed distance in millimetres in the vertical
               direction (positive for up) from the centre of
               the beam to the centre of the detector. 
@@ -6756,9 +6511,10 @@ save_diffrn_measurement.specimen_support
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The physical device used to support the crystal during data
+;
+             The physical device used to support the crystal during data
               collection.
 ;
     _name.category_id             diffrn_measurement
@@ -6777,60 +6533,35 @@ save_diffrn_measurement.specimen_support
 
 save_
 
-save_diffrn_measurement.variant
-
-    _definition.id                '_diffrn_measurement.variant'
-    _definition.update            2025-09-23
-    _description.text
-;            The value of _diffrn_measurement.variant gives the variant
-             to which the given DIFFRN_MEASUREMENT row is related.
-
-             If this value is not given, the variant is assumed to be
-             the default null variant.
-
-             This item is a pointer to _variant.variant in the
-             VARIANT category.
-;
-    _name.category_id             diffrn_measurement
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_MEASUREMENT_AXIS
 
-    _definition.id                DIFFRN_MEASUREMENT_AXIS
+    _definition.id                diffrn_measurement_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT_AXIS category associate
      axes with goniometers.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_MEASUREMENT_AXIS
+    _name.object_id               diffrn_measurement_axis
 
     loop_
       _category_key.name
          '_diffrn_measurement_axis.measurement_device'
          '_diffrn_measurement_axis.measurement_id'
          '_diffrn_measurement_axis.axis_id'
-         '_diffrn_measurement_axis.variant'
 
 save_
 
 save_diffrn_measurement_axis.axis_id
 
     _definition.id                '_diffrn_measurement_axis.axis_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _axis.id in
+;
+             This data item is a pointer to _axis.id in
               the AXIS category.
 ;
     _name.category_id             diffrn_measurement_axis
@@ -6846,7 +6577,7 @@ save_
 save_diffrn_measurement_axis.diffrn_id
 
     _definition.id                '_diffrn_measurement_axis.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     No definition supplied
@@ -6864,9 +6595,10 @@ save_
 save_diffrn_measurement_axis.measurement_device
 
     _definition.id                '_diffrn_measurement_axis.measurement_device'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn_measurement.device
+;
+             This data item is a pointer to _diffrn_measurement.device
               in the DIFFRN_MEASUREMENT category.
 ;
     _name.category_id             diffrn_measurement_axis
@@ -6885,9 +6617,10 @@ save_diffrn_measurement_axis.measurement_id
     _alias.definition_id          '_diffrn_measurement_axis.id'
     _alias.deprecation_date       .
     _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn_measurement.id in
+;
+             This data item is a pointer to _diffrn_measurement.id in
               the DIFFRN_MEASUREMENT category.
 
               This item was previously named _diffrn_measurement_axis.id,
@@ -6904,39 +6637,15 @@ save_diffrn_measurement_axis.measurement_id
 
 save_
 
-save_diffrn_measurement_axis.variant
-
-    _definition.id                '_diffrn_measurement_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_measurement_axis.variant gives the variant
-              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_measurement_axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_RADIATION
 
-    _definition.id                DIFFRN_RADIATION
+    _definition.id                diffrn_radiation
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Data items in the DIFFRN_RADIATION category describe
+;
+             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
               its collimation and monochromatization before the sample.
 
@@ -6944,12 +6653,8 @@ save_DIFFRN_RADIATION
               items in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_RADIATION
-
-    loop_
-      _category_key.name
-         '_diffrn_radiation.diffrn_id'
-         '_diffrn_radiation.variant'
+    _name.object_id               diffrn_radiation
+    _category_key.name            '_diffrn_radiation.diffrn_id'
 
     loop_
       _description_example.case
@@ -6962,7 +6667,8 @@ save_DIFFRN_RADIATION
     _diffrn_radiation.type                 'Cu K\a'
     _diffrn_radiation.wavelength_id         1
 ;
-;   Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
                 structure corresponding to PDB entry 5HVP
 ;
 ;
@@ -6970,7 +6676,8 @@ save_DIFFRN_RADIATION
     _diffrn_radiation.type             'Cu K\a'
     _diffrn_radiation.monochromator    'graphite'
 ;
-;    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+;
+    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
                 [Acta Cryst. (1991), C47, 2276-2277].
 ;
 
@@ -6979,9 +6686,10 @@ save_
 save_diffrn_radiation.beam_flux
 
     _definition.id                '_diffrn_radiation.beam_flux'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The instantaneous flux spacially integrated over the portion
+;
+             The instantaneous flux spacially integrated over the portion
               of the beam available to be incident on a sample (e.g. after 
               collimation).  If the flux varies over the course of the 
               experiment, the average over the time of the experiment should 
@@ -7000,9 +6708,10 @@ save_
 save_diffrn_radiation.beam_flux_density
 
     _definition.id                '_diffrn_radiation.beam_flux_density'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The instantaneous flux per unit area orhtogonal to the beam.
+;
+             The instantaneous flux per unit area orhtogonal to the beam.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_density
@@ -7018,9 +6727,10 @@ save_diffrn_radiation.beam_flux_density_integrated
 
     _definition.id
         '_diffrn_radiation.beam_flux_density_integrated'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time integral of the flux density.  The time over 
+;
+             The time integral of the flux density.  The time over 
               which the beam flux density is integrated is given in 
               _diffrn_radiation.beam_flux_integration_time
 ;
@@ -7037,9 +6747,10 @@ save_
 save_diffrn_radiation.beam_flux_integrated
 
     _definition.id                '_diffrn_radiation.beam_flux_integrated'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time integral of the flux spacially integrated over the 
+;
+             The time integral of the flux spacially integrated over the 
               portion of the beam available to be incident on a sample 
               (e.g. after collimation).  The time over which the beam flux
               is integrated is given in 
@@ -7058,9 +6769,10 @@ save_
 save_diffrn_radiation.beam_flux_integration_time
 
     _definition.id                '_diffrn_radiation.beam_flux_integration_time'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time interval over which beam flux, beam incident flux
+;
+             The time interval over which beam flux, beam incident flux
               beam density is integrated.  
 ;
     _name.category_id             diffrn_radiation
@@ -7076,9 +6788,10 @@ save_
 save_diffrn_radiation.beam_incident_flux
 
     _definition.id                '_diffrn_radiation.beam_incident_flux'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The instantaneous flux spacially integrated over the portion of 
+;
+             The instantaneous flux spacially integrated over the portion of 
               the beam actually incident on the sample.  If the incident flux 
               varies over the course of the experiment, the average over the 
               time of the experiment should be reported.
@@ -7097,9 +6810,10 @@ save_diffrn_radiation.beam_incident_flux_integrated
 
     _definition.id
         '_diffrn_radiation.beam_incident_flux_integrated'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time integral of the flux spacially integrated over the
+;
+             The time integral of the flux spacially integrated over the
               portion of the beam actually incident on the sample.  The 
               time over which the beam flux is integrated is given in
 
@@ -7118,9 +6832,10 @@ save_
 save_diffrn_radiation.beam_width
 
     _definition.id                '_diffrn_radiation.beam_width'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Full width at half maximum of the beam incident on the sample
+;
+             Full width at half maximum of the beam incident on the sample
               in the plane of polarization (or horizontally if unpolarized).
 ;
     _name.category_id             diffrn_radiation
@@ -7140,9 +6855,10 @@ save_diffrn_radiation.collimation
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The collimation or focusing applied to the radiation.
+;
+             The collimation or focusing applied to the radiation.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               collimation
@@ -7162,9 +6878,10 @@ save_
 save_diffrn_radiation.diffrn_id
 
     _definition.id                '_diffrn_radiation.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn.id in the DIFFRN
+;
+             This data item is a pointer to _diffrn.id in the DIFFRN
               category.
 ;
     _name.category_id             diffrn_radiation
@@ -7180,9 +6897,10 @@ save_
 save_diffrn_radiation.div_x_source
 
     _definition.id                '_diffrn_radiation.div_x_source'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Beam crossfire in degrees parallel to the laboratory X axis
+;
+             Beam crossfire in degrees parallel to the laboratory X axis
               (see AXIS category).
 
               This is a characteristic of the X-ray beam as it illuminates
@@ -7211,9 +6929,10 @@ save_
 save_diffrn_radiation.div_x_y_source
 
     _definition.id                '_diffrn_radiation.div_x_y_source'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Beam crossfire correlation in degrees squared between the
+;
+             Beam crossfire correlation in degrees squared between the
               crossfire laboratory X-axis component and the crossfire
               laboratory Y-axis component (see AXIS category).
 
@@ -7246,9 +6965,10 @@ save_
 save_diffrn_radiation.div_y_source
 
     _definition.id                '_diffrn_radiation.div_y_source'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Beam crossfire in degrees parallel to the laboratory Y axis
+;
+             Beam crossfire in degrees parallel to the laboratory Y axis
               (see AXIS category).
 
               This is a characteristic of the X-ray beam as it illuminates
@@ -7282,9 +7002,10 @@ save_diffrn_radiation.filter_edge
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              Absorption edge in \%angstr\"oms of the radiation filter used.
+;
+              Absorption edge in \%angstr\"oms of the radiation filter used.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               filter_edge
@@ -7304,9 +7025,10 @@ save_diffrn_radiation.inhomogeneity
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Half-width in millimetres of the incident beam in the
+;
+             Half-width in millimetres of the incident beam in the
               direction perpendicular to the diffraction plane.
 ;
     _name.category_id             diffrn_radiation
@@ -7327,9 +7049,10 @@ save_diffrn_radiation.monochromator
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The method used to obtain monochromatic radiation. If a
+;
+             The method used to obtain monochromatic radiation. If a
               monochromator crystal is used, the material and the
               indices of the Bragg reflection are specified.
 ;
@@ -7356,9 +7079,10 @@ save_diffrn_radiation.polarisn_norm
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The angle in degrees, as viewed from the specimen, between the
+;
+             The angle in degrees, as viewed from the specimen, between the
               perpendicular component of the polarization and the diffraction
               plane. See _diffrn_radiation_polarisn_ratio.
 ;
@@ -7376,9 +7100,10 @@ save_
 save_diffrn_radiation.polarisn_norm_esd
 
     _definition.id                '_diffrn_radiation.polarisn_norm_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.) of
               _diffrn_radiation.polarisn_norm,
               the angle in degrees, as viewed from the specimen, between the
               perpendicular component of the polarization and the diffraction
@@ -7402,9 +7127,10 @@ save_diffrn_radiation.polarisn_ratio
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Polarization ratio of the diffraction beam incident on the
+;
+             Polarization ratio of the diffraction beam incident on the
               crystal. This is the ratio of the perpendicularly polarized to
               the parallel polarized component of the radiation. The
               perpendicular component forms an angle of
@@ -7426,9 +7152,10 @@ save_
 save_diffrn_radiation.polarisn_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarisn_ratio_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.) of
               _diffrn_radiation.polarisn_ratio,
               the polarization ratio of the diffraction beam incident on the
               crystal. 
@@ -7447,9 +7174,10 @@ save_
 save_diffrn_radiation.polarizn_source_norm
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The angle in degrees, as viewed from the specimen, between
+;
+             The angle in degrees, as viewed from the specimen, between
               the normal to the polarization plane and the laboratory
               Y-axis as defined in the AXIS category.
 
@@ -7485,9 +7213,10 @@ save_
 save_diffrn_radiation.polarizn_source_norm_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_source_norm,
               the angle in degrees, as viewed from the specimen, between
               the normal to the polarization plane and the laboratory
@@ -7507,9 +7236,10 @@ save_
 save_diffrn_radiation.polarizn_source_ratio
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+;
+             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared)
               of the electric vector in the plane of the normal to the
@@ -7561,9 +7291,10 @@ save_
 save_diffrn_radiation.polarizn_source_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_source_ratio,
               (Ip-In)/(Ip+In), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -7585,9 +7316,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_i
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+;
+             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
               squared) of the electric vector in the plane of polarization,
               In is the intensity (amplitude squared) of the electric vector
               in the plane of the normal to the plane of polarization,
@@ -7629,9 +7361,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_I,
               Ip+In+Inp, where Ip is the intensity (amplitude squared)
               of the electric vector in the plane of polarization,
@@ -7654,9 +7387,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_q
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -7695,9 +7429,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_Q,
               (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -7722,9 +7457,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_u
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -7763,9 +7499,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_U,
               (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -7790,9 +7527,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_v
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+;
+             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
               circular polarization, where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared) of
@@ -7832,9 +7570,10 @@ save_
 save_diffrn_radiation.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_V,
               +/-2*sqrt(IpIn), with a + sign for right-handed circular
               polarization, where Ip is the intensity
@@ -7864,9 +7603,10 @@ save_diffrn_radiation.probe
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Name of the type of radiation used. It is strongly
+;
+             Name of the type of radiation used. It is strongly
               recommended that this be given so that the
               probe radiation is clearly specified.
 ;
@@ -7893,9 +7633,10 @@ save_diffrn_radiation.type
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The nature of the radiation. This is typically a description
+;
+             The nature of the radiation. This is typically a description
               of the X-ray wavelength in Siegbahn notation.
 ;
     _name.category_id             diffrn_radiation
@@ -7914,37 +7655,13 @@ save_diffrn_radiation.type
 
 save_
 
-save_diffrn_radiation.variant
-
-    _definition.id                '_diffrn_radiation.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_radiation.variant gives the variant
-              to which the given DIFFRN_RADIATION row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_radiation
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_diffrn_radiation.wavelength_id
 
     _definition.id                '_diffrn_radiation.wavelength_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to
+;
+             This data item is a pointer to
               _diffrn_radiation_wavelength.id in the
               DIFFRN_RADIATION_WAVELENGTH category.
 ;
@@ -7964,9 +7681,10 @@ save_diffrn_radiation.xray_symbol
     _alias.deprecation_date       .
     _alias.dictionary_uri
         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The IUPAC symbol for the X-ray wavelength for the probe
+;
+             The IUPAC symbol for the X-ray wavelength for the probe
               radiation.
 ;
     _name.category_id             diffrn_radiation
@@ -7988,10 +7706,10 @@ save_
 
 save_DIFFRN_REFLN
 
-    _definition.id                DIFFRN_REFLN
+    _definition.id                diffrn_refln
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     This category redefinition has been added to extend the key of
@@ -8010,23 +7728,23 @@ save_DIFFRN_REFLN
      _diffrn_refln.frame_id
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_REFLN
+    _name.object_id               diffrn_refln
 
     loop_
       _category_key.name
          '_diffrn_refln.diffrn_id'
          '_diffrn_refln.id'
          '_diffrn_refln.frame_id'
-         '_diffrn_refln.variant'
 
 save_
 
 save_diffrn_refln.diffrn_id
 
     _definition.id                '_diffrn_refln.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a placeholder for the definition in the
+;
+             This item is a placeholder for the definition in the
               PDBx/mmCIF dictionary
 ;
     _name.category_id             diffrn_refln
@@ -8042,9 +7760,10 @@ save_
 save_diffrn_refln.frame_id
 
     _definition.id                '_diffrn_refln.frame_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn_data_frame.id
+;
+             This item is a pointer to _diffrn_data_frame.id
               in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_refln
@@ -8060,9 +7779,10 @@ save_
 save_diffrn_refln.id
 
     _definition.id                '_diffrn_refln.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a placeholder for the definition in the
+;
+             This item is a placeholder for the definition in the
               PDBx/mmCIF dictionary.
 ;
     _name.category_id             diffrn_refln
@@ -8074,35 +7794,10 @@ save_diffrn_refln.id
 
 save_
 
-save_diffrn_refln.variant
-
-    _definition.id                '_diffrn_refln.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_refln.variant gives the variant
-              to which the given DIFFRN_REFLN row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_refln
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_diffrn_reflns.diffrn_id
 
     _definition.id                '_diffrn_reflns.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     No definition supplied
@@ -8119,22 +7814,18 @@ save_
 
 save_DIFFRN_SCAN
 
-    _definition.id                DIFFRN_SCAN
+    _definition.id                diffrn_scan
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN category describe the parameters of one
      or more scans, relating axis positions to frames.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN
-
-    loop_
-      _category_key.name
-         '_diffrn_scan.id'
-         '_diffrn_scan.variant'
+    _name.object_id               diffrn_scan
+    _category_key.name            '_diffrn_scan.id'
 
     loop_
       _description_example.case
@@ -8215,7 +7906,8 @@ save_DIFFRN_SCAN
          is data that can be estimated at the same time, and *.date_end which
          can only be logged exactly if the data collection completes normally.
 ;
-;    ###CBF: VERSION 1.1
+;
+    ###CBF: VERSION 1.1
 
      data_image_1
 
@@ -8467,7 +8159,8 @@ save_DIFFRN_SCAN
           are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
           0.075) in this coordinate system.
 ;
-;    ###CBF: VERSION 1.1
+;
+    ###CBF: VERSION 1.1
 
      data_image_1
 
@@ -8726,9 +8419,10 @@ save_
 save_diffrn_scan.date_end
 
     _definition.id                '_diffrn_scan.date_end'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The date and time of the end of the scan.  Note that this
+;
+             The date and time of the end of the scan.  Note that this
               may be an estimate generated during the scan, before the
               precise time of the end of the scan is known, in which
               case _diffrn_scan.date_end_estimated should be used instead.
@@ -8745,9 +8439,10 @@ save_
 save_diffrn_scan.date_end_estimated
 
     _definition.id                '_diffrn_scan.date_end_estimated'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The estimated date and time of the end of the scan.  Note 
+;
+             The estimated date and time of the end of the scan.  Note 
               that this may be generated at the start or during the scan,
               before the precise time of the end of the scan is known.
 ;
@@ -8763,9 +8458,10 @@ save_
 save_diffrn_scan.date_start
 
     _definition.id                '_diffrn_scan.date_start'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The date and time of the start of the scan.
+;
+             The date and time of the start of the scan.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_start
@@ -8779,7 +8475,7 @@ save_
 save_diffrn_scan.diffrn_id
 
     _definition.id                '_diffrn_scan.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     No definition supplied
@@ -8797,9 +8493,10 @@ save_
 save_diffrn_scan.frame_id_end
 
     _definition.id                '_diffrn_scan.frame_id_end'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               last frame in the scan.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -8818,9 +8515,10 @@ save_
 save_diffrn_scan.frame_id_start
 
     _definition.id                '_diffrn_scan.frame_id_start'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               first frame in the scan.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -8839,9 +8537,10 @@ save_
 save_diffrn_scan.frames
 
     _definition.id                '_diffrn_scan.frames'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the number of frames in
+;
+             The value of this data item is the number of frames in
               the scan.
 ;
     _name.category_id             diffrn_scan
@@ -8858,9 +8557,10 @@ save_
 save_diffrn_scan.id
 
     _definition.id                '_diffrn_scan.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan.id uniquely identifies each
+;
+             The value of _diffrn_scan.id uniquely identifies each
               scan.  The identifier is used to tie together all the
               information about the scan.
 ;
@@ -8876,9 +8576,10 @@ save_
 save_diffrn_scan.integration_time
 
     _definition.id                '_diffrn_scan.integration_time'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Approximate average time in seconds to integrate each
+;
+             Approximate average time in seconds to integrate each
               step of the scan.  The precise time for integration
               of each particular step must be provided in
               _diffrn_scan_frame.integration_time, even
@@ -8897,9 +8598,10 @@ save_
 save_diffrn_scan.time_period
 
     _definition.id                '_diffrn_scan.time_period'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Approximate average time in seconds between the start
+;
+             Approximate average time in seconds between the start
               of each step of the scan.  The precise start-to-start
               time increment of each particular step may be provided in
               _diffrn_scan_frame.time_period.
@@ -8917,9 +8619,10 @@ save_
 save_diffrn_scan.time_rstrt_incr
 
     _definition.id                '_diffrn_scan.time_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             Approximate average time in seconds between the end
+;
+             Approximate average time in seconds between the end
               of integration of each step of the scan and the start
               of integration of the next step.
 
@@ -8946,37 +8649,12 @@ save_diffrn_scan.time_rstrt_incr
 
 save_
 
-save_diffrn_scan.variant
-
-    _definition.id                '_diffrn_scan.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan.variant gives the variant
-              to which the given DIFFRN_SCAN row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SCAN_AXIS
 
-    _definition.id                DIFFRN_SCAN_AXIS
+    _definition.id                diffrn_scan_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN_AXIS category describe the settings of
@@ -8984,22 +8662,22 @@ save_DIFFRN_SCAN_AXIS
      their zero points.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN_AXIS
+    _name.object_id               diffrn_scan_axis
 
     loop_
       _category_key.name
          '_diffrn_scan_axis.scan_id'
          '_diffrn_scan_axis.axis_id'
-         '_diffrn_scan_axis.variant'
 
 save_
 
 save_diffrn_scan_axis.angle_increment
 
     _definition.id                '_diffrn_scan_axis.angle_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in degrees.  In general, this will agree with
               _diffrn_scan_frame_axis.angle_increment. The
               sum of the values of _diffrn_scan_frame_axis.angle and
@@ -9027,9 +8705,10 @@ save_
 save_diffrn_scan_axis.angle_range
 
     _definition.id                '_diffrn_scan_axis.angle_range'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The total range covered during the scan from the starting position 
+;
+             The total range covered during the scan from the starting position 
               to the end of the final step for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
@@ -9046,9 +8725,10 @@ save_
 save_diffrn_scan_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.angle_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment after each step for the specified axis
+;
+             The increment after each step for the specified axis
               in degrees.  In general, this will agree with
               _diffrn_scan_frame_axis.angle_rstrt_incr.  The
               sum of the values of _diffrn_scan_frame_axis.angle,
@@ -9079,9 +8759,10 @@ save_
 save_diffrn_scan_axis.angle_start
 
     _definition.id                '_diffrn_scan_axis.angle_start'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The starting position for the specified axis in degrees.
+;
+             The starting position for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_start
@@ -9097,9 +8778,10 @@ save_
 save_diffrn_scan_axis.axis_id
 
     _definition.id                '_diffrn_scan_axis.axis_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes for the scan for which settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -9121,9 +8803,10 @@ save_
 save_diffrn_scan_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_axis.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_axis
@@ -9138,9 +8821,10 @@ save_
 save_diffrn_scan_axis.displacement_increment
 
     _definition.id                '_diffrn_scan_axis.displacement_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in millimetres.  In general, this will agree with
               _diffrn_scan_frame_axis.displacement_increment.
               The sum of the values of
@@ -9168,9 +8852,10 @@ save_
 save_diffrn_scan_axis.displacement_range
 
     _definition.id                '_diffrn_scan_axis.displacement_range'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The range from the starting position for the specified axis
+;
+             The range from the starting position for the specified axis
               in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
@@ -9187,9 +8872,10 @@ save_
 save_diffrn_scan_axis.displacement_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.displacement_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in millimetres.  In general, this will agree with
               _diffrn_scan_frame_axis.displacement_rstrt_incr.
               The sum of the values of
@@ -9220,9 +8906,10 @@ save_
 save_diffrn_scan_axis.displacement_start
 
     _definition.id                '_diffrn_scan_axis.displacement_start'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The starting position for the specified axis in millimetres.
+;
+             The starting position for the specified axis in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_start
@@ -9238,9 +8925,10 @@ save_
 save_diffrn_scan_axis.reference_angle
 
     _definition.id                '_diffrn_scan_axis.reference_angle'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in degrees
+;
+             The setting of the specified axis in degrees
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -9269,9 +8957,10 @@ save_
 save_diffrn_scan_axis.reference_displacement
 
     _definition.id                '_diffrn_scan_axis.reference_displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in millimetres
+;
+             The setting of the specified axis in millimetres
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -9298,9 +8987,10 @@ save_
 save_diffrn_scan_axis.scan_id
 
     _definition.id                '_diffrn_scan_axis.scan_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               scan for which axis settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -9319,37 +9009,12 @@ save_diffrn_scan_axis.scan_id
 
 save_
 
-save_diffrn_scan_axis.variant
-
-    _definition.id                '_diffrn_scan_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan_axis.variant gives the variant
-              to which the given DIFFRN_SCAN_AXIS row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan_axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SCAN_COLLECTION
 
-    _definition.id                DIFFRN_SCAN_COLLECTION
+    _definition.id                diffrn_scan_collection
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN_COLLECTION category describe
@@ -9359,17 +9024,13 @@ save_DIFFRN_SCAN_COLLECTION
      synchrotron and XFEL collection strategies evolve.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN_COLLECTION
-
-    loop_
-      _category_key.name
-         '_diffrn_scan_collection.scan_id'
-         '_diffrn_scan_collection.variant'
-
+    _name.object_id               diffrn_scan_collection
+    _category_key.name            '_diffrn_scan_collection.scan_id'
     _description_example.case
         'Example 1 - Describing a multi-wedge raster scan.'
     _description_example.detail
-;        loop_
+;
+        loop_
         _diffrn_scan_collection.scan_id
         _diffrn_scan_collection.details
        
@@ -9384,9 +9045,10 @@ save_
 save_diffrn_scan_collection.details
 
     _definition.id                '_diffrn_scan_collection.details'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan_collection.details should give a
+;
+             The value of _diffrn_scan_collection.details should give a
               description of special aspects of each collection strategy.
 ;
     _name.category_id             diffrn_scan_collection
@@ -9401,9 +9063,10 @@ save_
 save_diffrn_scan_collection.diffrn_id
 
     _definition.id                '_diffrn_scan_collection.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_collection
@@ -9419,9 +9082,10 @@ save_
 save_diffrn_scan_collection.scan_id
 
     _definition.id                '_diffrn_scan_collection.scan_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan_collection.scan_id identifies the scan
+;
+             The value of _diffrn_scan_collection.scan_id identifies the scan
               containing this frame.
 
               This item is a pointer to _diffrn_scan.id in the
@@ -9441,9 +9105,10 @@ save_
 save_diffrn_scan_collection.translation_width
 
     _definition.id                '_diffrn_scan_collection.translation_width'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan_collection.translation_width
+;
+             The value of _diffrn_scan_collection.translation_width
               gives the average single step translation in micrometres
               in collection strategies for which this information is
                appropriate, e.g. 'vector'.
@@ -9462,9 +9127,10 @@ save_
 save_diffrn_scan_collection.type
 
     _definition.id                '_diffrn_scan_collection.type'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan_collection.type identifies
+;
+             The value of _diffrn_scan_collection.type identifies
               the strategy used in this scan, e.g. `rotation', 'raster',
               'vector', 'still', etc.
 
@@ -9480,59 +9146,34 @@ save_diffrn_scan_collection.type
 
 save_
 
-save_diffrn_scan_collection.variant
-
-    _definition.id                '_diffrn_scan_collection.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan_collection.variant gives the variant
-              to which the given DIFFRN_SCAN_COLLECTION row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan_collection
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SCAN_FRAME
 
-    _definition.id                DIFFRN_SCAN_FRAME
+    _definition.id                diffrn_scan_frame
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN_FRAME category describe
      the relationships of particular frames to scans.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME
+    _name.object_id               diffrn_scan_frame
 
     loop_
       _category_key.name
          '_diffrn_scan_frame.scan_id'
          '_diffrn_scan_frame.frame_id'
-         '_diffrn_scan_frame.variant'
 
 save_
 
 save_diffrn_scan_frame.date
 
     _definition.id                '_diffrn_scan_frame.date'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The date and time of the start of the frame being scanned.
+;
+             The date and time of the start of the frame being scanned.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               date
@@ -9546,9 +9187,10 @@ save_
 save_diffrn_scan_frame.diffrn_id
 
     _definition.id                '_diffrn_scan_frame.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame
@@ -9564,9 +9206,10 @@ save_
 save_diffrn_scan_frame.frame_id
 
     _definition.id                '_diffrn_scan_frame.frame_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               frame being examined.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -9585,9 +9228,10 @@ save_
 save_diffrn_scan_frame.frame_number
 
     _definition.id                '_diffrn_scan_frame.frame_number'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the number of the frame
+;
+             The value of this data item is the number of the frame
               within the scan, starting with 1.  It is not necessarily
               the same as the value of _diffrn_scan_frame.frame_id,
               but it may be.
@@ -9607,9 +9251,10 @@ save_
 save_diffrn_scan_frame.integration_time
 
     _definition.id                '_diffrn_scan_frame.integration_time'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time in seconds to integrate this step of the scan.
+;
+             The time in seconds to integrate this step of the scan.
               This should be the precise time of integration of each
               particular frame.  The value of this data item should
               be given explicitly for each frame and not inferred
@@ -9628,9 +9273,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_i
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+;
+             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
               squared) of the electric vector in the plane of polarization,
               In is the intensity (amplitude squared) of the electric vector
               in the plane of the normal to the plane of polarization,
@@ -9672,9 +9318,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_I,
               Ip+In+Inp, where Ip is the intensity (amplitude squared)
               of the electric vector in the plane of polarization,
@@ -9697,9 +9344,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_q
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -9738,9 +9386,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_Q,
               (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -9765,9 +9414,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_u
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -9806,9 +9456,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_U,
               (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -9833,9 +9484,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_v
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+;
+             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
               circular polarization, where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared) of
@@ -9875,9 +9527,10 @@ save_
 save_diffrn_scan_frame.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V_esd'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_V,
               +/-2*sqrt(IpIn), with a + sign for right-handed circular
               polarization, where Ip is the intensity
@@ -9903,9 +9556,10 @@ save_
 save_diffrn_scan_frame.scan_id
 
     _definition.id                '_diffrn_scan_frame.scan_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _diffrn_scan_frame.scan_id identifies the scan
+;
+             The value of _diffrn_scan_frame.scan_id identifies the scan
               containing this frame.
 
               This item is a pointer to _diffrn_scan.id in the
@@ -9924,9 +9578,10 @@ save_
 save_diffrn_scan_frame.time_period
 
     _definition.id                '_diffrn_scan_frame.time_period'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time in seconds between the start of this frame and the
+;
+             The time in seconds between the start of this frame and the
               start of the next frame, if any.  If there is no next frame,
               a null value should be given.
 ;
@@ -9943,9 +9598,10 @@ save_
 save_diffrn_scan_frame.time_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame.time_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The time in seconds between the end of integration of this step of the scan
+;
+             The time in seconds between the end of integration of this step of the scan
               and the start of integration of the next step.
 
               The sum of the values of _diffrn_scan_frame.integration_time
@@ -9970,37 +9626,12 @@ save_diffrn_scan_frame.time_rstrt_incr
 
 save_
 
-save_diffrn_scan_frame.variant
-
-    _definition.id                '_diffrn_scan_frame.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan_frame.variant gives the variant
-              to which the given DIFFRN_SCAN_FRAME row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan_frame
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SCAN_FRAME_AXIS
 
-    _definition.id                DIFFRN_SCAN_FRAME_AXIS
+    _definition.id                diffrn_scan_frame_axis
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN_FRAME_AXIS category describe the
@@ -10011,22 +9642,22 @@ save_DIFFRN_SCAN_FRAME_AXIS
      simply inferred from values in DIFFRN_SCAN_AXIS.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME_AXIS
+    _name.object_id               diffrn_scan_frame_axis
 
     loop_
       _category_key.name
          '_diffrn_scan_frame_axis.frame_id'
          '_diffrn_scan_frame_axis.axis_id'
-         '_diffrn_scan_frame_axis.variant'
 
 save_
 
 save_diffrn_scan_frame_axis.angle
 
     _definition.id                '_diffrn_scan_frame_axis.angle'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in degrees for this frame.
+;
+             The setting of the specified axis in degrees for this frame.
               This is the setting at the start of the integration time.
 ;
     _name.category_id             diffrn_scan_frame_axis
@@ -10043,9 +9674,10 @@ save_
 save_diffrn_scan_frame_axis.angle_increment
 
     _definition.id                '_diffrn_scan_frame_axis.angle_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for this frame for the angular setting of
+;
+             The increment for this frame for the angular setting of
               the specified axis in degrees.  The sum of the values
               of _diffrn_scan_frame_axis.angle and
               _diffrn_scan_frame_axis.angle_increment is the
@@ -10066,9 +9698,10 @@ save_
 save_diffrn_scan_frame_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame_axis.angle_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment after this frame for the angular setting of
+;
+             The increment after this frame for the angular setting of
               the specified axis in degrees.  The sum of the values
               of _diffrn_scan_frame_axis.angle,
               _diffrn_scan_frame_axis.angle_increment and
@@ -10091,9 +9724,10 @@ save_
 save_diffrn_scan_frame_axis.axis_id
 
     _definition.id                '_diffrn_scan_frame_axis.axis_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes for the frame for which settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -10115,9 +9749,10 @@ save_
 save_diffrn_scan_frame_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_axis.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_axis
@@ -10133,9 +9768,10 @@ save_
 save_diffrn_scan_frame_axis.displacement
 
     _definition.id                '_diffrn_scan_frame_axis.displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in millimetres for this
+;
+             The setting of the specified axis in millimetres for this
               frame.  This is the setting at the start of the integration
               time.
 ;
@@ -10154,9 +9790,10 @@ save_diffrn_scan_frame_axis.displacement_increment
 
     _definition.id
         '_diffrn_scan_frame_axis.displacement_increment'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for this frame for the displacement setting of
+;
+             The increment for this frame for the displacement setting of
               the specified axis in millimetres.  The sum of the values
               of _diffrn_scan_frame_axis.displacement and
               _diffrn_scan_frame_axis.displacement_increment is the
@@ -10178,9 +9815,10 @@ save_diffrn_scan_frame_axis.displacement_rstrt_incr
 
     _definition.id
         '_diffrn_scan_frame_axis.displacement_rstrt_incr'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The increment for this frame for the displacement setting of
+;
+             The increment for this frame for the displacement setting of
               the specified axis in millimetres.  The sum of the values
               of _diffrn_scan_frame_axis.displacement,
               _diffrn_scan_frame_axis.displacement_increment and
@@ -10203,9 +9841,10 @@ save_
 save_diffrn_scan_frame_axis.frame_id
 
     _definition.id                '_diffrn_scan_frame_axis.frame_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               frame for which axis settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -10227,9 +9866,10 @@ save_
 save_diffrn_scan_frame_axis.reference_angle
 
     _definition.id                '_diffrn_scan_frame_axis.reference_angle'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in degrees
+;
+             The setting of the specified axis in degrees
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -10254,9 +9894,10 @@ save_diffrn_scan_frame_axis.reference_displacement
 
     _definition.id
         '_diffrn_scan_frame_axis.reference_displacement'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The setting of the specified axis in millimetres for this
+;
+             The setting of the specified axis in millimetres for this
               frame against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -10277,37 +9918,12 @@ save_diffrn_scan_frame_axis.reference_displacement
 
 save_
 
-save_diffrn_scan_frame_axis.variant
-
-    _definition.id                '_diffrn_scan_frame_axis.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan_frame_axis.variant gives the variant
-              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan_frame_axis
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SCAN_FRAME_MONITOR
 
-    _definition.id                DIFFRN_SCAN_FRAME_MONITOR
+    _definition.id                diffrn_scan_frame_monitor
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_SCAN_FRAME_MONITOR category record
@@ -10336,7 +9952,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      omitted.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SCAN_FRAME_MONITOR
+    _name.object_id               diffrn_scan_frame_monitor
 
     loop_
       _category_key.name
@@ -10344,10 +9960,11 @@ save_DIFFRN_SCAN_FRAME_MONITOR
          '_diffrn_scan_frame_monitor.detector_id'
          '_diffrn_scan_frame_monitor.scan_id'
          '_diffrn_scan_frame_monitor.frame_id'
-         '_diffrn_scan_frame_monitor.variant'
 
     _description_example.case
-;     # category DIFFRN_DETECTOR
+;
+
+     # category DIFFRN_DETECTOR
      loop_
      _diffrn_detector.diffrn_id
      _diffrn_detector.id
@@ -10466,12 +10083,14 @@ save_DIFFRN_SCAN_FRAME_MONITOR
       ELEMENT_Y        translation detector ELEMENT_X
      0 1 0 0 0 0
       MONITOR_Z        translation detector . 0 0 1 0 0 0
+
 ;
     _description_example.detail
-;    Example 1. The beam intensity for frame FRAME1 is being tracked
-     by a beamstop monitor detector BSM01, made from metal foil and
-     a PIN diode, located 20 mm in front of a MAR345 detector and being
-     sampled every 2 seconds in a 20 second scan.
+;
+    Example 1. The beam intensity for frame FRAME1 is being tracked
+        by a beamstop monitor detector BSM01, made from metal foil and
+        a PIN diode, located 20 mm in front of a MAR345 detector and being
+        sampled every 2 seconds in a 20 second scan.
 ;
 
 save_
@@ -10479,9 +10098,10 @@ save_
 save_diffrn_scan_frame_monitor.detector_id
 
     _definition.id                '_diffrn_scan_frame_monitor.detector_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to _diffrn_detector.id in
+;
+             This data item is a pointer to _diffrn_detector.id in
               the DIFFRN_DETECTOR category.
 
 ;
@@ -10498,9 +10118,10 @@ save_
 save_diffrn_scan_frame_monitor.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_monitor.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -10516,9 +10137,10 @@ save_
 save_diffrn_scan_frame_monitor.frame_id
 
     _definition.id                '_diffrn_scan_frame_monitor.frame_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn_data_frame.id
+;
+             This item is a pointer to _diffrn_data_frame.id
               in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -10534,9 +10156,10 @@ save_
 save_diffrn_scan_frame_monitor.id
 
     _definition.id                '_diffrn_scan_frame_monitor.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is an integer identifier which, along with
+;
+             This item is an integer identifier which, along with
               _diffrn_scan_frame_monitor.detector_id,
               _diffrn_scan_frame_monitor.scan_id, and
               _diffrn_scan_frame_monitor.frame_id
@@ -10560,9 +10183,10 @@ save_
 save_diffrn_scan_frame_monitor.integration_time
 
     _definition.id                '_diffrn_scan_frame_monitor.integration_time'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The precise time for integration of the monitor value given in
+;
+             The precise time for integration of the monitor value given in
               _diffrn_scan_frame_monitor.monitor_value
               must be given in _diffrn_scan_frame_monitor.integration_time.
 ;
@@ -10585,9 +10209,10 @@ save_diffrn_scan_frame_monitor.monitor_value
 ;\
 https://github.com/dials/cbflib/raw/refs/heads/main/doc/cif_img_1.8.2.dic
 ;
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value reported by the monitor detector should be given in
+;
+             The value reported by the monitor detector should be given in
               _diffrn_scan_frame_monitor.monitor_value.
 
               The value is typed as float to allow of monitors for very
@@ -10611,9 +10236,10 @@ save_
 save_diffrn_scan_frame_monitor.scan_id
 
     _definition.id                '_diffrn_scan_frame_monitor.scan_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn_scan.id in
+;
+             This item is a pointer to _diffrn_scan.id in
               the DIFFRN_SCAN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -10625,46 +10251,22 @@ save_diffrn_scan_frame_monitor.scan_id
 
 save_
 
-save_diffrn_scan_frame_monitor.variant
-
-    _definition.id                '_diffrn_scan_frame_monitor.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _diffrn_scan_frame_monitor.variant gives the variant
-              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             diffrn_scan_frame_monitor
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_DIFFRN_SOURCE
 
-    _definition.id                DIFFRN_SOURCE
+    _definition.id                diffrn_source
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              Data items in the DIFFRN_SOURCE category record details of
+;
+              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
 
                This is a stub category for use of DIFFRN_SOURCE which is
                specified in the mmCIF_PDBx dictionary
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               DIFFRN_SOURCE
+    _name.object_id               diffrn_source
     _category_key.name            '_diffrn_source.diffrn_id'
 
 save_
@@ -10672,9 +10274,10 @@ save_
 save_diffrn_source.diffrn_id
 
     _definition.id                '_diffrn_source.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              This data item is a pointer to _diffrn.id in the DIFFRN
+;
+              This data item is a pointer to _diffrn.id in the DIFFRN
                category.
 ;
     _name.category_id             diffrn_source
@@ -10689,10 +10292,10 @@ save_
 
 save_MAP
 
-    _definition.id                MAP
+    _definition.id                map
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the MAP category record
@@ -10707,17 +10310,18 @@ save_MAP
      Examples are given in the MAP_SEGMENT category.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               MAP
+    _name.object_id               map
 
     loop_
       _category_key.name
          '_map.id'
          '_map.diffrn_id'
          '_map.entry_id'
-         '_map.variant'
 
     _description_example.case
-;        loop_
+;
+
+        loop_
         _map.id
         _map.details
 
@@ -10733,7 +10337,8 @@ save_MAP
    ;
 ;
     _description_example.detail
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map
 ;
 
@@ -10742,9 +10347,10 @@ save_
 save_map.details
 
     _definition.id                '_map.details'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;              The value of _map.details should give a
+;
+              The value of _map.details should give a
                description of special aspects of each map.
 
 ;
@@ -10755,11 +10361,13 @@ save_map.details
     _type.container               Single
     _type.contents                Text
     _description_example.case
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map
 ;
     _description_example.detail
-;        loop_
+;
+        loop_
         _map.id
         _map.details
 
@@ -10779,9 +10387,10 @@ save_
 save_map.diffrn_id
 
     _definition.id                '_map.diffrn_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _diffrn.id in the
+;
+             This item is a pointer to _diffrn.id in the
               DIFFRN category.
 ;
     _name.category_id             map
@@ -10797,9 +10406,10 @@ save_
 save_map.entry_id
 
     _definition.id                '_map.entry_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _entry.id in the
+;
+             This item is a pointer to _entry.id in the
               ENTRY category.
 ;
     _name.category_id             map
@@ -10814,9 +10424,10 @@ save_
 save_map.id
 
     _definition.id                '_map.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map.id must uniquely identify
+;
+             The value of _map.id must uniquely identify
               each map for the given '_diffrn.id' or entry.id.
 ;
     _name.category_id             map
@@ -10828,53 +10439,29 @@ save_map.id
 
 save_
 
-save_map.variant
-
-    _definition.id                '_map.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _map.variant gives the variant
-              to which the given map row is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             map
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
 save_MAP_SEGMENT
 
-    _definition.id                MAP_SEGMENT
+    _definition.id                map_segment
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the MAP_SEGMENT category record
      the details about each segment (section or brick) of a map.
 ;
     _name.category_id             CIF_IMG_HEAD
-    _name.object_id               MAP_SEGMENT
+    _name.object_id               map_segment
 
     loop_
       _category_key.name
          '_map_segment.id'
          '_map_segment.map_id'
-         '_map_segment.variant'
 
     _description_example.case
-;        loop_
+;
+
+        loop_
         _map.id
         _map.details
 
@@ -10899,7 +10486,8 @@ save_MAP_SEGMENT
         rho_obs  rho_obs  map_structure 2 mask_structure 1
 ;
     _description_example.detail
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map, each consisting of one
                 segment, both using the same array structure
                 and mask.
@@ -10910,9 +10498,10 @@ save_
 save_map_segment.array_id
 
     _definition.id                '_map_segment.array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.array_id identifies the array 
+;
+             The value of _map_segment.array_id identifies the array 
               structure into which the map is organized.
 
               This item is a pointer to _array_structure.id in the
@@ -10930,9 +10519,10 @@ save_
 save_map_segment.array_section_id
 
     _definition.id                '_map_segment.array_section_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure_list_section.id
+;
+             This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
@@ -10948,9 +10538,10 @@ save_
 save_map_segment.binary_id
 
     _definition.id                '_map_segment.binary_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.binary_id distinguishes the particular 
+;
+             The value of _map_segment.binary_id distinguishes the particular 
               set of data organized according to _map_segment.array_id in 
               which the data values of the map are stored.
 
@@ -10970,9 +10561,10 @@ save_
 save_map_segment.details
 
     _definition.id                '_map_segment.details'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.details should give a
+;
+             The value of _map_segment.details should give a
               description of special aspects of each segment of a map.
 ;
     _name.category_id             map_segment
@@ -10981,10 +10573,11 @@ save_map_segment.details
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _description_example.case     'Example to be provided'
+    _description_example.case     '               Example to be provided'
     _description_example.detail
 ;
-    . . .
+               
+                . . .
 ;
 
 save_
@@ -10992,9 +10585,10 @@ save_
 save_map_segment.id
 
     _definition.id                '_map_segment.id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.id must uniquely
+;
+             The value of _map_segment.id must uniquely
               identify each segment of a map.
 ;
     _name.category_id             map_segment
@@ -11010,9 +10604,10 @@ save_
 save_map_segment.map_id
 
     _definition.id                '_map_segment.map_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _map.id
+;
+             This item is a pointer to _map.id
               in the MAP category.
 ;
     _name.category_id             map_segment
@@ -11027,9 +10622,10 @@ save_
 save_map_segment.mask_array_id
 
     _definition.id                '_map_segment.mask_array_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.mask_array_id, if given, describes
+;
+             The value of _map_segment.mask_array_id, if given, describes
               the array structure into which the mask for the map is
               organized.  If no value is given, then all elements of
               the map are valid.  If a value is given, then only
@@ -11058,9 +10654,10 @@ save_
 save_map_segment.mask_array_section_id
 
     _definition.id                '_map_segment.mask_array_section_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             This item is a pointer to _array_structure_list_section.id
+;
+             This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
@@ -11075,9 +10672,10 @@ save_
 save_map_segment.mask_binary_id
 
     _definition.id                '_map_segment.mask_binary_id'
-    _definition.update            2025-09-23
+    _definition.update            2026-05-14
     _description.text
-;             The value of _map_segment.mask_binary_id identifies the 
+;
+             The value of _map_segment.mask_binary_id identifies the 
               particular set of data organized according to 
               _map_segment.mask_array_id specifying the mask for the map.
 
@@ -11091,297 +10689,6 @@ save_map_segment.mask_binary_id
     _type.container               Single
     _type.contents                Integer
     _units.code                   none
-
-save_
-
-save_map_segment.variant
-
-    _definition.id                '_map_segment.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _map_segment.variant gives the variant
-              to which the given map segment is related.
-
-              If this value is not given, the variant is assumed to be
-              the default null variant.
-
-              This item is a pointer to _variant.variant in the
-              VARIANT category.
-;
-    _name.category_id             map_segment
-    _name.object_id               variant
-    _name.linked_item_id          '_variant.variant'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
-save_VARIANT
-
-    _definition.id                VARIANT
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2025-09-23
-    _description.text
-;
-    Data items in the VARIANT category record
-     the details about sets of variants of data items.
-
-     There is sometimes a need to allow for multiple versions of the
-     same data items in order to allow for refinements and corrections
-     to earlier assumptions, observations and calculations.  In order
-     to allow data sets to contain more than one variant of the same
-     information, an optional *.variant data item as a pointer to
-     _variant.variant has been added to the key of every category,
-     as an implicit data item with a null (empty) default value.
-
-     All rows in a category with the same variant value are considered
-     to be related to one another and to all rows in other categories
-     with the same variant value.  For a given variant, all such rows
-     are also considered to be related to all rows with a null variant
-     value, except that a row with a null variant value for which all
-     other components of its key are identical to those entries in
-     another row with a non-null variant value is not related the
-     the rows with that non-null variant value.  This behaviour is
-     similar to the convention for identifying alternate conformers
-     in an atom list.
-
-     An optional role may be specified for a variant as the value of
-     _variant.role.  Possible roles are null, 'preferred',
-     'raw data', 'unsuccessful trial'.
-
-     variants may carry an optional timestamp as the value of
-     _variant.timestamp.
-
-     variants may be related to other variants from which they were
-     derived by the value of _variant.variant_of.
-
-     Further details about the variant may be specified as the value
-     of _variant.details.
-
-     In order to allow variant information from multiple datasets to
-     be combined, _variant.diffrn_id and/or _variant.entry_id may
-     be used.
-;
-    _name.category_id             CIF_IMG_HEAD
-    _name.object_id               VARIANT
-
-    loop_
-      _category_key.name
-         '_variant.variant'
-         '_variant.diffrn_id'
-         '_variant.entry_id'
-
-    _description_example.case
-;        loop_
-        _variant.variant
-        _variant.role
-        _variant.timestamp
-        _variant.variant_of
-        _variant.details
-            . "raw data" 2007-08-03T23:20:00 . .
-            indexed "preferred" 2007-08-04T01:17:28 .
-              "indexed cell and refined beam centre"
-
-        loop_
-        _diffrn_detector_element.detector_id
-        _diffrn_detector_element.id
-        _diffrn_detector_element.reference_center_fast
-        _diffrn_detector_element.reference_center_slow
-        _diffrn_detector_element.reference_center_units
-        _diffrn_detector_element.variant
-        d1     d1_ccd_1  201.5 201.5  mm  .
-        d1     d1_ccd_2  -1.8  201.5  mm  .
-        d1     d1_ccd_3  201.6  -1.4  mm  .
-        d1     d1_ccd_4  -1.7   -1.5  mm  .
-        d1     d1_ccd_1  201.3 201.6  mm  indexed
-        d1     d1_ccd_2  -2.0  201.6  mm  indexed
-        d1     d1_ccd_3  201.3  -1.5  mm  indexed
-        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
-;
-    _description_example.detail
-;   Example 1. Distinguishing between a raw beam centre and a refined beam
-       centre inferred after indexing.  Detector d1 is composed of
-       four CCD detector elements, each 200 mm by 200 mm, arranged
-       in a square, in the pattern
-
-                   1     2
-                      *
-                   3     4
-
-       Note that the beam centre is slightly displaced from each of the
-       detector elements, just beyond the lower right corner of 1,
-       the lower left corner of 2, the upper right corner of 3 and
-       the upper left corner of 4.  For each element, the detector
-       face coordinate system is assumed to have the fast axis
-       running from left to right and the slow axis running from
-       top to bottom with the origin at the top left corner.
-
-       After indexing and refinement, the centre is shifted by 0.2 mm
-       left and 0.1 mm down.
-;
-
-save_
-
-save_variant.details
-
-    _definition.id                '_variant.details'
-    _definition.update            2025-09-23
-    _description.text
-;             A description of special aspects of the variant.
-;
-    _name.category_id             variant
-    _name.object_id               details
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'indexed cell and refined beam centre'
-
-save_
-
-save_variant.diffrn_id
-
-    _definition.id                '_variant.diffrn_id'
-    _definition.update            2025-09-23
-    _description.text
-;             This item is a pointer to _diffrn.id in the
-              diffrn category.
-;
-    _name.category_id             variant
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_variant.entry_id
-
-    _definition.id                '_variant.entry_id'
-    _definition.update            2025-09-23
-    _description.text
-;             This item is a pointer to _entry.id in the
-              entry category
-;
-    _name.category_id             variant
-    _name.object_id               entry_id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_variant.role
-
-    _definition.id                '_variant.role'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _variant.role  specified a role
-              for this variant.  Possible roles are null, 'preferred',
-              'raw data', and 'unsuccessful trial'.
-
-              A null value for _variant.role leaves the
-              precise role of the variant unspecified.  No inference should
-              be made that the variant with the latest time stamp is
-              preferred.
-;
-    _name.category_id             variant
-    _name.object_id               role
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         'preferred'
-;    A value of 'preferred' indicates that rows of any categories specifying
-     this variant should be used in preference to rows with the same key
-     specifying other variants or the null variant.  It is an error to specify
-     two variants that appear in the same category with the same key as being
-     preferred, but it is not an error to specify more than one variant as
-     preferred in other cases.
-;
-         'raw data'
-;    A value of 'raw data' indicates data prior to any corrections, 
-     calculations or refinements.  It is not necessarily an error for raw data
-     also to be a variant of an earlier variant.  It may be replacement raw 
-     data for earlier data believed to be erroneous.
-;
-         'unsuccessful trial'
-;    A value of 'unsuccessful trial' indicates data that should not be used
-     for further calculation.
-;
-
-save_
-
-save_variant.timestamp
-
-    _definition.id                '_variant.timestamp'
-    _definition.update            2025-09-23
-    _description.text
-;             The date and time identifying a variant.  This is not 
-              necessarily the precise time of the measurement or calculation
-              of the individual related data items, but a timestamp that 
-              reflects the order in which the variants were defined.
-;
-    _name.category_id             variant
-    _name.object_id               timestamp
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_variant.variant
-
-    _definition.id                '_variant.variant'
-    _definition.update            2025-09-23
-    _description.text
-;             The value of _variant.variant must uniquely identify
-              each variant for the given diffraction experiment and/or entry
-
-              This item has been made implicit and given a default value of 
-              null.
-;
-    _name.category_id             variant
-    _name.object_id               variant
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.default          .
-
-save_
-
-save_variant.variant_of
-
-    _definition.id                '_variant.variant_of'
-    _definition.update            2025-09-23
-    _description.text
-;            The value of _variant.variant_of gives the variant
-             from which this variant was derived.  If this value is not given,
-             the variant is assumed to be derived from the default null 
-             variant.
-
-             This item is a pointer to _variant.variant in the
-             VARIANT category.
-;
-    _name.category_id             variant
-    _name.object_id               variant_of
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -11673,7 +10980,8 @@ save_
        (HJB)
 ;
          1.3.2                    2005-06-25
-;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+;
+  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
               to those of current mmCIF; float modified by allowing integers
               terminated by a point as valid. The 'time' part of
               yyyy-mm-dd types made optional in the regexp. (BM)
@@ -11694,7 +11002,8 @@ save_
    (HJB)
 ;
          1.4.0                    2006-07-04
-;  This is a change to reintegrate all changes made in the course of
+;
+  This is a change to reintegrate all changes made in the course of
    publication of ITVG, by the RCSB from April 2005 through
    August 2008 and changes for the 2006 imgCIF workshop in
    Hawaii.
@@ -11734,7 +11043,8 @@ save_
                added sub_category 'vector' (JDW)
 ;
          1.5.0                    2007-07-25
-;  This is a cumulative list of the changes proposed since the
+;
+  This is a cumulative list of the changes proposed since the
    imgCIF workshop in Hawaii in July 2006.  It is the result
    of contributions by H. J. Bernstein, A. Hammersley,
    J. Wright and W. Kabsch.
@@ -11783,7 +11093,8 @@ save_
        Further clarifications of the coordinate system. (HJB)
 ;
          1.5.3                    2007-07-08
-;  Changes to support SLS miniCBF and suggestions
+;
+  Changes to support SLS miniCBF and suggestions
    from the 24 May 07 BNL imgCIF workshop (HJB)
 
      + Added new data items
@@ -11801,7 +11112,8 @@ save_
      + Changed all array_id data items to implicit
 ;
          1.5.4                    2007-07-28
-;  Typographics corrections (HJB)
+;
+  Typographics corrections (HJB)
 
      + Corrected embedded degree characters to \%
      + Corrected embedded Aring to \%A
@@ -11821,7 +11133,8 @@ save_
          +  add DIFFRN_SCAN_FRAME_MONITOR category
 ;
          1.6.4                    2011-07-02
-;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+;
+  Corrections to support DLS Dectris header as per G. Winter (HJB)
 
     +  Define new tags _diffrn_scan.time_period,
        _diffrn_scan.time_rstrt_incr,
@@ -11834,7 +11147,8 @@ save_
 
 ;
          1.7.0                    2013-06-18
-;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+;
+  Additions to start merge of CBF, HDF5 and NeXus (HJB)
 
     +  Define new ARRAY_STRUCTURE_LIST_SECTION category
     +  Add new _category.NX_mapping_details DDL tag to carry
@@ -11853,7 +11167,8 @@ save_
 
 ;
          1.7.1                    2013-08-10
-;  Minor cleanup (HJB)
+;
+  Minor cleanup (HJB)
 
     +  Correction to description of
          _diffrn_data_frame.array_section_id
@@ -11862,7 +11177,8 @@ save_
 
 ;
          1.7.2                    2013-10-07
-;  Add FEL detector positioning tags and change back to NXgoniometer
+;
+  Add FEL detector positioning tags and change back to NXgoniometer
 
     +  Add
        _axis.rotation_axis and
@@ -11871,7 +11187,8 @@ save_
 
 ;
          1.7.3                    2013-10-15
-;  Major cleanup of dictionary typos, misplaced loops, etc
+;
+  Major cleanup of dictionary typos, misplaced loops, etc
        by John Westbrook
 
     +  Change _item.mandatory_code of all *.variant to implicit
@@ -11899,7 +11216,8 @@ save_
          enumeration for _variant.role (HJB)
 ;
          1.7.7                    2014-02-22
-;  Major changes to NeXus mapping to conform to JS functional
+;
+  Major changes to NeXus mapping to conform to JS functional
     mapping prototype, add Stoke parameter tags for polarization
     and beam intensity, and add an new tag for FEL axes (HJB)
 
@@ -11917,7 +11235,8 @@ save_
        + Update dictionary version
 ;
          1.7.8                    2014-02-22
-;  Minor changes to NeXus mapping. (HJB)
+;
+  Minor changes to NeXus mapping. (HJB)
 
        + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
        NXdetector base class terminology
@@ -11926,7 +11245,8 @@ save_
        the reverse mapping from NeXus of the equivalent field in NXdetector.
 ;
          1.7.9                    2014-04-05
-;  Corrections to Stokes parameter description. (HJB)
+;
+  Corrections to Stokes parameter description. (HJB)
 
     + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
     and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
@@ -11979,7 +11299,8 @@ save_
         + Add _diffrn_radiation.beam_flux
 ;
          1.8.0                    2021-01-24
-;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+;
+   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
 
     + Add _diffrn_data_frame.center_derived as optional
     + Add _diffrn_measurement.sample_detector_distance_derived as optional
@@ -12008,7 +11329,8 @@ save_
         + Add _diffrn_scan_collection.variant as optional
 ;
          1.8.3                    2021-02-28
-;   Correction as per Brian McMahon
+;
+   Correction as per Brian McMahon
 
     + Fix _item.name for _array_structure_list.array_section_id
     + Remove spurious _item_aliases.alias_name from
@@ -12018,7 +11340,8 @@ save_
     + Deprecate _diffrn_scan_frame_monitor.value
 ;
          1.8.4                    2021-04-15
-;   Copy-editing refinements (bm)
+;
+   Copy-editing refinements (bm)
 
     + Add _item_related.related_name and
       "_item_related.function_code replacedby" to deprecated items.
@@ -12066,7 +11389,8 @@ save_
         + Add _array_data_external_data.archive_path
 ;
          1.8.7                    2023-01-26
-;   Various additions
+;
+   Various additions
 
     + Add _array_data_external_data.file_compression
       2022-06-09 (jrh).
@@ -12076,7 +11400,8 @@ save_
       2022-12-31 (ab) 
 ;
          1.8.8                    2024-01-20
-;   Additional flux tags and change to ddl2 version being the master
+;
+   Additional flux tags and change to ddl2 version being the master
     instead of the html version being the master.  Make changes to
     support conversions to DDLm and back to DDL2.  Mark tags aliased
     from mmCIF_PDBx dictionary.
@@ -12107,8 +11432,9 @@ save_
 ;
        Pick up minor type corrections from 1.8.9 dcitionary
 ;
-         1.8.9                    2026-05-03
-;   Addition of missing diffrn.id pointers
+         1.8.9                    2026-05-14
+;
+   Addition of missing diffrn.id pointers
 
     + Add _diffrn_detector_element.diffrn_id
     + Add _diffrn_measurement_axis.diffrn_id
@@ -12122,10 +11448,6 @@ save_
      (DDLm conversion) Specified Set categories ["diffrn_radiation", "diffrn_measurement", "diffrn_detector", "diffrn", "diffrn_source"]
 
      (DDLm conversion) Removed redundant aliases and definitions for aliased data names ["_diffrn_frame_data.binary_id", "_diffrn_frame_data.id", "_diffrn_scan_frame_monitor.value", "_diffrn_frame_data.details", "_diffrn_measurement_axis.id", "_diffrn_frame_data.array_id", "_diffrn_frame_data.detector_element_id", "_diffrn_detector_axis.id"]
-
-     (DDLm conversion) Removed DDL2-only categories
-
-     (DDLm conversion) Specified Set categories ["diffrn", "diffrn_detector", "diffrn_measurement", "diffrn_radiation", "diffrn_source"]
 
      (DDLm conversion) Removed DDL2-only categories
 

--- a/cif_img_variant.dic
+++ b/cif_img_variant.dic
@@ -65,7 +65,7 @@ save_ARRAY_DATA
      For full processing and archiving, most of the tags in this
      dictionary will need to be populated.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_data
 
     loop_
@@ -243,7 +243,7 @@ save_ARRAY_DATA_EXTERNAL_DATA
      record the location and essential characteristics of arrays of data for
     use in  ARRAY_DATA that are found external to the cif_img file.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_data_external_data
     _category_key.name            '_array_data_external_data.id'
 
@@ -286,7 +286,7 @@ save_ARRAY_ELEMENT_SIZE
     Data items in the ARRAY_ELEMENT_SIZE category record the physical
      size of array elements along each array dimension.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_element_size
 
     loop_
@@ -360,7 +360,7 @@ save_ARRAY_INTENSITIES
      value of _array_intensities.linearity will be 'raw'
      and _array_intensities.gain will not be used.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_intensities
 
     loop_
@@ -426,7 +426,7 @@ save_ARRAY_STRUCTURE
     Data items in the ARRAY_STRUCTURE category record the organization and
      encoding of array data that may be stored in the ARRAY_DATA category.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_structure
 
     loop_
@@ -486,7 +486,7 @@ save_ARRAY_STRUCTURE_LIST
 
      The relationship to physical axes may be given.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_structure_list
 
     loop_
@@ -568,7 +568,7 @@ save_ARRAY_STRUCTURE_LIST_AXIS
      Axes may be specified either for an entire array or for just a section
      of an array.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_structure_list_axis
 
     loop_
@@ -635,7 +635,7 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     _array_structure_list_section.array_id and not by the ordering implied
     by the stride.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               array_structure_list_section
 
     loop_
@@ -1058,7 +1058,7 @@ save_AXIS
      Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
      Brookhaven National Laboratory.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               axis
 
     loop_
@@ -2529,7 +2529,7 @@ save_DIFFRN_DATA_FRAME
               The items from the old category are provided
               as aliases but should not be used for new work.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_data_frame
 
     loop_
@@ -2602,7 +2602,7 @@ save_DIFFRN_DETECTOR
      detector used to measure the scattered radiation, including
      any analyser and post-sample collimation.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_detector
 
     loop_
@@ -2662,7 +2662,7 @@ save_DIFFRN_DETECTOR_AXIS
     Data items in the DIFFRN_DETECTOR_AXIS category associate
      axes with detectors.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_detector_axis
 
     loop_
@@ -2716,7 +2716,7 @@ save_DIFFRN_DETECTOR_ELEMENT
      is preferable to simply providing the centre of the
      detector element.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_detector_element
 
     loop_
@@ -2797,7 +2797,7 @@ save_DIFFRN_MEASUREMENT
      during data measurement and the manner in which the
      diffraction data were measured.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_measurement
 
     loop_
@@ -2874,7 +2874,7 @@ save_DIFFRN_MEASUREMENT_AXIS
     Data items in the DIFFRN_MEASUREMENT_AXIS category associate
      axes with goniometers.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_measurement_axis
 
     loop_
@@ -2927,7 +2927,7 @@ save_DIFFRN_RADIATION
               Post-sample treatment of the beam is described by data
               items in the DIFFRN_DETECTOR category.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_radiation
 
     loop_
@@ -3011,7 +3011,7 @@ save_DIFFRN_REFLN
      data set identified by _diffrn_reflns.diffrn_id and
      _diffrn_refln.frame_id
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_refln
 
     loop_
@@ -3060,7 +3060,7 @@ save_DIFFRN_SCAN
     Data items in the DIFFRN_SCAN category describe the parameters of one
      or more scans, relating axis positions to frames.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan
 
     loop_
@@ -3695,7 +3695,7 @@ save_DIFFRN_SCAN_AXIS
      axes for particular scans.  Unspecified axes are assumed to be at
      their zero points.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan_axis
 
     loop_
@@ -3746,7 +3746,7 @@ save_DIFFRN_SCAN_COLLECTION
      This category is a preliminary version being developed as
      synchrotron and XFEL collection strategies evolve.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan_collection
 
     loop_
@@ -3807,7 +3807,7 @@ save_DIFFRN_SCAN_FRAME
     Data items in the DIFFRN_SCAN_FRAME category describe
      the relationships of particular frames to scans.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan_frame
 
     loop_
@@ -3859,7 +3859,7 @@ save_DIFFRN_SCAN_FRAME_AXIS
      those values should be given explicitly in this category and not
      simply inferred from values in DIFFRN_SCAN_AXIS.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan_frame_axis
 
     loop_
@@ -3929,7 +3929,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
      _diffrn_scan_frame_monitor.id may be
      omitted.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               diffrn_scan_frame_monitor
 
     loop_
@@ -4119,7 +4119,7 @@ save_MAP
 
      Examples are given in the MAP_SEGMENT category.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               map
 
     loop_
@@ -4192,7 +4192,7 @@ save_MAP_SEGMENT
     Data items in the MAP_SEGMENT category record
      the details about each segment (section or brick) of a map.
 ;
-    _name.category_id             CIF_IMG_HEAD
+    _name.category_id             VARIANT_HEAD
     _name.object_id               map_segment
 
     loop_
@@ -4311,7 +4311,7 @@ save_VARIANT
      be combined, _variant.diffrn_id and/or _variant.entry_id may
      be used.
 ;
-    _name.category_id             variant_head
+    _name.category_id             VARIANT_HEAD
     _name.object_id               variant
     _category_key.name            '_variant.variant'
     _description_example.case

--- a/cif_img_variant.dic
+++ b/cif_img_variant.dic
@@ -1,0 +1,4539 @@
+#\#CIF_2.0
+##################################################################
+#                                                                #
+#                                                                #
+#                 variant dictionary                           #
+#                                                                #
+##################################################################
+
+data_VARIANT_DIC
+
+    _dictionary.title             VARIANT_DIC
+    _dictionary.class             Instance
+    _dictionary.version           1.0.0
+    _dictionary.date              2026-05-14
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         CifCore
+    _description.text
+;
+    This dictionary adds the variant category to the imported
+    dictionary.
+;
+
+save_VARIANT_HEAD
+
+    _definition.id                VARIANT_HEAD
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2026-05-14
+    _description.text
+;
+    The VARIANT_HEAD category becomes the overarching category
+    for the variant category and related data names defined below.
+;
+    _name.category_id             VARIANT_DIC
+    _name.object_id               VARIANT_HEAD
+
+    _import.get
+        [{'dupl':Ignore  'file':cif_img.dic  'mode':Full  'save':cif_img_head}]
+
+save_
+
+save_ARRAY_DATA
+
+    _definition.id                array_data
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_DATA category are the containers for
+     the array data items described in the category ARRAY_STRUCTURE.
+
+     It is recognized that the data in this category need to be used in
+     two distinct ways.  During a data collection the lack of ancillary
+     data and timing constraints in processing data may dictate the
+     need to make a 'miniCBF', nothing more than an essential minimum
+     of information to record the results of the data collection.  In that
+     case it is proper to use the ARRAY_DATA category as a
+     container for just a single image and a compacted, beamline-dependent
+     list of data collection parameter values.  In such
+     a case, only the tags '_array_data.header_convention',
+     '_array_data.header_contents' and '_array_data.data' need be
+     populated.
+
+     For full processing and archiving, most of the tags in this
+     dictionary will need to be populated.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_data
+
+    loop_
+      _category_key.name
+         '_array_data.array_id'
+         '_array_data.binary_id'
+         '_array_data.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+
+         loop_
+        _array_data.array_id
+        _array_data.binary_id
+        _array_data.data
+        image_1 1
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF_CANONICAL"
+        Content-Transfer-Encoding: X-BASE16
+        X-Binary-Size: 3927126
+        X-Binary-ID: 1
+        Content-MD5: u2sTJEovAHkmkDjPi+gWsg==
+
+        # Hexadecimal encoding, byte 0, byte order ...21
+        #
+        H4< 0050B810 00000000 00000000 00000000 000F423F 00000000 00000000 ...
+        ....
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+        image_2 2
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="X-CBF-PACKED"
+        Content-Transfer-Encoding: BASE64
+        X-Binary-Size: 3745758
+        X-Binary-ID: 2
+        Content-MD5: 1zsJjWPfol2GYl2V+QSXrw==
+
+        ELhQAAAAAAAA...
+        ...
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+;
+        Example 1.
+
+        This example shows two binary data blocks.  The first one
+        was compressed by the CBF_CANONICAL compression algorithm and is
+        presented as hexadecimal data.  The first character 'H' on the
+        data lines means hexadecimal.  It could have been 'O' for octal
+        or 'D' for decimal.  The second character on the line shows
+        the number of bytes in each word (in this case '4'), which then
+        requires eight hexadecimal digits per word.  The third character
+        gives the order of octets within a word, in this case '<'
+        for the ordering 4321 (i.e. 'big-endian').  Alternatively, the
+        character '>' could have been used for the ordering 1234
+        (i.e. 'little-endian').  The block has a 'message digest'
+        to check the integrity of the data.
+
+        The second block is similar, but uses CBF_PACKED compression
+        and BASE64 encoding.  Note that the size and the digest are
+        different.
+;
+;
+        ###CBF: VERSION 1.5
+        # CBF file written by CBFlib v0.7.8
+
+        data_insulin_pilatus6m
+
+        _array_data.header_convention SLS_1.0
+        _array_data.header_contents
+        ;
+        # Detector: PILATUS 6M SN: 60-0001
+        # 2007/Jun/17 15:12:36.928
+        # Pixel_size 172e-6 m x 172e-6 m
+        # Silicon sensor, thickness 0.000320 m
+        # Exposure_time 0.995000 s
+        # Exposure_period 1.000000 s
+        # Tau = 194.0e-09 s
+        # Count_cutoff 1048575 counts
+        # Threshold_setting 5000 eV
+        # Wavelength 1.2398 A
+        # Energy_range (0, 0) eV
+        # Detector_distance 0.15500 m
+        # Detector_Voffset -0.01003 m
+        # Beam_xy (1231.00, 1277.00) pixels
+        # Flux 22487563295 ph/s
+        # Filter_transmission 0.0008
+        # Start_angle 13.0000 deg.
+        # Angle_increment 1.0000 deg.
+        # Detector_2theta 0.0000 deg.
+        # Polarization 0.990
+        # Alpha 0.0000 deg.
+        # Kappa 0.0000 deg.
+        # Phi 0.0000 deg.
+        # Chi 0.0000 deg.
+        # Oscillation_axis  X, CW
+        # N_oscillations 1
+        ;
+
+        _array_data.data
+        ;
+        --CIF-BINARY-FORMAT-SECTION--
+        Content-Type: application/octet-stream;
+             conversions="x-CBF_BYTE_OFFSET"
+        Content-Transfer-Encoding: BINARY
+        X-Binary-Size: 6247567
+        X-Binary-ID: 1
+        X-Binary-Element-Type: "signed 32-bit integer"
+        X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+        Content-MD5: 8wO6i2+899lf5iO8QPdgrw==
+        X-Binary-Number-of-Elements: 6224001
+        X-Binary-Size-Fastest-Dimension: 2463
+        X-Binary-Size-Second-Dimension: 2527
+        X-Binary-Size-Padding: 4095
+
+        ...
+
+        --CIF-BINARY-FORMAT-SECTION----
+        ;
+;
+;
+        Example 2.
+
+        This example shows a single image in a miniCBF, provided by
+        E. Eikenberry.  The entire CBF consists of one data block
+        containing one category and three tags.  The CBFlib
+        program convert_miniCBF and a suitable template file
+        can be used to convert this miniCBF to a full imgCIF
+        file.
+;
+
+save_
+
+save_array_data.variant
+
+    _definition.id                '_array_data.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_data.variant gives the variant
+              to which the given ARRAY_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_data
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_DATA_EXTERNAL_DATA
+
+    _definition.id                array_data_external_data
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_DATA_EXTERNAL_DATA category optionally
+     record the location and essential characteristics of arrays of data for
+    use in  ARRAY_DATA that are found external to the cif_img file.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_data_external_data
+    _category_key.name            '_array_data_external_data.id'
+
+save_
+
+save_array_data_external_data.variant
+
+    _definition.id                '_array_data_external_data.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_data_external_data.variant gives the variant
+              to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_data_external_data
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_ELEMENT_SIZE
+
+    _definition.id                array_element_size
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_ELEMENT_SIZE category record the physical
+     size of array elements along each array dimension.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_element_size
+
+    loop_
+      _category_key.name
+         '_array_element_size.array_id'
+         '_array_element_size.index'
+         '_array_element_size.variant'
+
+    _description_example.case
+;
+        loop_
+       _array_element_size.array_id
+       _array_element_size.index
+       _array_element_size.size
+        image_1   1    1.22e-6
+        image_1   2    1.22e-6
+;
+    _description_example.detail
+;
+      Example 1. A regular 2D array with a uniform element dimension
+                    of 1220 nanometres.
+;
+
+save_
+
+save_array_element_size.variant
+
+    _definition.id                '_array_element_size.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_element_size.variant gives the variant
+              to which the given ARRAY_ELEMENT_SIZE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_element_size
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_INTENSITIES
+
+    _definition.id                array_intensities
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_INTENSITIES category record the
+     information required to recover the intensity data from
+     the set of data values stored in the ARRAY_DATA category.
+
+     The detector may have a complex relationship
+     between the raw intensity values and the number of
+     incident photons.  In most cases, the number stored
+     in the final array will have a simple linear relationship
+     to the actual number of incident photons, given by
+     _array_intensities.gain.  If raw, uncorrected values
+     are presented (e.g. for calibration experiments), the
+     value of _array_intensities.linearity will be 'raw'
+     and _array_intensities.gain will not be used.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_intensities
+
+    loop_
+      _category_key.name
+         '_array_intensities.array_id'
+         '_array_intensities.binary_id'
+         '_array_intensities.variant'
+
+    _description_example.case
+;
+        loop_
+        _array_intensities.array_id
+        _array_intensities.linearity
+        _array_intensities.gain
+        _array_intensities.overload
+        _array_intensities.undefined_value
+        _array_intensities.pixel_fast_bin_size
+        _array_intensities.pixel_slow_bin_size
+        _array_intensities.pixel_binning_method
+        image_1   linear  1.2    655535   0   2   2    hardware
+;
+    _description_example.detail
+;
+        Example 1
+;
+
+save_
+
+save_array_intensities.variant
+
+    _definition.id                '_array_intensities.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_intensities.variant gives the variant
+              to which the given ARRAY_INTENSITIES row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_intensities
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE
+
+    _definition.id                array_structure
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_STRUCTURE category record the organization and
+     encoding of array data that may be stored in the ARRAY_DATA category.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_structure
+
+    loop_
+      _category_key.name
+         '_array_structure.id'
+         '_array_structure.variant'
+
+    _description_example.case
+;
+     loop_
+    _array_structure.id
+    _array_structure.encoding_type
+    _array_structure.compression_type
+    _array_structure.byte_order
+     image_1       "unsigned 16-bit integer"  none  little_endian
+;
+    _description_example.detail   'Example 1.'
+
+save_
+
+save_array_structure.variant
+
+    _definition.id                '_array_structure.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_structure.variant gives the variant
+              to which the given ARRAY_STRUCTURE row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST
+
+    _definition.id                array_structure_list
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_STRUCTURE_LIST category record the size
+     and organization of each array dimension.
+
+     The relationship to physical axes may be given.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_structure_list
+
+    loop_
+      _category_key.name
+         '_array_structure_list.array_id'
+         '_array_structure_list.index'
+         '_array_structure_list.variant'
+
+    _description_example.case
+;
+        loop_
+       _array_structure_list.array_id
+       _array_structure_list.index
+       _array_structure_list.dimension
+       _array_structure_list.precedence
+       _array_structure_list.direction
+       _array_structure_list.axis_set_id
+        image_1   1    1300    1     increasing  ELEMENT_X
+        image_1   2    1200    2     decreasing  ELEMENY_Y
+;
+    _description_example.detail
+;
+       Example 1. An image array of 1300 x 1200 elements.  The raster
+                    order of the image is left to right (increasing) in the
+                    first dimension and bottom to top (decreasing) in
+                    the second dimension.
+;
+
+save_
+
+save_array_structure_list.variant
+
+    _definition.id                '_array_structure_list.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_structure_list.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST_AXIS
+
+    _definition.id                array_structure_list_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the ARRAY_STRUCTURE_LIST_AXIS category describe
+     the physical settings of sets of axes for the centres of pixels that
+     correspond to data points described in the
+     ARRAY_STRUCTURE_LIST category.
+
+     In the simplest cases, the physical increments of a single axis correspond
+     to the increments of a single array index.  More complex organizations,
+     e.g. spiral scans, may require coupled motions along multiple axes.
+
+     Note that a spiral scan uses two coupled axes: one for the angular
+     direction and one for the radial direction.  This differs from a
+     cylindrical scan for which the two axes are not coupled into one
+     set.
+
+     Axes may be specified either for an entire array or for just a section
+     of an array.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_structure_list_axis
+
+    loop_
+      _category_key.name
+         '_array_structure_list_axis.axis_set_id'
+         '_array_structure_list_axis.axis_id'
+         '_array_structure_list_axis.variant'
+
+save_
+
+save_array_structure_list_axis.variant
+
+    _definition.id                '_array_structure_list_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+            The value of _array_structure_list_axis.variant gives the variant
+              to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_ARRAY_STRUCTURE_LIST_SECTION
+
+    _definition.id                array_structure_list_section
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
+    the dimension-by-dimension start, end and stride of each section of an
+    array that is to be referenced.
+
+    For any array with identifier ARRAYID, array section ids of the form
+    ARRAYID(start1:end1:stride1,start2:end2:stride2, ...) are defined
+    by default.
+
+    For the given index, the elements in the section are of indices:
+    _array_structure_list_section.start,
+    _array_structure_list_section.start + _array_structure_list_section.stride,
+    _array_structure_list_section.start + 2*_array_structure_list_section.stride,
+    ...
+
+    stopping either when the indices leave the limits of the indices
+    of that dimension or 
+    [min(_array_structure_list_section.start, _array_structure_list_section.end),
+     max(_array_structure_list_section.start, _array_structure_list_section.end)].
+    The ordering of these elements is determined by the overall ordering of
+    _array_structure_list_section.array_id and not by the ordering implied
+    by the stride.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               array_structure_list_section
+
+    loop_
+      _category_key.name
+         '_array_structure_list_section.id'
+         '_array_structure_list_section.array_id'
+         '_array_structure_list_section.index'
+         '_array_structure_list_section.variant'
+
+    _description_example.case
+;
+
+     loop_
+    _array_structure_list.array_id
+    _array_structure_list.index
+    _array_structure_list.dimension
+    _array_structure_list.precedence
+    _array_structure_list.direction
+    _array_structure_list.axis_set_id
+    myarray   1    1300    1     increasing  ELEMENT_X
+    myarray   2    1200    2     increasing  ELEMENT_Y
+    myarray   3    700     3     increasing  FRAME_NO
+
+     loop_
+    _array_structure_list_section.id
+    _array_structure_list_section.array_id
+    _array_structure_list_section.index
+    _array_structure_list_section.start
+    _array_structure_list_section.end
+    _array_structure_list_section.stride
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
+    "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+
+;
+    _description_example.detail
+;
+       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+                    700 frames is defined in ARRAY_STRUCTURE_LIST, and
+                    the array section identifier
+
+                    "myarray(101:1200,101:1100,1:700:10)"
+
+                    is explicitly defined taking every 10th frame and
+                    removing a 100 pixel border.  Note that even though
+                    the slow index high is 700, the last frame that
+                    will actually be included is only 691.
+;
+
+save_
+
+save_array_structure_list_section.variant
+
+    _definition.id                '_array_structure_list_section.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _array_structure_list_section.variant gives the
+              variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
+              is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             array_structure_list_section
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_AXIS
+
+    _definition.id                axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+   Data items in the AXIS category record the information required
+     to describe the various goniometer, detector, source and other
+     axes needed to specify a data collection or the axes defining the
+     coordinate system of an image.  
+
+     The location of each axis is specified by two vectors: the axis 
+     itself, given by a unit vector in the direction of the axis, and 
+     an offset to the base of the unit vector.  
+
+     The vectors defining an axis are referenced to an appropriate
+     coordinate system, given in _axis.system.  The axis vector itself,
+       [_axis.vector[1], _axis.vector[2], _axis.vector[3]],
+     is a dimensionless unit vector.  Where meaningful, an offset vector
+       [_axis.offset[1], _axis.offset[2], _axis.offset[3]]
+     supplies the offsets to the base of a rotation or translation axis in
+     X, Y and Z.  This is appropriate for the imgCIF standard laboratory 
+     coordinate system, the NeXus/HDF5 McStas laboratory coordinate system 
+     and the last two Cartesian coordinate systems, but for the direct lattice, 
+     X corresponds to a, Y to b and Z to c, while for the reciprocal lattice,
+     X corresponds to a*, Y to b* and Z to c*.
+
+     For purposes of visualization, all the coordinate systems are 
+     taken as right-handed, i.e. using the convention that the extended 
+     thumb of a right hand could point along the first (X) axis, the 
+     straightened pointer finger could point along the second (Y) axis 
+     and the middle finger folded inward could point along the third (Z)
+     axis.  For a right-handed rotation axis, if the right hand is wrapped
+     around the axis with the thumb pointed in the direction of the axis,
+     the fingers point in the positive rotation direction, i.e. clockwise.  
+
+     THE IMGCIF STANDARD LABORATORY COORDINATE SYSTEM 
+     The imgCIF standard laboratory coordinate system is a right-handed   
+     orthogonal coordinate system similar to that used by MOSFLM,  
+     but imgCIF puts Z along the X-ray beam, rather than putting X along the
+     X-ray beam as in MOSFLM.
+
+     The vectors for the imgCIF standard laboratory coordinate system
+     form a right-handed Cartesian coordinate system with its origin
+     in the sample or specimen.  The origin of the axis system should,
+     if possible, be defined in terms of mechanically stable axes to be
+     both in the sample and in the beam.  If the sample goniometer or other
+     sample positioner has two axes the intersection of which defines a
+     unique point at which the sample should be mounted to be bathed
+     by the beam, that will be the origin of the axis system.  If no such
+     point is defined, then the midpoint of the line of intersection
+     between the sample and the centre of the beam will define the origin.
+     For this definition the sample positioning system will be set at 
+     its initial reference position for the experiment.
+                             | Y (to complete right-handed system)
+                             |
+                             |
+                             |
+                             |
+                             |
+                             |________________X
+                            /       principal goniometer axis
+                           /
+                          /
+                         /
+                        /
+                       /Z (to source)
+     Axis 1 (X): The X-axis is aligned to the mechanical axis pointing from
+     the sample or specimen along the  principal axis of the goniometer or
+     sample positioning system if the sample positioning system has an axis 
+     that intersects the origin and which forms an angle of more than 22.5 
+     degrees with the beam axis.
+
+     Axis 2 (Y): The Y-axis completes an orthogonal right-handed system
+     defined by the X-axis and the Z-axis (see below).
+
+     Axis 3 (Z): The Z-axis is derived from the source axis which goes from
+     the sample to the source.  The Z-axis is the component of the source axis
+     in the direction of the source orthogonal to the X-axis in the plane
+     defined by the X-axis and the source axis.
+
+     If the conditions for the X-axis can be met, the coordinate system
+     will be based on the goniometer or other sample positioning system
+     and the beam and not on the orientation of the detector, gravity etc.  
+     The vectors necessary to specify all other axes are given by sets of 
+     three components in the order (X, Y, Z).
+     If the axis involved is a rotation axis, it is right-handed, i.e. as
+     one views the object to be rotated from the origin (the tail) of the
+     unit vector, the rotation is clockwise.  If a translation axis is
+     specified, the direction of the unit vector specifies the sense of
+     positive translation.
+
+     In some experimental techniques, there is no goniometer or the principal
+     axis of the goniometer is at a small acute angle with respect to
+     the source axis.  In such cases, other reference axes are needed
+     to define a useful coordinate system.  The order of priority in
+     defining directions in such cases is to use the detector, then
+     gravity, then north.
+
+     If the X-axis cannot be defined as above, then the
+     direction (not the origin) of the X-axis should be parallel to the axis 
+     of the primary detector element corresponding to the most rapidly 
+     varying dimension of that detector element's data array, with its 
+     positive sense corresponding to increasing values of the index for 
+     that dimension.  If the detector is such that such a direction cannot 
+     be defined (as with a point detector) or that the direction forms an
+     angle of less than 22.5 degrees with respect to the source axis, then 
+     the X-axis should be chosen so that if the Y-axis is chosen 
+     in the direction of gravity, and the Z-axis is chosen to be along 
+     the source axis, a right-handed orthogonal coordinate system is chosen.  
+     In the case of a vertical source axis, as a last resort, the 
+     X-axis should be chosen to point north.
+
+     All rotations are given in degrees and all translations are given in mm.
+
+     Axes may be dependent on one another.  The X-axis is the only goniometer
+     axis the direction of which is strictly connected to the hardware.  All
+     other axes are specified by the positions they would assume when the
+     axes upon which they depend are at their zero points.
+
+     When specifying detector axes, the axis is given to the beam centre.
+     The location of the beam centre on the detector should be given in the
+     DIFFRN_DETECTOR category in distortion-corrected millimetres from
+     the (0,0) corner of the detector.
+
+     For convenience when describing detector element (module) placement,
+     an optional mounting rotation axis and rotation angle may be
+     specified.  In such cases, the mounting rotation axis and angle
+     of rotation around the mounting rotation axis are applied after
+     applying the transformations upon which the given axis depends.
+
+     It should be noted that many different origins arise in the definition
+     of an experiment.  In particular, as noted above, it is necessary to
+     specify the location of the beam centre on the detector in terms
+     of the origin of the detector, which is, of course, not coincident
+     with the centre of the sample.
+     THE NEXUS/HDF5 MCSTAS LABORATORY COORDINATE SYSTEM 
+     The standard coordinate frame in NeXus is the McStas coordinate frame,
+     in which the Z-axis points in the direction of the incident beam, the
+     X-axis is orthogonal to the Z-axis in the horizontal plane and pointing
+     left as seen from the source and the Y-axis points upwards.  The
+     origin is in the sample.
+
+     Differences in Coordinate Frames
+
+     The standard coordinate frame in imgCIF/CBF aligns the X-axis to the
+     principal goniometer axis, and chooses the Z-axis to point from the sample
+     into the beam.  If the beam is not orthogonal to the X-axis, the Z-axis
+     is the component of the vector that points into the beam orthogonal to the
+     X-axis.  The Y-axis is chosen to complete a right-handed axis system.
+
+     Let us call the NeXus coordinate axes, X_nx, Y_nx and Z_nx, the
+     imgCIF/CBF coordinate axes, X_cbf, Y_cbf and Z_cbf and the direction
+     of gravity, Gravity.  In order to translate a vector v_nx = ( x, y, z)
+     from the NeXus coordinate system to the imgCIF coordinate system, we
+     also need two additional axes, as unit vectors, Gravity_cbf the downwards
+     direction, and  Beam_cbf, the direction of the beam, e.g. ( 0, 0, -1).   
+
+     In practice, the beam is not necessarily perfectly horizontal, so Y_nx
+     is not necessarily perfectly vertical. Therefore, in order to generate
+     X_nx, Y_nx and Z_nx some care is needed.  The cross product between two
+     vectors a and b is a new vector c orthogonal to both a and b,
+     chosen so that a, b, c is a right-handed system.  If a and b are
+     orthogonal unit vectors, this right-handed system is an orthonormal
+     coordinate system.
+
+     In the CBF coordinate frame, Z_nx is aligned to Beam_cbf:
+
+        Z_nx = Beam_cbf.
+
+     X_nx is defined as being horizontal at right angles to the beam,
+     pointing to the left when seen from the source.  Assuming the beam is
+     not vertical, we can compute X_nx as the normalized cross product of
+     the  beam and gravity:
+
+        X_nx = (Beam_cbf x Gravity_cbf)/||Beam_cbf x Gravity_cbf||.
+
+     To see that this satisfies the constraint of being horizontal and
+     pointing to the left, consider the case of Beam = ( 0, 0, -1 )
+     and Gravity = ( 0, 0, 1 ); then we would have X_nx = ( 1, 0, 0 )
+     from the cross product above.  The normalization is only necessary
+     if the beam is not horizontal.
+
+     Finally Y_nx is computed as the cross product of the beam and X_nx,
+     completing an orthonormal right-handed system with Y_nx pointing upwards
+
+        Y_nx = Beam_cbf x X_nx.
+
+     Then we know that in the imgCIF/CBF coordinate frame
+
+        v_nx = X.X_nx + Y.Y_nx + Z.Z_nx.
+
+     Thus, given the imgCIF/CBF vectors for the true direction of the beam
+     and the true direction of gravity, we have a linear transformation from
+     the NeXus coordinate frame to the imgCIF/CBF coordinate frame.   The
+     origins of the two frames agree.   The inverse linear transformation will
+     transform a vector in the imgCIF/CBF coordinate frame into the NeXus
+     coordinate frame.
+
+     In the common case in which the beam is orthogonal to the principal
+     goniometer axis so that Beam_cbf = ( 0, 0, -1 ) and the imgCIF/CBF
+     Y-axis points upwards, the transformation inverts the X and Z axes.
+     In the other common case in which the beam is orthogonal to the
+     principal goniometer axis and the imgCIF/CBF Y-axis points
+     downwards, the transformation inverts the Y and Z axes.
+
+     Mapping axes
+
+     There are two transformations needed:  coord_xform(v) which takes a vector,
+     v, in the CBF imgCIF Standard Laboratory Coordinate System and returns the
+     equivalent McStas coordinate vector, and offset_xform(o) which takes an
+     offset, o, in the CBF imgCIF Standard Laboratory Coordinate System and
+     returns the equivalent NeXus offset.
+
+     In imgCIF/CBF all the information about all axes other than their
+     settings are gathered in one AXIS category.  The closest equivalent
+     container in NeXus is the NXinstrument class.  We put the information
+     about detector axes into a
+     detector:NXdetector/transformations:NXtransformations NeXus class instance,
+     information about the goniometer into a
+     goniometer:NXgoniometer/transformations:NXtransformations NeXus
+     class instance, etc.  Additionally, in view of the general nature of
+     some axes, such as the coordinate frame axes and gravity, we add a
+     transformations:NXtransformation NeXus class instance under NXentry with
+     axis__gravity, axis__beam and other axes not tied to specific equipment.
+
+     We have applied the coordinate frame transformation changing
+     the CBF laboratory coordinates into McStas coordinates.  Notice that X and
+     Z have changed direction, but Y has not.   In other experimental setups,
+     other transformations may occur.   The offsets for dependent axes are
+     given relative to the total offset of axes on which that axis is dependent.
+     Note that the axis settings do not enter into this calculation, because the
+     offsets of dependent axes are given with all axes at their zero settings.
+     The cbf_location attribute gives a mapping back into the CBF AXIS category
+     in dotted notation.  The first component is the data block.  The second
+     component is "axis".  The third component is either "vector" or
+     "offset"  for information drawn from the AXIS.VECTOR[...] or
+     AXIS.OFFSET[...] respectively.  The last component is the CBF row number
+     to facilitate recovering the original CBF layout.
+
+     THE DIRECT LATTICE (FRACTIONAL COORDINATES) 
+     The unit cell, reciprocal cell and crystallographic orthogonal 
+     Cartesian coordinate system are defined by the CELL and the matrices 
+     in the ATOM_SITES category.
+
+     The direct lattice coordinate system is a system of fractional
+     coordinates aligned to the crystal, rather than to the laboratory.
+     This is a natural coordinate system for maps and atomic coordinates.
+     It is the simplest coordinate system in which to apply symmetry.
+     The axes are determined by the cell edges, and are not necessarily
+     orthogonal.  This coordinate system is not uniquely defined and 
+     depends on the cell parameters in the CELL category and the
+     settings chosen to index the crystal. 
+
+     Molecules in a crystal studied by X-ray diffraction are organized
+     into a repeating regular array of unit cells.  Each unit cell is defined 
+     by three vectors, a, b and c.  To quote from Drenth (2001),
+     "The choice of the unit cell is not unique and therefore, guidelines
+     have been established for selecting the standard basis vectors and
+     the origin.  They are based on symmetry and metric considerations:
+
+      "(1)  The axial system should be right-handed.
+       (2)  The basis vectors should coincide as much as possible with
+       directions of highest symmetry.
+       (3)  The cell taken should be the smallest one that satisfies
+       condition (2)
+       (4)  Of all the lattice vectors, none is shorter than a.
+       (5)  Of those not directed along a, none is shorter than b.
+       (6)  Of those not lying in the ab plane, none is shorter than c.
+       (7)  The three angles between the basis vectors a, b and c are
+       either all acute (<90 degrees) or all obtuse (&ge;90 degrees)."
+
+     These rules do not produce a unique result that is stable under
+     the assumption of experimental errors, and the resulting cell
+     may not be primitive.
+
+     In this coordinate system, the vector (.5, .5, .5) is in the middle
+     of the given unit cell.
+
+     Grid coordinates are an important variation on fractional coordinates
+     used when working with maps.  In imgCIF, the conversion from
+     fractional to grid coordinates is implicit in the array indexing
+     specified by _array_structure_list.dimension.  Note that this
+     implicit grid-coordinate scheme is 1-based, not zero-based, i.e.
+     the origin of the cell for axes along the cell edges with no
+     specified _array_structure_list_axis.displacement will have
+     grid coordinates of (1,1,1), i.e. array indices of (1,1,1).
+     THE ORTHOGONAL CARTESIAN COORDINATE SYSTEM (REAL SPACE) 
+     The orthogonal Cartesian coordinate system is a transformation of
+     the direct lattice to the actual physical coordinates of atoms in
+     space.  It is similar to the laboratory coordinate system, but
+     is anchored to and moves with the crystal, rather than being
+     anchored to the laboratory.  The transformation from fractional
+     to orthogonal Cartesian coordinates is given by the
+              _atom_sites.Cartn_transf_matrix[i][j]  and
+              _atom_sites.Cartn_transf_vector[i]
+     tags.  A common choice for the matrix of the transformation is 
+     given in Protein Data Bank (1992):
+
+              | a      b cos \g   c cos \b                            |
+              | 0      b sin \g   c (cos \a - cos \b cos \g)/sin \g   |
+              | 0      0          V/(a b sin \g)                      |
+
+     This is a convenient coordinate system in which to do fitting
+     of models to maps and in which to understand the chemistry of
+     a molecule.
+     THE RECIPROCAL LATTICE 
+     The reciprocal lattice coordinate system is used for diffraction
+     intensities.  It is based on the reciprocal cell, the dual of the cell,
+     in which reciprocal cell edges are derived from direct cell faces:
+
+        a* = bc sin \a /V  b* = ac sin \b /V  c* = ab sin \g /V
+        cos \a* = (cos \b  cos \g  - cos \a )/(sin \b sin \g )
+        cos \b* = (cos \a  cos \g  - cos \b )/(sin \a sin \g )
+        cos \g* = (cos \a  cos \b  - cos \g )/(sin \a sin \b )
+        V = abc (1 - cos^2^ \a 
+                       - cos^2^ \b
+                       - cos^2^ \g
+                       + 2 cos \a cos \b cos \g )^1/2^
+
+     In this form the dimensions of the reciprocal lattice are in reciprocal
+     \%angstr\"oms (\%A^-1^).  A dimensionless form can be obtained by 
+     multiplying by the wavelength.  Reflections are commonly indexed against
+     this coordinate system as (h, k, l) triples.
+     References:
+
+     Drenth, J. (2001). Introduction to basic crystallography.
+     International tables for crystallography, Vol. F, Crystallography of
+     biological macromolecules, edited by M. G. Rossmann & E. Arnold,
+     1st ed., ch. 2.1, pp. 44--63. Dordrecht: Kluwer Academic Publishers.    
+
+     Leslie, A. G. W. & Powell, H. (2004). MOSFLM v6.11.
+     MRC Laboratory of Molecular Biology, Hills Road, Cambridge, England.
+     http://www.CCP4.ac.uk/dist/X-windows/Mosflm/.
+
+     Stout, G. H. & Jensen, L. H. (1989). X-ray structure determination,
+     2nd ed., 453 pp. New York: Wiley.
+
+     Protein Data Bank (1992). Atomic Coordinate and Bibliographic
+     Entry Format Description. Report, February 1992. Brookhaven, NY, USA:
+     Brookhaven National Laboratory.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               axis
+
+    loop_
+      _category_key.name
+         '_axis.id'
+         '_axis.equipment'
+         '_axis.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        omega rotation goniometer     .    1        0        0
+        kappa rotation goniometer omega    -.64279  0       -.76604
+        phi   rotation goniometer kappa    1        0        0
+;
+;
+      Example 1.
+
+        This example shows the axis specification of the axes of a
+        kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
+        (1989). X-ray structure determination. A practical
+        guide, 2nd ed. p. 134. New York: Wiley Interscience].
+
+        There are three axes specified, and no offsets.  The outermost axis,
+        omega, is pointed along the X axis.  The next innermost axis, kappa,
+        is at a 50 degree angle to the X axis, pointed away from the source.
+        The innermost axis, phi, aligns with the X axis when omega and
+        phi are at their zero points.  If T-omega, T-kappa and T-phi
+        are the transformation matrices derived from the axis settings,
+        the complete transformation would be:
+            X' = (T-omega) (T-kappa) (T-phi) X
+;
+;
+        loop_
+        _axis.id
+        _axis.type
+        _axis.equipment
+        _axis.depends_on
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        _axis.offset[1] _axis.offset[2] _axis.offset[3]
+        source       .        source     .       0     0     1   . . .
+        gravity      .        gravity    .       0    -1     0   . . .
+        tranz     translation detector rotz      0     0     1   0 0 -68
+        twotheta  rotation    detector   .       1     0     0   . . .
+        roty      rotation    detector twotheta  0     1     0   0 0 -68
+        rotz      rotation    detector roty      0     0     1   0 0 -68
+;
+;
+      Example 2.
+
+        This example shows the axis specification of the axes of a
+        detector, source and gravity.  The order has been changed as a
+        reminder that the ordering of presentation of tokens is not
+        significant.  The centre of rotation of the detector has been taken
+        to be 68 mm in the direction away from the source.
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        CELL_A_AXIS    fractional       1 0 0
+        CELL_B_AXIS    fractional       0 1 0
+        CELL_C_AXIS    fractional       0 0 1
+
+        loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing CELL_A_AXIS
+        map 1 25 2 increasing CELL_B_AXIS
+        map 1 25 3 increasing CELL_C_AXIS
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.fract_displacement
+        _array_structure_list_axis.fract_displacement_increment
+        CELL_A_AXIS 0.01 0.02
+        CELL_B_AXIS 0.01 0.02
+        CELL_C_AXIS 0.01 0.02
+;
+;
+      Example 3.
+
+        This example shows the axis specification of the axes for a map,
+        using fractional coordinates.  Each cell edge has been divided
+        into a grid of 50 divisions in the ARRAY_STRUCTURE_LIST_AXIS 
+        category.  The map is using only the first octant of the grid
+        in the ARRAY_STRUCTURE_LIST category.
+
+        The fastest changing axis is along A, then along B,
+        and the slowest is along C. 
+
+        The map sampling is being done in the middle of each grid
+        division.
+
+;
+;
+        loop_
+        _axis.id
+        _axis.system
+        _axis.vector[1] _axis.vector[2] _axis.vector[3]
+        X    orthogonal       1 0 0
+        Y    orthogonal       0 1 0
+        Z    orthogonal       0 0 1
+
+                loop_
+        _array_structure_list.array_id
+        _array_structure_list.index
+        _array_structure_list.dimension
+        _array_structure_list.precedence
+        _array_structure_list.direction
+        _array_structure_list.axis_set_id
+        map 1 25 1 increasing X
+        map 2 25 2 increasing Y
+        map 3 25 3 increasing Z
+
+        loop_
+        _array_structure_list_axis.axis_id
+        _array_structure_list_axis.displacement
+        _array_structure_list_axis.displacement_increment
+        X 7.5e-8 1.5e-7
+        Y 7.5e-8 1.5e-7
+        Z 7.5e-8 1.5e-7
+;
+;
+      Example 4.
+
+        This example shows the axis specification of the axes for a map,
+        this time as orthogonal \%angstr\"oms, using the same coordinate system 
+        as for the atomic coordinates.  The map is sampling every 1.5
+        \%A (1.5e-7 mm) in a map segment 37.5 \%A on a side.
+;
+;
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_D0_X
+    CSPAD_FRONT AXIS_D0_Y
+    CSPAD_FRONT AXIS_D0_Z
+    CSPAD_FRONT AXIS_D0_R
+    CSPAD_FRONT FS_D0Q0
+    CSPAD_FRONT FS_D0Q0S0
+    CSPAD_FRONT FS_D0Q0S0A0
+    CSPAD_FRONT FS_D0Q0S0A1
+    CSPAD_FRONT FS_D0Q0S1
+    CSPAD_FRONT FS_D0Q0S1A0
+    CSPAD_FRONT FS_D0Q0S1A1
+    CSPAD_FRONT FS_D0Q0S2
+    CSPAD_FRONT FS_D0Q0S2A0
+    CSPAD_FRONT FS_D0Q0S2A1
+    CSPAD_FRONT FS_D0Q0S3
+    CSPAD_FRONT FS_D0Q0S3A0
+    CSPAD_FRONT FS_D0Q0S3A1
+    CSPAD_FRONT FS_D0Q0S4
+    CSPAD_FRONT FS_D0Q0S4A0
+    CSPAD_FRONT FS_D0Q0S4A1
+    CSPAD_FRONT FS_D0Q0S5
+    CSPAD_FRONT FS_D0Q0S5A0
+    CSPAD_FRONT FS_D0Q0S5A1
+    CSPAD_FRONT FS_D0Q0S6
+    CSPAD_FRONT FS_D0Q0S6A0
+    CSPAD_FRONT FS_D0Q0S6A1
+    CSPAD_FRONT FS_D0Q0S7
+    CSPAD_FRONT FS_D0Q0S7A0
+    CSPAD_FRONT FS_D0Q0S7A1
+    CSPAD_FRONT FS_D0Q1
+    CSPAD_FRONT FS_D0Q1S0
+    CSPAD_FRONT FS_D0Q1S0A0
+    CSPAD_FRONT FS_D0Q1S0A1
+    CSPAD_FRONT FS_D0Q1S1
+    CSPAD_FRONT FS_D0Q1S1A0
+    CSPAD_FRONT FS_D0Q1S1A1
+    CSPAD_FRONT FS_D0Q1S2
+    CSPAD_FRONT FS_D0Q1S2A0
+    CSPAD_FRONT FS_D0Q1S2A1
+    CSPAD_FRONT FS_D0Q1S3
+    CSPAD_FRONT FS_D0Q1S3A0
+    CSPAD_FRONT FS_D0Q1S3A1
+    CSPAD_FRONT FS_D0Q1S4
+    CSPAD_FRONT FS_D0Q1S4A0
+    CSPAD_FRONT FS_D0Q1S4A1
+    CSPAD_FRONT FS_D0Q1S5
+    CSPAD_FRONT FS_D0Q1S5A0
+    CSPAD_FRONT FS_D0Q1S5A1
+    CSPAD_FRONT FS_D0Q1S6
+    CSPAD_FRONT FS_D0Q1S6A0
+    CSPAD_FRONT FS_D0Q1S6A1
+    CSPAD_FRONT FS_D0Q1S7
+    CSPAD_FRONT FS_D0Q1S7A0
+    CSPAD_FRONT FS_D0Q1S7A1
+    CSPAD_FRONT FS_D0Q2
+    CSPAD_FRONT FS_D0Q2S0
+    CSPAD_FRONT FS_D0Q2S0A0
+    CSPAD_FRONT FS_D0Q2S0A1
+    CSPAD_FRONT FS_D0Q2S1
+    CSPAD_FRONT FS_D0Q2S1A0
+    CSPAD_FRONT FS_D0Q2S1A1
+    CSPAD_FRONT FS_D0Q2S2
+    CSPAD_FRONT FS_D0Q2S2A0
+    CSPAD_FRONT FS_D0Q2S2A1
+    CSPAD_FRONT FS_D0Q2S3
+    CSPAD_FRONT FS_D0Q2S3A0
+    CSPAD_FRONT FS_D0Q2S3A1
+    CSPAD_FRONT FS_D0Q2S4
+    CSPAD_FRONT FS_D0Q2S4A0
+    CSPAD_FRONT FS_D0Q2S4A1
+    CSPAD_FRONT FS_D0Q2S5
+    CSPAD_FRONT FS_D0Q2S5A0
+    CSPAD_FRONT FS_D0Q2S5A1
+    CSPAD_FRONT FS_D0Q2S6
+    CSPAD_FRONT FS_D0Q2S6A0
+    CSPAD_FRONT FS_D0Q2S6A1
+    CSPAD_FRONT FS_D0Q2S7
+    CSPAD_FRONT FS_D0Q2S7A0
+    CSPAD_FRONT FS_D0Q2S7A1
+    CSPAD_FRONT FS_D0Q3
+    CSPAD_FRONT FS_D0Q3S0
+    CSPAD_FRONT FS_D0Q3S0A0
+    CSPAD_FRONT FS_D0Q3S0A1
+    CSPAD_FRONT FS_D0Q3S1
+    CSPAD_FRONT FS_D0Q3S1A0
+    CSPAD_FRONT FS_D0Q3S1A1
+    CSPAD_FRONT FS_D0Q3S2
+    CSPAD_FRONT FS_D0Q3S2A0
+    CSPAD_FRONT FS_D0Q3S2A1
+    CSPAD_FRONT FS_D0Q3S3
+    CSPAD_FRONT FS_D0Q3S3A0
+    CSPAD_FRONT FS_D0Q3S3A1
+    CSPAD_FRONT FS_D0Q3S4
+    CSPAD_FRONT FS_D0Q3S4A0
+    CSPAD_FRONT FS_D0Q3S4A1
+    CSPAD_FRONT FS_D0Q3S5
+    CSPAD_FRONT FS_D0Q3S5A0
+    CSPAD_FRONT FS_D0Q3S5A1
+    CSPAD_FRONT FS_D0Q3S6
+    CSPAD_FRONT FS_D0Q3S6A0
+    CSPAD_FRONT FS_D0Q3S6A1
+    CSPAD_FRONT FS_D0Q3S7
+    CSPAD_FRONT FS_D0Q3S7A0
+    CSPAD_FRONT FS_D0Q3S7A1
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.equipment_component
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source . 0 0 1 . . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . . .
+    AXIS_D0_Z translation detector . 0 0 1 . . . detector_arm . .
+    AXIS_D0_Y translation detector AXIS_D0_Z 0 1 0 . . . detector_arm . .
+    AXIS_D0_X translation detector AXIS_D0_Y 1 0 0 . . . detector_arm . .
+    AXIS_D0_R rotation detector AXIS_D0_X 0 0 1 0.0 0.0 0.0 detector_arm . .
+    FS_D0Q0 rotation detector AXIS_D0_R 0 0 1 -49.860765625 41.643353125 0.0 detector_quadrant . .
+    FS_D0Q0S0 rotation detector FS_D0Q0 0.0 0.0 1.0 11.3696 -23.189925 0.0 detector_sensor . .
+    FS_D0Q0S0A0 rotation detector FS_D0Q0S0 0 0 1 -10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A0_F translation detector FS_D0Q0S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A0_S translation detector AXIS_D0Q0S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S0A1 rotation detector FS_D0Q0S0 0 0 1 10.835 0.0 0.0 detector_asic 89.66181 FS_D0Q0S0
+    AXIS_D0Q0S0A1_F translation detector FS_D0Q0S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S0A1_S translation detector AXIS_D0Q0S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1 rotation detector FS_D0Q0 0.0 0.0 1.0 34.815 -23.309825 0.0 detector_sensor . .
+    FS_D0Q0S1A0 rotation detector FS_D0Q0S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A0_F translation detector FS_D0Q0S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A0_S translation detector AXIS_D0Q0S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S1A1 rotation detector FS_D0Q0S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00132 FS_D0Q0S1
+    AXIS_D0Q0S1A1_F translation detector FS_D0Q0S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S1A1_S translation detector AXIS_D0Q0S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2 rotation detector FS_D0Q0 -0.0 -0.0 -1.0 -23.5389 -10.921625 0.0 detector_sensor . .
+    FS_D0Q0S2A0 rotation detector FS_D0Q0S2 0 0 1 -10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A0_F translation detector FS_D0Q0S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A0_S translation detector AXIS_D0Q0S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S2A1 rotation detector FS_D0Q0S2 0 0 1 10.835 0.0 0.0 detector_asic 359.68548 FS_D0Q0S2
+    AXIS_D0Q0S2A1_F translation detector FS_D0Q0S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S2A1_S translation detector AXIS_D0Q0S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3 rotation detector FS_D0Q0 0.0 0.0 1.0 -23.5499 -34.181125 0.0 detector_sensor . .
+    FS_D0Q0S3A0 rotation detector FS_D0Q0S3 0 0 1 -10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A0_F translation detector FS_D0Q0S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A0_S translation detector AXIS_D0Q0S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S3A1 rotation detector FS_D0Q0S3 0 0 1 10.835 0.0 0.0 detector_asic 359.96513 FS_D0Q0S3
+    AXIS_D0Q0S3A1_F translation detector FS_D0Q0S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S3A1_S translation detector AXIS_D0Q0S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4 rotation detector FS_D0Q0 0.0 0.0 1.0 -11.2651 24.282775 0.0 detector_sensor . .
+    FS_D0Q0S4A0 rotation detector FS_D0Q0S4 0 0 1 -10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A0_F translation detector FS_D0Q0S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A0_S translation detector AXIS_D0Q0S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S4A1 rotation detector FS_D0Q0S4 0 0 1 10.835 0.0 0.0 detector_asic 270.14738 FS_D0Q0S4
+    AXIS_D0Q0S4A1_F translation detector FS_D0Q0S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S4A1_S translation detector AXIS_D0Q0S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5 rotation detector FS_D0Q0 0.0 0.0 1.0 -34.7336 24.169475 0.0 detector_sensor . .
+    FS_D0Q0S5A0 rotation detector FS_D0Q0S5 0 0 1 -10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A0_F translation detector FS_D0Q0S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A0_S translation detector AXIS_D0Q0S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S5A1 rotation detector FS_D0Q0S5 0 0 1 10.835 0.0 0.0 detector_asic 270.07896 FS_D0Q0S5
+    AXIS_D0Q0S5A1_F translation detector FS_D0Q0S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S5A1_S translation detector AXIS_D0Q0S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6 rotation detector FS_D0Q0 0.0 0.0 1.0 23.5488 33.320375 0.0 detector_sensor . .
+    FS_D0Q0S6A0 rotation detector FS_D0Q0S6 0 0 1 -10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A0_F translation detector FS_D0Q0S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A0_S translation detector AXIS_D0Q0S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S6A1 rotation detector FS_D0Q0S6 0 0 1 10.835 0.0 0.0 detector_asic 359.78222 FS_D0Q0S6
+    AXIS_D0Q0S6A1_F translation detector FS_D0Q0S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S6A1_S translation detector AXIS_D0Q0S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7 rotation detector FS_D0Q0 0.0 0.0 1.0 23.3541 9.829875 0.0 detector_sensor . .
+    FS_D0Q0S7A0 rotation detector FS_D0Q0S7 0 0 1 -10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A0_F translation detector FS_D0Q0S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A0_S translation detector AXIS_D0Q0S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q0S7A1 rotation detector FS_D0Q0S7 0 0 1 10.835 0.0 0.0 detector_asic 359.89604 FS_D0Q0S7
+    AXIS_D0Q0S7A1_F translation detector FS_D0Q0S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q0S7A1_S translation detector AXIS_D0Q0S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1 rotation detector AXIS_D0_R 0 0 1 41.512521875 50.149653125 0.0 detector_quadrant . .
+    FS_D0Q1S0 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.1589875 -11.451825 0.0 detector_sensor . .
+    FS_D0Q1S0A0 rotation detector FS_D0Q1S0 0 0 1 -10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A0_F translation detector FS_D0Q1S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A0_S translation detector AXIS_D0Q1S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S0A1 rotation detector FS_D0Q1S0 0 0 1 10.835 0.0 0.0 detector_asic 0.27238 FS_D0Q1S0
+    AXIS_D0Q1S0A1_F translation detector FS_D0Q1S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S0A1_S translation detector AXIS_D0Q1S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1 rotation detector FS_D0Q1 -0.0 -0.0 -1.0 -23.2073875 -34.782825 0.0 detector_sensor . .
+    FS_D0Q1S1A0 rotation detector FS_D0Q1S1 0 0 1 -10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A0_F translation detector FS_D0Q1S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A0_S translation detector AXIS_D0Q1S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S1A1 rotation detector FS_D0Q1S1 0 0 1 10.835 0.0 0.0 detector_asic 0.00525999986641 FS_D0Q1S1
+    AXIS_D0Q1S1A1_F translation detector FS_D0Q1S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S1A1_S translation detector AXIS_D0Q1S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2 rotation detector FS_D0Q1 0.0 0.0 1.0 -10.7311875 23.286175 0.0 detector_sensor . .
+    FS_D0Q1S2A0 rotation detector FS_D0Q1S2 0 0 1 -10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A0_F translation detector FS_D0Q1S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A0_S translation detector AXIS_D0Q1S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S2A1 rotation detector FS_D0Q1S2 0 0 1 10.835 0.0 0.0 detector_asic 270.02545 FS_D0Q1S2
+    AXIS_D0Q1S2A1_F translation detector FS_D0Q1S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S2A1_S translation detector AXIS_D0Q1S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3 rotation detector FS_D0Q1 0.0 0.0 1.0 -34.1402875 23.344475 0.0 detector_sensor . .
+    FS_D0Q1S3A0 rotation detector FS_D0Q1S3 0 0 1 -10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A0_F translation detector FS_D0Q1S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A0_S translation detector AXIS_D0Q1S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S3A1 rotation detector FS_D0Q1S3 0 0 1 10.835 0.0 0.0 detector_asic 270.03066 FS_D0Q1S3
+    AXIS_D0Q1S3A1_F translation detector FS_D0Q1S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S3A1_S translation detector AXIS_D0Q1S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 11.407275 0.0 detector_sensor . .
+    FS_D0Q1S4A0 rotation detector FS_D0Q1S4 0 0 1 -10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A0_F translation detector FS_D0Q1S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A0_S translation detector AXIS_D0Q1S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S4A1 rotation detector FS_D0Q1S4 0 0 1 10.835 0.0 0.0 detector_asic 179.96381 FS_D0Q1S4
+    AXIS_D0Q1S4A1_F translation detector FS_D0Q1S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S4A1_S translation detector AXIS_D0Q1S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5 rotation detector FS_D0Q1 0.0 0.0 1.0 24.0035125 34.876875 0.0 detector_sensor . .
+    FS_D0Q1S5A0 rotation detector FS_D0Q1S5 0 0 1 -10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A0_F translation detector FS_D0Q1S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A0_S translation detector AXIS_D0Q1S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S5A1 rotation detector FS_D0Q1S5 0 0 1 10.835 0.0 0.0 detector_asic 180.02434 FS_D0Q1S5
+    AXIS_D0Q1S5A1_F translation detector FS_D0Q1S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S5A1_S translation detector AXIS_D0Q1S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6 rotation detector FS_D0Q1 0.0 0.0 1.0 33.2523125 -23.321925 0.0 detector_sensor . .
+    FS_D0Q1S6A0 rotation detector FS_D0Q1S6 0 0 1 -10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A0_F translation detector FS_D0Q1S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A0_S translation detector AXIS_D0Q1S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S6A1 rotation detector FS_D0Q1S6 0 0 1 10.835 0.0 0.0 detector_asic 270.08027 FS_D0Q1S6
+    AXIS_D0Q1S6A1_F translation detector FS_D0Q1S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S6A1_S translation detector AXIS_D0Q1S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7 rotation detector FS_D0Q1 0.0 0.0 1.0 9.9785125 -23.358225 0.0 detector_sensor . .
+    FS_D0Q1S7A0 rotation detector FS_D0Q1S7 0 0 1 -10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A0_F translation detector FS_D0Q1S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A0_S translation detector AXIS_D0Q1S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q1S7A1 rotation detector FS_D0Q1S7 0 0 1 10.835 0.0 0.0 detector_asic 270.15067 FS_D0Q1S7
+    AXIS_D0Q1S7A1_F translation detector FS_D0Q1S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q1S7A1_S translation detector AXIS_D0Q1S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2 rotation detector AXIS_D0_R 0 0 1 49.596146875 -41.351371875 0.0 detector_quadrant . .
+    FS_D0Q2S0 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -11.3150125 23.1242 0.0 detector_sensor . .
+    FS_D0Q2S0A0 rotation detector FS_D0Q2S0 0 0 1 -10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A0_F translation detector FS_D0Q2S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A0_S translation detector AXIS_D0Q2S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S0A1 rotation detector FS_D0Q2S0 0 0 1 10.835 0.0 0.0 detector_asic 90.04803 FS_D0Q2S0
+    AXIS_D0Q2S0A1_F translation detector FS_D0Q2S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S0A1_S translation detector AXIS_D0Q2S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1 rotation detector FS_D0Q2 -0.0 -0.0 -1.0 -34.6999125 23.155 0.0 detector_sensor . .
+    FS_D0Q2S1A0 rotation detector FS_D0Q2S1 0 0 1 -10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A0_F translation detector FS_D0Q2S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A0_S translation detector AXIS_D0Q2S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S1A1 rotation detector FS_D0Q2S1 0 0 1 10.835 0.0 0.0 detector_asic 90.00592 FS_D0Q2S1
+    AXIS_D0Q2S1A1_F translation detector FS_D0Q2S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S1A1_S translation detector AXIS_D0Q2S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2 rotation detector FS_D0Q2 0.0 0.0 1.0 23.4746875 10.7811 0.0 detector_sensor . .
+    FS_D0Q2S2A0 rotation detector FS_D0Q2S2 0 0 1 -10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A0_F translation detector FS_D0Q2S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A0_S translation detector AXIS_D0Q2S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S2A1 rotation detector FS_D0Q2S2 0 0 1 10.835 0.0 0.0 detector_asic 180.11318 FS_D0Q2S2
+    AXIS_D0Q2S2A1_F translation detector FS_D0Q2S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S2A1_S translation detector AXIS_D0Q2S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3 rotation detector FS_D0Q2 0.0 0.0 1.0 23.6220875 34.2221 0.0 detector_sensor . .
+    FS_D0Q2S3A0 rotation detector FS_D0Q2S3 0 0 1 -10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A0_F translation detector FS_D0Q2S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A0_S translation detector AXIS_D0Q2S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S3A1 rotation detector FS_D0Q2S3 0 0 1 10.835 0.0 0.0 detector_asic 179.92104 FS_D0Q2S3
+    AXIS_D0Q2S3A1_F translation detector FS_D0Q2S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S3A1_S translation detector AXIS_D0Q2S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4 rotation detector FS_D0Q2 0.0 0.0 1.0 11.1953875 -23.9954 0.0 detector_sensor . .
+    FS_D0Q2S4A0 rotation detector FS_D0Q2S4 0 0 1 -10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A0_F translation detector FS_D0Q2S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A0_S translation detector AXIS_D0Q2S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S4A1 rotation detector FS_D0Q2S4 0 0 1 10.835 0.0 0.0 detector_asic 89.63875 FS_D0Q2S4
+    AXIS_D0Q2S4A1_F translation detector FS_D0Q2S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S4A1_S translation detector AXIS_D0Q2S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5 rotation detector FS_D0Q2 0.0 0.0 1.0 34.5494875 -24.1901 0.0 detector_sensor . .
+    FS_D0Q2S5A0 rotation detector FS_D0Q2S5 0 0 1 -10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A0_F translation detector FS_D0Q2S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A0_S translation detector AXIS_D0Q2S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S5A1 rotation detector FS_D0Q2S5 0 0 1 10.835 0.0 0.0 detector_asic 89.68154 FS_D0Q2S5
+    AXIS_D0Q2S5A1_F translation detector FS_D0Q2S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S5A1_S translation detector AXIS_D0Q2S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.4854125 -33.2552 0.0 detector_sensor . .
+    FS_D0Q2S6A0 rotation detector FS_D0Q2S6 0 0 1 -10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A0_F translation detector FS_D0Q2S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A0_S translation detector AXIS_D0Q2S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S6A1 rotation detector FS_D0Q2S6 0 0 1 10.835 0.0 0.0 detector_asic 179.83473 FS_D0Q2S6
+    AXIS_D0Q2S6A1_F translation detector FS_D0Q2S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S6A1_S translation detector AXIS_D0Q2S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7 rotation detector FS_D0Q2 0.0 0.0 1.0 -23.3413125 -9.8417 0.0 detector_sensor . .
+    FS_D0Q2S7A0 rotation detector FS_D0Q2S7 0 0 1 -10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A0_F translation detector FS_D0Q2S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A0_S translation detector AXIS_D0Q2S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q2S7A1 rotation detector FS_D0Q2S7 0 0 1 10.835 0.0 0.0 detector_asic 180.092 FS_D0Q2S7
+    AXIS_D0Q2S7A1_F translation detector FS_D0Q2S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q2S7A1_S translation detector AXIS_D0Q2S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3 rotation detector AXIS_D0_R 0 0 1 -41.247903125 -50.441634375 0.0 detector_quadrant . .
+    FS_D0Q3S0 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1056375 11.6367625 0.0 detector_sensor . .
+    FS_D0Q3S0A0 rotation detector FS_D0Q3S0 0 0 1 -10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A0_F translation detector FS_D0Q3S0A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A0_S translation detector AXIS_D0Q3S0A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S0A1 rotation detector FS_D0Q3S0 0 0 1 10.835 0.0 0.0 detector_asic 180.12436 FS_D0Q3S0
+    AXIS_D0Q3S0A1_F translation detector FS_D0Q3S0A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S0A1_S translation detector AXIS_D0Q3S0A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1 rotation detector FS_D0Q3 0.0 0.0 1.0 23.1298375 34.9864625 0.0 detector_sensor . .
+    FS_D0Q3S1A0 rotation detector FS_D0Q3S1 0 0 1 -10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A0_F translation detector FS_D0Q3S1A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A0_S translation detector AXIS_D0Q3S1A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S1A1 rotation detector FS_D0Q3S1 0 0 1 10.835 0.0 0.0 detector_asic 180.00263 FS_D0Q3S1
+    AXIS_D0Q3S1A1_F translation detector FS_D0Q3S1A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S1A1_S translation detector AXIS_D0Q3S1A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 10.9572375 -23.5830375 0.0 detector_sensor . .
+    FS_D0Q3S2A0 rotation detector FS_D0Q3S2 0 0 1 -10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A0_F translation detector FS_D0Q3S2A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A0_S translation detector AXIS_D0Q3S2A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S2A1 rotation detector FS_D0Q3S2 0 0 1 10.835 0.0 0.0 detector_asic 269.55191 FS_D0Q3S2
+    AXIS_D0Q3S2A1_F translation detector FS_D0Q3S2A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S2A1_S translation detector AXIS_D0Q3S2A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 34.4180375 -23.4818375 0.0 detector_sensor . .
+    FS_D0Q3S3A0 rotation detector FS_D0Q3S3 0 0 1 -10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A0_F translation detector FS_D0Q3S3A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A0_S translation detector AXIS_D0Q3S3A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S3A1 rotation detector FS_D0Q3S3 0 0 1 10.835 0.0 0.0 detector_asic 269.74206 FS_D0Q3S3
+    AXIS_D0Q3S3A1_F translation detector FS_D0Q3S3A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S3A1_S translation detector AXIS_D0Q3S3A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1283625 -11.5336375 0.0 detector_sensor . .
+    FS_D0Q3S4A0 rotation detector FS_D0Q3S4 0 0 1 -10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A0_F translation detector FS_D0Q3S4A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A0_S translation detector AXIS_D0Q3S4A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S4A1 rotation detector FS_D0Q3S4 0 0 1 10.835 0.0 0.0 detector_asic 359.81971 FS_D0Q3S4
+    AXIS_D0Q3S4A1_F translation detector FS_D0Q3S4A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S4A1_S translation detector AXIS_D0Q3S4A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5 rotation detector FS_D0Q3 0.0 0.0 1.0 -24.1701625 -34.9548375 0.0 detector_sensor . .
+    FS_D0Q3S5A0 rotation detector FS_D0Q3S5 0 0 1 -10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A0_F translation detector FS_D0Q3S5A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A0_S translation detector AXIS_D0Q3S5A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S5A1 rotation detector FS_D0Q3S5 0 0 1 10.835 0.0 0.0 detector_asic 359.99883 FS_D0Q3S5
+    AXIS_D0Q3S5A1_F translation detector FS_D0Q3S5A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S5A1_S translation detector AXIS_D0Q3S5A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -33.3089625 23.4474625 0.0 detector_sensor . .
+    FS_D0Q3S6A0 rotation detector FS_D0Q3S6 0 0 1 -10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A0_F translation detector FS_D0Q3S6A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A0_S translation detector AXIS_D0Q3S6A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S6A1 rotation detector FS_D0Q3S6 0 0 1 10.835 0.0 0.0 detector_asic 269.67299 FS_D0Q3S6
+    AXIS_D0Q3S6A1_F translation detector FS_D0Q3S6A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S6A1_S translation detector AXIS_D0Q3S6A1_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7 rotation detector FS_D0Q3 -0.0 -0.0 -1.0 -10.0032625 23.4826625 0.0 detector_sensor . .
+    FS_D0Q3S7A0 rotation detector FS_D0Q3S7 0 0 1 -10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A0_F translation detector FS_D0Q3S7A0 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A0_S translation detector AXIS_D0Q3S7A0_F 0 -1 0 0 0 0.0 detector_asic . .
+    FS_D0Q3S7A1 rotation detector FS_D0Q3S7 0 0 1 10.835 0.0 0.0 detector_asic 269.67561 FS_D0Q3S7
+    AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
+    AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
+;
+;
+       Example 5.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+;
+;
+
+     loop_
+    _diffrn_detector_axis.detector_id
+    _diffrn_detector_axis.axis_id
+    CSPAD_FRONT AXIS_DETECTOR_X
+    CSPAD_FRONT AXIS_DETECTOR_Y
+    CSPAD_FRONT AXIS_DETECTOR_Z
+    CSPAD_FRONT AXIS_DETECTOR_PITCH
+
+     loop_
+    _diffrn_detector_element.id
+    _diffrn_detector_element.detector_id
+    ELE_D0Q0S0A0 CSPAD_FRONT
+    ELE_D0Q0S0A1 CSPAD_FRONT
+    ELE_D0Q0S1A0 CSPAD_FRONT
+    ELE_D0Q0S1A1 CSPAD_FRONT
+    ELE_D0Q0S2A0 CSPAD_FRONT
+    ELE_D0Q0S2A1 CSPAD_FRONT
+    ELE_D0Q0S3A0 CSPAD_FRONT
+    ELE_D0Q0S3A1 CSPAD_FRONT
+    ELE_D0Q0S4A0 CSPAD_FRONT
+    ELE_D0Q0S4A1 CSPAD_FRONT
+    ELE_D0Q0S5A0 CSPAD_FRONT
+    ELE_D0Q0S5A1 CSPAD_FRONT
+    ELE_D0Q0S6A0 CSPAD_FRONT
+    ELE_D0Q0S6A1 CSPAD_FRONT
+    ELE_D0Q0S7A0 CSPAD_FRONT
+    ELE_D0Q0S7A1 CSPAD_FRONT
+    ELE_D0Q1S0A0 CSPAD_FRONT
+    ELE_D0Q1S0A1 CSPAD_FRONT
+    ELE_D0Q1S1A0 CSPAD_FRONT
+    ELE_D0Q1S1A1 CSPAD_FRONT
+    ELE_D0Q1S2A0 CSPAD_FRONT
+    ELE_D0Q1S2A1 CSPAD_FRONT
+    ELE_D0Q1S3A0 CSPAD_FRONT
+    ELE_D0Q1S3A1 CSPAD_FRONT
+    ELE_D0Q1S4A0 CSPAD_FRONT
+    ELE_D0Q1S4A1 CSPAD_FRONT
+    ELE_D0Q1S5A0 CSPAD_FRONT
+    ELE_D0Q1S5A1 CSPAD_FRONT
+    ELE_D0Q1S6A0 CSPAD_FRONT
+    ELE_D0Q1S6A1 CSPAD_FRONT
+    ELE_D0Q1S7A0 CSPAD_FRONT
+    ELE_D0Q1S7A1 CSPAD_FRONT
+    ELE_D0Q2S0A0 CSPAD_FRONT
+    ELE_D0Q2S0A1 CSPAD_FRONT
+    ELE_D0Q2S1A0 CSPAD_FRONT
+    ELE_D0Q2S1A1 CSPAD_FRONT
+    ELE_D0Q2S2A0 CSPAD_FRONT
+    ELE_D0Q2S2A1 CSPAD_FRONT
+    ELE_D0Q2S3A0 CSPAD_FRONT
+    ELE_D0Q2S3A1 CSPAD_FRONT
+    ELE_D0Q2S4A0 CSPAD_FRONT
+    ELE_D0Q2S4A1 CSPAD_FRONT
+    ELE_D0Q2S5A0 CSPAD_FRONT
+    ELE_D0Q2S5A1 CSPAD_FRONT
+    ELE_D0Q2S6A0 CSPAD_FRONT
+    ELE_D0Q2S6A1 CSPAD_FRONT
+    ELE_D0Q2S7A0 CSPAD_FRONT
+    ELE_D0Q2S7A1 CSPAD_FRONT
+    ELE_D0Q3S0A0 CSPAD_FRONT
+    ELE_D0Q3S0A1 CSPAD_FRONT
+    ELE_D0Q3S1A0 CSPAD_FRONT
+    ELE_D0Q3S1A1 CSPAD_FRONT
+    ELE_D0Q3S2A0 CSPAD_FRONT
+    ELE_D0Q3S2A1 CSPAD_FRONT
+    ELE_D0Q3S3A0 CSPAD_FRONT
+    ELE_D0Q3S3A1 CSPAD_FRONT
+    ELE_D0Q3S4A0 CSPAD_FRONT
+    ELE_D0Q3S4A1 CSPAD_FRONT
+    ELE_D0Q3S5A0 CSPAD_FRONT
+    ELE_D0Q3S5A1 CSPAD_FRONT
+    ELE_D0Q3S6A0 CSPAD_FRONT
+    ELE_D0Q3S6A1 CSPAD_FRONT
+    ELE_D0Q3S7A0 CSPAD_FRONT
+    ELE_D0Q3S7A1 CSPAD_FRONT
+     loop_
+    _axis.id
+    _axis.type
+    _axis.equipment
+    _axis.depends_on
+    _axis.vector[1]
+    _axis.vector[2]
+    _axis.vector[3]
+    _axis.offset[1]
+    _axis.offset[2]
+    _axis.offset[3]
+    _axis.rotation
+    _axis.rotation_axis
+    AXIS_SOURCE general source   . 0 0 1 . . . . .
+    AXIS_GRAVITY general gravity . 0 -1 0 . . . . .
+    AXIS_DETECTOR_Z translation detector
+                                 . 0 0 1 0 0 0 . .
+    AXIS_DETECTOR_Y translation detector
+                   AXIS_DETECTOR_Z 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_X translation detector
+                   AXIS_DETECTOR_Y 1 0 0 0 0 0 . .
+    AXIS_DETECTOR_PITCH rotation detector
+                   AXIS_DETECTOR_X 0 1 0 0 0 0 . .
+    AXIS_DETECTOR_ROT rotation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 0 . .
+    AXIS_D0_ORIGIN translation detector
+               AXIS_DETECTOR_PITCH 0 0 1 0 0 171.0104 . .
+    AXIS_D0_ROT rotation detector
+                    AXIS_D0_ORIGIN 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0 translation detector
+                    AXIS_D0_ORIGIN . . . 0.0 0.0 0.0 0.0 AXIS_D0_ROT
+    AXIS_D0Q0_ROT rotation detector
+                           AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0 translation detector
+                           AXIS_D0 . . . -49.860765625 41.643353125 0.0
+                                      0.0 AXIS_D0Q0_ROT
+    AXIS_D0Q0S0_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S0 translation detector
+                          AXIS_D0Q0 . . . 11.3696 -23.189925 0.0
+                                      89.66181 AXIS_D0Q0S0_ROT
+    AXIS_D0Q0S0A0_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A0 translation detector
+                        AXIS_D0Q0S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S0A0_ROT
+    AXIS_D0Q0S0A0_F translation detector
+                      AXIS_D0Q0S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A0_S translation detector
+                      AXIS_D0Q0S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S0A1_ROT rotation detector
+                        AXIS_D0Q0S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S0A1 translation detector
+                        AXIS_D0Q0S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S0A1_ROT
+    AXIS_D0Q0S0A1_F translation detector
+                      AXIS_D0Q0S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S0A1_S translation detector
+                      AXIS_D0Q0S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1_ROT rotation detector
+                          AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S1 translation detector
+                          AXIS_D0Q0 . . . 34.815 -23.309825 0.0
+                                      90.00132 AXIS_D0Q0S1_ROT
+    AXIS_D0Q0S1A0_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A0 translation detector
+                        AXIS_D0Q0S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S1A0_ROT
+    AXIS_D0Q0S1A0_F translation detector
+                      AXIS_D0Q0S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A0_S translation detector
+                      AXIS_D0Q0S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S1A1_ROT rotation detector
+                        AXIS_D0Q0S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S1A1 translation detector
+                        AXIS_D0Q0S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S1A1_ROT
+    AXIS_D0Q0S1A1_F translation detector
+                      AXIS_D0Q0S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S1A1_S translation detector
+                      AXIS_D0Q0S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2_ROT rotation detector
+                          AXIS_D0Q0 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q0S2 translation detector
+                          AXIS_D0Q0 . . . -23.5389 -10.921625 0.0
+                                     359.68548 AXIS_D0Q0S2_ROT
+    AXIS_D0Q0S2A0_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A0 translation detector
+                        AXIS_D0Q0S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S2A0_ROT
+    AXIS_D0Q0S2A0_F translation detector
+                        AXIS_D0Q0S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A0_S translation detector
+                        AXIS_D0Q0S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S2A1_ROT rotation detector
+                        AXIS_D0Q0S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S2A1 translation detector
+                        AXIS_D0Q0S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S2A1_ROT
+    AXIS_D0Q0S2A1_F translation detector
+                        AXIS_D0Q0S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S2A1_S translation detector
+                        AXIS_D0Q0S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S3 translation detector
+                        AXIS_D0Q0 . . . -23.5499 -34.181125 0.0
+                                   359.96513 AXIS_D0Q0S3_ROT
+    AXIS_D0Q0S3A0_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A0 translation detector
+                        AXIS_D0Q0S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S3A0_ROT
+    AXIS_D0Q0S3A0_F translation detector
+                        AXIS_D0Q0S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A0_S translation detector
+                        AXIS_D0Q0S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S3A1_ROT rotation detector
+                        AXIS_D0Q0S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S3A1 translation detector
+                        AXIS_D0Q0S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S3A1_ROT
+    AXIS_D0Q0S3A1_F translation detector
+                        AXIS_D0Q0S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S3A1_S translation detector
+                        AXIS_D0Q0S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S4 translation detector
+                        AXIS_D0Q0 . . . -11.2651 24.282775 0.0
+                                   270.14738 AXIS_D0Q0S4_ROT
+    AXIS_D0Q0S4A0_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A0 translation detector
+                        AXIS_D0Q0S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S4A0_ROT
+    AXIS_D0Q0S4A0_F translation detector
+                        AXIS_D0Q0S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A0_S translation detector
+                        AXIS_D0Q0S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S4A1_ROT rotation detector
+                        AXIS_D0Q0S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S4A1 translation detector
+                        AXIS_D0Q0S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S4A1_ROT
+    AXIS_D0Q0S4A1_F translation detector
+                        AXIS_D0Q0S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S4A1_S translation detector
+                        AXIS_D0Q0S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S5 translation detector
+                        AXIS_D0Q0 . . . -34.7336 24.169475 0.0
+                                   270.07896 AXIS_D0Q0S5_ROT
+    AXIS_D0Q0S5A0_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A0 translation detector
+                        AXIS_D0Q0S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S5A0_ROT
+    AXIS_D0Q0S5A0_F translation detector
+                        AXIS_D0Q0S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A0_S translation detector
+                        AXIS_D0Q0S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S5A1_ROT rotation detector
+                        AXIS_D0Q0S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S5A1 translation detector
+                        AXIS_D0Q0S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S5A1_ROT
+    AXIS_D0Q0S5A1_F translation detector
+                        AXIS_D0Q0S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S5A1_S translation detector
+                        AXIS_D0Q0S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S6 translation detector
+                        AXIS_D0Q0 . . . 23.5488 33.320375 0.0
+                                   359.78222 AXIS_D0Q0S6_ROT
+    AXIS_D0Q0S6A0_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A0 translation detector
+                        AXIS_D0Q0S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S6A0_ROT
+    AXIS_D0Q0S6A0_F translation detector
+                        AXIS_D0Q0S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A0_S translation detector
+                        AXIS_D0Q0S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S6A1_ROT rotation detector
+                        AXIS_D0Q0S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S6A1 translation detector
+                        AXIS_D0Q0S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S6A1_ROT
+    AXIS_D0Q0S6A1_F translation detector
+                        AXIS_D0Q0S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S6A1_S translation detector
+                        AXIS_D0Q0S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7_ROT rotation detector
+                        AXIS_D0Q0 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q0S7 translation detector
+                        AXIS_D0Q0 . . . 23.3541 9.829875 0.0
+                                   359.89604 AXIS_D0Q0S7_ROT
+    AXIS_D0Q0S7A0_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A0 translation detector
+                        AXIS_D0Q0S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q0S7A0_ROT
+    AXIS_D0Q0S7A0_F translation detector
+                        AXIS_D0Q0S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A0_S translation detector
+                        AXIS_D0Q0S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q0S7A1_ROT rotation detector
+                        AXIS_D0Q0S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q0S7A1 translation detector
+                        AXIS_D0Q0S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q0S7A1_ROT
+    AXIS_D0Q0S7A1_F translation detector
+                        AXIS_D0Q0S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q0S7A1_S translation detector
+                        AXIS_D0Q0S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1 translation detector
+                        AXIS_D0 . . . 41.512521875 50.149653125 0.0
+                                   0.0 AXIS_D0Q1_ROT
+    AXIS_D0Q1S0_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S0 translation detector
+                        AXIS_D0Q1 . . . -23.1589875 -11.451825 0.0
+                                     0.27238 AXIS_D0Q1S0_ROT
+    AXIS_D0Q1S0A0_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A0 translation detector
+                        AXIS_D0Q1S0 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q1S0A0_ROT
+    AXIS_D0Q1S0A0_F translation detector
+                        AXIS_D0Q1S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A0_S translation detector
+                        AXIS_D0Q1S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S0A1_ROT rotation detector
+                        AXIS_D0Q1S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S0A1 translation detector
+                        AXIS_D0Q1S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S0A1_ROT
+    AXIS_D0Q1S0A1_F translation detector
+                        AXIS_D0Q1S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S0A1_S translation detector
+                        AXIS_D0Q1S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1_ROT rotation detector
+                        AXIS_D0Q1 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q1S1 translation detector
+                        AXIS_D0Q1 . . . -23.2073875 -34.782825 0.0
+                                     0.00525999986641 AXIS_D0Q1S1_ROT
+    AXIS_D0Q1S1A0_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A0 translation detector
+                        AXIS_D0Q1S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S1A0_ROT
+    AXIS_D0Q1S1A0_F translation detector
+                        AXIS_D0Q1S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A0_S translation detector
+                        AXIS_D0Q1S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S1A1_ROT rotation detector
+                        AXIS_D0Q1S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S1A1 translation detector
+                        AXIS_D0Q1S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S1A1_ROT
+    AXIS_D0Q1S1A1_F translation detector
+                        AXIS_D0Q1S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S1A1_S translation detector
+                        AXIS_D0Q1S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S2 translation detector
+                        AXIS_D0Q1 . . . -10.7311875 23.286175 0.0
+                                   270.02545 AXIS_D0Q1S2_ROT
+    AXIS_D0Q1S2A0_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A0 translation detector
+                        AXIS_D0Q1S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S2A0_ROT
+    AXIS_D0Q1S2A0_F translation detector
+                        AXIS_D0Q1S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A0_S translation detector
+                        AXIS_D0Q1S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S2A1_ROT rotation detector
+                        AXIS_D0Q1S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S2A1 translation detector
+                        AXIS_D0Q1S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S2A1_ROT
+    AXIS_D0Q1S2A1_F translation detector
+                        AXIS_D0Q1S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S2A1_S translation detector
+                        AXIS_D0Q1S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S3 translation detector
+                        AXIS_D0Q1 . . . -34.1402875 23.344475 0.0
+                                   270.03066 AXIS_D0Q1S3_ROT
+    AXIS_D0Q1S3A0_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A0 translation detector
+                        AXIS_D0Q1S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S3A0_ROT
+    AXIS_D0Q1S3A0_F translation detector
+                        AXIS_D0Q1S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A0_S translation detector
+                        AXIS_D0Q1S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S3A1_ROT rotation detector
+                        AXIS_D0Q1S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S3A1 translation detector
+                        AXIS_D0Q1S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S3A1_ROT
+    AXIS_D0Q1S3A1_F translation detector
+                        AXIS_D0Q1S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S3A1_S translation detector
+                        AXIS_D0Q1S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S4 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 11.407275 0.0
+                                    179.96381 AXIS_D0Q1S4_ROT
+    AXIS_D0Q1S4A0_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A0 translation detector
+                        AXIS_D0Q1S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S4A0_ROT
+    AXIS_D0Q1S4A0_F translation detector
+                        AXIS_D0Q1S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A0_S translation detector
+                        AXIS_D0Q1S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S4A1_ROT rotation detector
+                        AXIS_D0Q1S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S4A1 translation detector
+                        AXIS_D0Q1S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S4A1_ROT
+    AXIS_D0Q1S4A1_F translation detector
+                        AXIS_D0Q1S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S4A1_S translation detector
+                        AXIS_D0Q1S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S5 translation detector
+                        AXIS_D0Q1 . . . 24.0035125 34.876875 0.0
+                                   180.02434 AXIS_D0Q1S5_ROT
+    AXIS_D0Q1S5A0_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A0 translation detector
+                        AXIS_D0Q1S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S5A0_ROT
+    AXIS_D0Q1S5A0_F translation detector
+                        AXIS_D0Q1S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A0_S translation detector
+                        AXIS_D0Q1S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S5A1_ROT rotation detector
+                        AXIS_D0Q1S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S5A1 translation detector
+                        AXIS_D0Q1S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S5A1_ROT
+    AXIS_D0Q1S5A1_F translation detector
+                        AXIS_D0Q1S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S5A1_S translation detector
+                        AXIS_D0Q1S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S6 translation detector
+                        AXIS_D0Q1 . . . 33.2523125 -23.321925 0.0
+                                   270.08027 AXIS_D0Q1S6_ROT
+    AXIS_D0Q1S6A0_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A0 translation detector
+                        AXIS_D0Q1S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S6A0_ROT
+    AXIS_D0Q1S6A0_F translation detector
+                        AXIS_D0Q1S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A0_S translation detector
+                        AXIS_D0Q1S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S6A1_ROT rotation detector
+                        AXIS_D0Q1S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S6A1 translation detector
+                        AXIS_D0Q1S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S6A1_ROT
+    AXIS_D0Q1S6A1_F translation detector
+                        AXIS_D0Q1S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S6A1_S translation detector
+                        AXIS_D0Q1S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7_ROT rotation detector
+                        AXIS_D0Q1 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q1S7 translation detector
+                        AXIS_D0Q1 . . . 9.9785125 -23.358225 0.0
+                                   270.15067 AXIS_D0Q1S7_ROT
+    AXIS_D0Q1S7A0_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A0 translation detector
+                        AXIS_D0Q1S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q1S7A0_ROT
+    AXIS_D0Q1S7A0_F translation detector
+                        AXIS_D0Q1S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A0_S translation detector
+                        AXIS_D0Q1S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q1S7A1_ROT rotation detector
+                        AXIS_D0Q1S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q1S7A1 translation detector
+                        AXIS_D0Q1S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q1S7A1_ROT
+    AXIS_D0Q1S7A1_F translation detector
+                        AXIS_D0Q1S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q1S7A1_S translation detector
+                        AXIS_D0Q1S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2 translation detector
+                        AXIS_D0 . . . 49.596146875 -41.351371875 0.0
+                                   0.0 AXIS_D0Q2_ROT
+    AXIS_D0Q2S0_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S0 translation detector
+                        AXIS_D0Q2 . . . -11.3150125 23.1242 0.0
+                                    90.04803 AXIS_D0Q2S0_ROT
+    AXIS_D0Q2S0A0_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A0 translation detector
+                        AXIS_D0Q2S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S0A0_ROT
+    AXIS_D0Q2S0A0_F translation detector
+                        AXIS_D0Q2S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A0_S translation detector
+                        AXIS_D0Q2S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S0A1_ROT rotation detector
+                        AXIS_D0Q2S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S0A1 translation detector
+                        AXIS_D0Q2S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S0A1_ROT
+    AXIS_D0Q2S0A1_F translation detector
+                        AXIS_D0Q2S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S0A1_S translation detector
+                        AXIS_D0Q2S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1_ROT rotation detector
+                        AXIS_D0Q2 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q2S1 translation detector
+                        AXIS_D0Q2 . . . -34.6999125 23.155 0.0
+                                    90.00592 AXIS_D0Q2S1_ROT
+    AXIS_D0Q2S1A0_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A0 translation detector
+                        AXIS_D0Q2S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S1A0_ROT
+    AXIS_D0Q2S1A0_F translation detector
+                        AXIS_D0Q2S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A0_S translation detector
+                        AXIS_D0Q2S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S1A1_ROT rotation detector
+                        AXIS_D0Q2S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S1A1 translation detector
+                        AXIS_D0Q2S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S1A1_ROT
+    AXIS_D0Q2S1A1_F translation detector
+                        AXIS_D0Q2S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S1A1_S translation detector
+                        AXIS_D0Q2S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S2 translation detector
+                        AXIS_D0Q2 . . . 23.4746875 10.7811 0.0
+                                    180.11318 AXIS_D0Q2S2_ROT
+    AXIS_D0Q2S2A0_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A0 translation detector
+                        AXIS_D0Q2S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S2A0_ROT
+    AXIS_D0Q2S2A0_F translation detector
+                        AXIS_D0Q2S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A0_S translation detector
+                        AXIS_D0Q2S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S2A1_ROT rotation detector
+                        AXIS_D0Q2S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S2A1 translation detector
+                        AXIS_D0Q2S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S2A1_ROT
+    AXIS_D0Q2S2A1_F translation detector
+                        AXIS_D0Q2S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S2A1_S translation detector
+                        AXIS_D0Q2S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S3 translation detector
+                        AXIS_D0Q2 . . . 23.6220875 34.2221 0.0
+                                   179.92104 AXIS_D0Q2S3_ROT
+    AXIS_D0Q2S3A0_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A0 translation detector
+                        AXIS_D0Q2S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S3A0_ROT
+    AXIS_D0Q2S3A0_F translation detector
+                        AXIS_D0Q2S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A0_S translation detector
+                        AXIS_D0Q2S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S3A1_ROT rotation detector
+                        AXIS_D0Q2S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S3A1 translation detector
+                        AXIS_D0Q2S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S3A1_ROT
+    AXIS_D0Q2S3A1_F translation detector
+                        AXIS_D0Q2S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S3A1_S translation detector
+                        AXIS_D0Q2S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S4 translation detector
+                        AXIS_D0Q2 . . . 11.1953875 -23.9954 0.0
+                                      89.63875 AXIS_D0Q2S4_ROT
+    AXIS_D0Q2S4A0_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A0 translation detector
+                        AXIS_D0Q2S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q2S4A0_ROT
+    AXIS_D0Q2S4A0_F translation detector
+                        AXIS_D0Q2S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A0_S translation detector
+                        AXIS_D0Q2S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S4A1_ROT rotation detector
+                        AXIS_D0Q2S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S4A1 translation detector
+                        AXIS_D0Q2S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S4A1_ROT
+    AXIS_D0Q2S4A1_F translation detector
+                        AXIS_D0Q2S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S4A1_S translation detector
+                        AXIS_D0Q2S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S5 translation detector
+                        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0
+                                    89.68154 AXIS_D0Q2S5_ROT
+    AXIS_D0Q2S5A0_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A0 translation detector
+                        AXIS_D0Q2S5 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A0_ROT
+    AXIS_D0Q2S5A0_F translation detector
+                        AXIS_D0Q2S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A0_S translation detector
+                        AXIS_D0Q2S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S5A1_ROT rotation detector
+                        AXIS_D0Q2S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S5A1 translation detector
+                        AXIS_D0Q2S5 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S5A1_ROT
+    AXIS_D0Q2S5A1_F translation detector
+                        AXIS_D0Q2S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S5A1_S translation detector
+                        AXIS_D0Q2S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S6 translation detector
+                        AXIS_D0Q2 . . . -23.4854125 -33.2552 0.0
+                                   179.83473 AXIS_D0Q2S6_ROT
+    AXIS_D0Q2S6A0_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A0 translation detector
+                        AXIS_D0Q2S6 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A0_ROT
+    AXIS_D0Q2S6A0_F translation detector
+                        AXIS_D0Q2S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A0_S translation detector
+                        AXIS_D0Q2S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S6A1_ROT rotation detector
+                        AXIS_D0Q2S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S6A1 translation detector
+                        AXIS_D0Q2S6 . . . 10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S6A1_ROT
+    AXIS_D0Q2S6A1_F translation detector
+                        AXIS_D0Q2S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S6A1_S translation detector
+                        AXIS_D0Q2S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7_ROT rotation detector
+                        AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q2S7 translation detector
+                        AXIS_D0Q2 . . . -23.3413125 -9.8417 0.0
+                                   180.092 AXIS_D0Q2S7_ROT
+    AXIS_D0Q2S7A0_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A0 translation detector
+                        AXIS_D0Q2S7 . . . -10.835 0.0 0.0
+                                       0.0 AXIS_D0Q2S7A0_ROT
+    AXIS_D0Q2S7A0_F translation detector
+                        AXIS_D0Q2S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A0_S translation detector
+                        AXIS_D0Q2S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q2S7A1_ROT rotation detector
+                        AXIS_D0Q2S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q2S7A1 translation detector
+                        AXIS_D0Q2S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q2S7A1_ROT
+    AXIS_D0Q2S7A1_F translation detector
+                        AXIS_D0Q2S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q2S7A1_S translation detector
+                        AXIS_D0Q2S7A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3_ROT rotation detector
+                        AXIS_D0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3 translation detector
+                        AXIS_D0 . . . -41.247903125 -50.441634375 0.0
+                                   0.0 AXIS_D0Q3_ROT
+    AXIS_D0Q3S0_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S0 translation detector
+                        AXIS_D0Q3 . . . 23.1056375 11.6367625 0.0
+                                   180.12436 AXIS_D0Q3S0_ROT
+    AXIS_D0Q3S0A0_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A0 translation detector
+                        AXIS_D0Q3S0 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S0A0_ROT
+    AXIS_D0Q3S0A0_F translation detector
+                        AXIS_D0Q3S0A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A0_S translation detector
+                        AXIS_D0Q3S0A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S0A1_ROT rotation detector
+                        AXIS_D0Q3S0 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S0A1 translation detector
+                        AXIS_D0Q3S0 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S0A1_ROT
+    AXIS_D0Q3S0A1_F translation detector
+                        AXIS_D0Q3S0A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S0A1_S translation detector
+                        AXIS_D0Q3S0A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S1 translation detector
+                        AXIS_D0Q3 . . . 23.1298375 34.9864625 0.0
+                                   180.00263 AXIS_D0Q3S1_ROT
+    AXIS_D0Q3S1A0_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A0 translation detector
+                        AXIS_D0Q3S1 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S1A0_ROT
+    AXIS_D0Q3S1A0_F translation detector
+                        AXIS_D0Q3S1A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A0_S translation detector
+                        AXIS_D0Q3S1A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S1A1_ROT rotation detector
+                        AXIS_D0Q3S1 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S1A1 translation detector
+                        AXIS_D0Q3S1 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S1A1_ROT
+    AXIS_D0Q3S1A1_F translation detector
+                        AXIS_D0Q3S1A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S1A1_S translation detector
+                        AXIS_D0Q3S1A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S2 translation detector
+                        AXIS_D0Q3 . . . 10.9572375 -23.5830375 0.0
+                                   269.55191 AXIS_D0Q3S2_ROT
+    AXIS_D0Q3S2A0_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A0 translation detector
+                        AXIS_D0Q3S2 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S2A0_ROT
+    AXIS_D0Q3S2A0_F translation detector
+                        AXIS_D0Q3S2A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A0_S translation detector
+                        AXIS_D0Q3S2A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S2A1_ROT rotation detector
+                        AXIS_D0Q3S2 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S2A1 translation detector
+                        AXIS_D0Q3S2 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S2A1_ROT
+    AXIS_D0Q3S2A1_F translation detector
+                        AXIS_D0Q3S2A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S2A1_S translation detector
+                        AXIS_D0Q3S2A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S3 translation detector
+                        AXIS_D0Q3 . . . 34.4180375 -23.4818375 0.0
+                                   269.74206 AXIS_D0Q3S3_ROT
+    AXIS_D0Q3S3A0_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A0 translation detector
+                        AXIS_D0Q3S3 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S3A0_ROT
+    AXIS_D0Q3S3A0_F translation detector
+                        AXIS_D0Q3S3A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A0_S translation detector
+                        AXIS_D0Q3S3A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S3A1_ROT rotation detector
+                        AXIS_D0Q3S3 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S3A1 translation detector
+                        AXIS_D0Q3S3 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S3A1_ROT
+    AXIS_D0Q3S3A1_F translation detector
+                        AXIS_D0Q3S3A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S3A1_S translation detector
+                        AXIS_D0Q3S3A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S4 translation detector
+                        AXIS_D0Q3 . . . -24.1283625 -11.5336375 0.0
+                                   359.81971 AXIS_D0Q3S4_ROT
+    AXIS_D0Q3S4A0_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A0 translation detector
+                        AXIS_D0Q3S4 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S4A0_ROT
+    AXIS_D0Q3S4A0_F translation detector
+                        AXIS_D0Q3S4A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A0_S translation detector
+                        AXIS_D0Q3S4A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S4A1_ROT rotation detector
+                        AXIS_D0Q3S4 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S4A1 translation detector
+                        AXIS_D0Q3S4 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S4A1_ROT
+    AXIS_D0Q3S4A1_F translation detector
+                        AXIS_D0Q3S4A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S4A1_S translation detector
+                        AXIS_D0Q3S4A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5_ROT rotation detector
+                        AXIS_D0Q3 0.0 0.0 1.0 0 0 0 . .
+    AXIS_D0Q3S5 translation detector
+                        AXIS_D0Q3 . . . -24.1701625 -34.9548375 0.0
+                                   359.99883 AXIS_D0Q3S5_ROT
+    AXIS_D0Q3S5A0_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A0 translation detector
+                        AXIS_D0Q3S5 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S5A0_ROT
+    AXIS_D0Q3S5A0_F translation detector
+                        AXIS_D0Q3S5A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A0_S translation detector
+                        AXIS_D0Q3S5A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S5A1_ROT rotation detector
+                        AXIS_D0Q3S5 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S5A1 translation detector
+                        AXIS_D0Q3S5 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S5A1_ROT
+    AXIS_D0Q3S5A1_F translation detector
+                        AXIS_D0Q3S5A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S5A1_S translation detector
+                        AXIS_D0Q3S5A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S6 translation detector
+                        AXIS_D0Q3 . . . -33.3089625 23.4474625 0.0
+                                   269.67299 AXIS_D0Q3S6_ROT
+    AXIS_D0Q3S6A0_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A0 translation detector
+                        AXIS_D0Q3S6 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S6A0_ROT
+    AXIS_D0Q3S6A0_F translation detector
+                        AXIS_D0Q3S6A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A0_S translation detector
+                        AXIS_D0Q3S6A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S6A1_ROT rotation detector
+                        AXIS_D0Q3S6 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S6A1 translation detector
+                        AXIS_D0Q3S6 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S6A1_ROT
+    AXIS_D0Q3S6A1_F translation detector
+                        AXIS_D0Q3S6A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S6A1_S translation detector
+                        AXIS_D0Q3S6A1 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7_ROT rotation detector
+                        AXIS_D0Q3 -0.0 -0.0 -1.0 0 0 0 . .
+    AXIS_D0Q3S7 translation detector
+                        AXIS_D0Q3 . . . -10.0032625 23.4826625 0.0
+                                   269.67561 AXIS_D0Q3S7_ROT
+    AXIS_D0Q3S7A0_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A0 translation detector
+                        AXIS_D0Q3S7 . . . -10.835 0.0 0.0 0.0 AXIS_D0Q3S7A0_ROT
+    AXIS_D0Q3S7A0_F translation detector
+                        AXIS_D0Q3S7A0 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A0_S translation detector
+                        AXIS_D0Q3S7A0 0 1 0 0 0 0 . .
+    AXIS_D0Q3S7A1_ROT rotation detector
+                        AXIS_D0Q3S7 0.0 0.0 0.0 0 0 0 . .
+    AXIS_D0Q3S7A1 translation detector
+                        AXIS_D0Q3S7 . . . 10.835 0.0 0.0 0.0 AXIS_D0Q3S7A1_ROT
+    AXIS_D0Q3S7A1_F translation detector
+                        AXIS_D0Q3S7A1 1 0 0 0 0 0 . .
+    AXIS_D0Q3S7A1_S translation detector
+                        AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
+
+;
+;
+       Example 6.
+
+    This example shows an excerpt from the axis specification of an FEL detector
+    provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
+    _axis.rotation to organize the positional dependencies.  The approach
+    in Example 5 is now preferred.
+
+    The detector is divided into 4 quadrants, each quadrant contains 8 sensors
+    and each sensor contains 2 ASICs.  We want to be able to refine the
+    placement of each of these elements, so we maintain the set of vectors
+    that places them.
+
+    To do this, the first vector of importance is an initial placement axis
+    that moves from the origin along the Z axis a distance equal to the
+    detector distance.  This is the origin for the rest of the axes and is
+    called AXIS_D0_ORIGIN.
+
+    Each subsequent movement involves a frame shift.  This is done by using
+    two imgCIF axes: a rotation axis and a translation axis.  The rotation
+    axis is listed first, and includes no offset or angle.  The actual frame
+    shift is done by using a translation axis.  An offset is used first in
+    the parent's frame, and then an angle is listed to rotate around the
+    rotation axis.
+
+    Example, sensor five of quadrant 2.  First a rotation axis is listed:
+
+    AXIS_D0Q2S5_ROT rotation detector AXIS_D0Q2 0.0 0.0 1.0 0 0 0 . .
+    This defines a rotation axis around the z axis in the frame of quadrant 2.
+
+    Next a translation axis is listed:
+    AXIS_D0Q2S5 translation detector
+        AXIS_D0Q2 . . . 34.5494875 -24.1901 0.0 89.68154 AXIS_D0Q2S5_ROT
+    Here, in the frame of quadrant 2, we shift X by 34 and Y by -24 mm,
+    then rotate 89 degrees around the axis named AXIS_D0Q2S5_ROT.
+
+    And so forth.
+;
+
+save_
+
+save_axis.variant
+
+    _definition.id                '_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+            The value of _axis.variant gives the variant
+              to which the given AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DATA_FRAME
+
+    _definition.id                diffrn_data_frame
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+            Data items in the DIFFRN_DATA_FRAME category record
+              the details about each frame of data.
+
+              The items in this category were previously in a
+              DIFFRN_FRAME_DATA category, which is now deprecated.
+              The items from the old category are provided
+              as aliases but should not be used for new work.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_data_frame
+
+    loop_
+      _category_key.name
+         '_diffrn_data_frame.id'
+         '_diffrn_data_frame.detector_element_id'
+         '_diffrn_data_frame.variant'
+
+    _description_example.case
+;
+        loop_
+        _diffrn_data_frame.id
+        _diffrn_data_frame.detector_element_id
+        _diffrn_data_frame.array_id
+        _diffrn_data_frame.binary_id
+        frame_1   d1_ccd_1  array_1  1
+        frame_1   d1_ccd_2  array_1  2
+        frame_1   d1_ccd_3  array_1  3
+        frame_1   d1_ccd_4  array_1  4
+;
+    _description_example.detail
+;
+     Example 1. a frame containing data from four frame elements.
+
+                       Each frame element has a common array configuration
+                       'array_1' described in ARRAY_STRUCTURE and related
+                       categories.  The data for each detector element are
+                       stored in four groups of binary data in the
+                       ARRAY_DATA category, linked by the array_id and
+                       binary_id.
+;
+
+save_
+
+save_diffrn_data_frame.variant
+
+    _definition.id                '_diffrn_data_frame.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_data_frame.variant gives the variant
+              to which the given DIFFRN_DATA_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_data_frame
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR
+
+    _definition.id                diffrn_detector
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR category describe the
+     detector used to measure the scattered radiation, including
+     any analyser and post-sample collimation.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_detector
+
+    loop_
+      _category_key.name
+         '_diffrn_detector.diffrn_id'
+         '_diffrn_detector.id'
+         '_diffrn_detector.variant'
+
+    _description_example.case
+;
+    _diffrn_detector.diffrn_id             'd1'
+    _diffrn_detector.detector              'multiwire'
+    _diffrn_detector.type                  'Siemens'
+;
+    _description_example.detail
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+
+save_
+
+save_diffrn_detector.variant
+
+    _definition.id                '_diffrn_detector.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_detector.variant gives the variant
+              to which the given DIFFRN_DETECTOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR_AXIS
+
+    _definition.id                diffrn_detector_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR_AXIS category associate
+     axes with detectors.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_detector_axis
+
+    loop_
+      _category_key.name
+         '_diffrn_detector_axis.detector_id'
+         '_diffrn_detector_axis.axis_id'
+         '_diffrn_detector_axis.variant'
+
+save_
+
+save_diffrn_detector_axis.variant
+
+    _definition.id                '_diffrn_detector_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+            The value of _diffrn_detector_axis.variant gives the variant
+             to which the given DIFFRN_DETECTOR_AXIS row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             diffrn_detector_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_DETECTOR_ELEMENT
+
+    _definition.id                diffrn_detector_element
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_DETECTOR_ELEMENT category record
+     the details about spatial layout and other characteristics
+     of each element of a detector which may have multiple elements.
+
+     In most cases, giving more detailed information
+     in ARRAY_STRUCTURE_LIST and ARRAY_STRUCTURE_LIST_AXIS
+     is preferable to simply providing the centre of the
+     detector element.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_detector_element
+
+    loop_
+      _category_key.name
+         '_diffrn_detector_element.id'
+         '_diffrn_detector_element.detector_id'
+         '_diffrn_detector_element.variant'
+
+    _description_example.case
+;
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        d1     d1_ccd_1  201.5 201.5  mm
+        d1     d1_ccd_2  -1.8  201.5  mm
+        d1     d1_ccd_3  201.6  -1.4  mm
+        d1     d1_ccd_4  -1.7   -1.5  mm
+;
+    _description_example.detail
+;
+      Example 1. Detector d1 is composed of four CCD detector elements,
+        each 200 mm by 200 mm, arranged in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+        Note that the beam centre is slightly displaced from each of the
+        detector elements, just beyond the lower right corner of 1,
+        the lower left corner of 2, the upper right corner of 3 and
+        the upper left corner of 4.  For each element, the detector
+        face coordinate system is assumed to have the fast axis
+        running from left to right and the slow axis running from
+        top to bottom with the origin at the top left corner.
+;
+
+save_
+
+save_diffrn_detector_element.variant
+
+    _definition.id                '_diffrn_detector_element.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_detector_element.variant gives the variant
+              to which the given DIFFRN_DETECTOR_ELEMENT row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+               VARIANT category.
+;
+    _name.category_id             diffrn_detector_element
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_MEASUREMENT
+
+    _definition.id                diffrn_measurement
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_MEASUREMENT category record details
+     about the device used to orient and/or position the crystal
+     during data measurement and the manner in which the
+     diffraction data were measured.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_measurement
+
+    loop_
+      _category_key.name
+         '_diffrn_measurement.device'
+         '_diffrn_measurement.diffrn_id'
+         '_diffrn_measurement.id'
+         '_diffrn_measurement.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+    _diffrn_measurement.diffrn_id          'd1'
+    _diffrn_measurement.device             '3-circle camera'
+    _diffrn_measurement.device_type        'Supper model X'
+    _diffrn_measurement.device_details     'none'
+    _diffrn_measurement.method             'omega scan'
+    _diffrn_measurement.details
+    ; 440 frames, 0.20 degrees, 150 sec, detector distance 12 cm, 
+      detector angle 22.5 degrees
+    ;
+;
+;
+    Example 1. based on PDB entry 5HVP and laboratory records for the
+                 structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_measurement.diffrn_id       's1'
+    _diffrn_measurement.device_type     'Philips PW1100/20 diffractometer'
+    _diffrn_measurement.method          'theta/2theta (\q/2\q)'
+;
+;
+     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                  [Acta Cryst. (1991), C47, 2276-2277].
+;
+
+save_
+
+save_diffrn_measurement.variant
+
+    _definition.id                '_diffrn_measurement.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+            The value of _diffrn_measurement.variant gives the variant
+             to which the given DIFFRN_MEASUREMENT row is related.
+
+             If this value is not given, the variant is assumed to be
+             the default null variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_MEASUREMENT_AXIS
+
+    _definition.id                diffrn_measurement_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_MEASUREMENT_AXIS category associate
+     axes with goniometers.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_measurement_axis
+
+    loop_
+      _category_key.name
+         '_diffrn_measurement_axis.measurement_device'
+         '_diffrn_measurement_axis.measurement_id'
+         '_diffrn_measurement_axis.axis_id'
+         '_diffrn_measurement_axis.variant'
+
+save_
+
+save_diffrn_measurement_axis.variant
+
+    _definition.id                '_diffrn_measurement_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_measurement_axis.variant gives the variant
+              to which the given DIFFRN_MEASUREMENT_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_measurement_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_RADIATION
+
+    _definition.id                diffrn_radiation
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2026-05-14
+    _description.text
+;
+             Data items in the DIFFRN_RADIATION category describe
+              the radiation used for measuring diffraction intensities,
+              its collimation and monochromatization before the sample.
+
+              Post-sample treatment of the beam is described by data
+              items in the DIFFRN_DETECTOR category.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_radiation
+
+    loop_
+      _category_key.name
+         '_diffrn_radiation.diffrn_id'
+         '_diffrn_radiation.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+    _diffrn_radiation.diffrn_id            'set1'
+
+    _diffrn_radiation.collimation          '0.3 mm double pinhole'
+    _diffrn_radiation.monochromator        'graphite'
+    _diffrn_radiation.type                 'Cu K\a'
+    _diffrn_radiation.wavelength_id         1
+;
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP
+;
+;
+    _diffrn_radiation.wavelength_id    1
+    _diffrn_radiation.type             'Cu K\a'
+    _diffrn_radiation.monochromator    'graphite'
+;
+;
+    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+
+save_
+
+save_diffrn_radiation.variant
+
+    _definition.id                '_diffrn_radiation.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_radiation.variant gives the variant
+              to which the given DIFFRN_RADIATION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_REFLN
+
+    _definition.id                diffrn_refln
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    This category redefinition has been added to extend the key of
+     the standard DIFFRN_REFLN category.
+
+     Data items in the DIFFRN_REFLN category record details about
+     the intensities in the diffraction data set
+     identified by _diffrn_refln.diffrn_id.
+
+     The DIFFRN_REFLN data items refer to individual intensity
+     measurements and must be included in looped lists.
+
+     The DIFFRN_REFLNS data items specify the parameters that apply
+     to all intensity  measurements in the particular diffraction
+     data set identified by _diffrn_reflns.diffrn_id and
+     _diffrn_refln.frame_id
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_refln
+
+    loop_
+      _category_key.name
+         '_diffrn_refln.diffrn_id'
+         '_diffrn_refln.id'
+         '_diffrn_refln.frame_id'
+         '_diffrn_refln.variant'
+
+save_
+
+save_diffrn_refln.variant
+
+    _definition.id                '_diffrn_refln.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_refln.variant gives the variant
+              to which the given DIFFRN_REFLN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN
+
+    _definition.id                diffrn_scan
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN category describe the parameters of one
+     or more scans, relating axis positions to frames.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan
+
+    loop_
+      _category_key.name
+         '_diffrn_scan.id'
+         '_diffrn_scan.variant'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+      _diffrn_scan.id                   1
+      _diffrn_scan.date_start         '2001-11-18T03:26:42'
+      _diffrn_scan.date_end_estimated '2001-11-18T03:36:45'
+      _diffrn_scan.date_end           '2001-11-18T03:36:45'
+      _diffrn_scan.integration_time    3.0
+      _diffrn_scan.frame_id_start      mad_L2_000
+      _diffrn_scan.frame_id_end        mad_L2_200
+      _diffrn_scan.frames              201
+
+     loop_
+      _diffrn_scan_axis.scan_id
+      _diffrn_scan_axis.axis_id
+      _diffrn_scan_axis.angle_start
+      _diffrn_scan_axis.angle_range
+      _diffrn_scan_axis.angle_increment
+      _diffrn_scan_axis.displacement_start
+      _diffrn_scan_axis.displacement_range
+      _diffrn_scan_axis.displacement_increment
+
+       1 omega 200.0 20.1 0.1 . . .
+       1 kappa -40.0  0.0 0.0 . . .
+       1 phi   127.5  0.0 0.0 . . .
+       1 tranz  . . .   2.3 0.0 0.0
+
+      _diffrn_scan_frame.scan_id                   1
+      _diffrn_scan_frame.date               '2001-11-18T03:27:33'
+      _diffrn_scan_frame.integration_time    3.0
+      _diffrn_scan_frame.frame_id            mad_L2_018
+      _diffrn_scan_frame.frame_number        18
+
+     loop_
+      _diffrn_scan_frame_axis.frame_id
+      _diffrn_scan_frame_axis.axis_id
+      _diffrn_scan_frame_axis.angle
+      _diffrn_scan_frame_axis.angle_increment
+      _diffrn_scan_frame_axis.displacement
+      _diffrn_scan_frame_axis.displacement_increment
+
+       mad_L2_018 omega 201.8  0.1 . .
+       mad_L2_018 kappa -40.0  0.0 . .
+       mad_L2_018 phi   127.5  0.0 . .
+       mad_L2_018 tranz  .     .  2.3 0.0
+;
+;
+         Example 1. derived from a suggestion by R. M. Sweet.
+
+         The vector of each axis is not given here, because it is provided in
+         the AXIS category.  By making _diffrn_scan_axis.scan_id and
+         _diffrn_scan_axis.axis_id keys of the DIFFRN_SCAN_AXIS category,
+         an arbitrary number of scanning and fixed axes can be specified for a
+         scan.  In this example, three rotation axes and one translation axis
+         at nonzero values are specified, with one axis stepping.  There is no
+         reason why more axes could not have been specified to step. Range
+         information has been specified, but note that it can be calculated from
+         the  number of frames and the increment, so the data item
+         _diffrn_scan_axis.angle_range could be dropped.
+
+         Both the sweep data and the data for a single frame are specified.
+
+         Note that the information on how the axes are stepped is given twice,
+         once in terms of the overall averages in the value of
+         _diffrn_scan.integration_time and the values for DIFFRN_SCAN_AXIS,
+         and precisely for the given frame in the value for
+         _diffrn_scan_frame.integration_time and the values for
+         DIFFRN_SCAN_FRAME_AXIS.  If dose-related adjustments are made to
+         scan times and nonlinear stepping is done, these values may differ.
+         Therefore, in interpreting the data for a particular frame it is
+         important to use the frame-specific data.
+
+         There are three date/times in this set: *.date_start and
+         *. date_end_estimated, both of which are mandatory, because the former
+         is data which can be logged at the start of collection and the latter
+         is data that can be estimated at the same time, and *.date_end which
+         can only be logged exactly if the data collection completes normally.
+;
+;
+    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+     loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 2300 1 increasing ELEMENT_X
+      ARRAY1 2 2300 2 increasing ELEMENT_Y
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.displacement_increment
+      ELEMENT_X ELEMENT_X 0.075 0.150
+      ELEMENT_Y ELEMENT_Y 0.075 0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+      ARRAY1 2 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+;
+         Example 2. a more extensive example (R. M. Sweet, P. J. Ellis &
+          H. J. Bernstein).
+
+          A detector is placed 240 mm along the Z axis from the goniometer.
+          This leads to a choice:  either the axes of
+          the detector are defined at the origin, and then a Z setting of -240
+          is entered, or the axes are defined with the necessary Z offset.
+          In this case, the setting is used and the offset is left as zero.
+          This axis is called DETECTOR_Z.
+
+          The axis for positioning the detector in the Y direction depends
+          on the detector Z axis.  This axis is called DETECTOR_Y.
+
+          The axis for positioning the detector in the X direction depends
+          on the detector Y axis (and therefore on the detector Z axis).
+          This axis is called DETECTOR_X.
+
+          This detector may be rotated around the Y axis.  This rotation axis
+          depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+          A coordinate system is defined on the face of the detector in terms of
+          2300 0.150 mm pixels in each direction.  The ELEMENT_X axis is used to
+          index the first array index of the data array and the ELEMENT_Y
+          axis is used to index the second array index.  Because the pixels
+          are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
+          0.075) in this coordinate system.
+;
+;
+    ###CBF: VERSION 1.1
+
+     data_image_1
+
+     # category DIFFRN
+    _diffrn.id P6MB
+    _diffrn.crystal_id P6MB_CRYSTAL7
+
+     # category DIFFRN_SOURCE
+     loop_
+    _diffrn_source.diffrn_id
+    _diffrn_source.source
+    _diffrn_source.type
+      P6MB synchrotron 'SSRL beamline 9-1'
+
+     # category DIFFRN_RADIATION
+          loop_
+     _diffrn_radiation.diffrn_id
+     _diffrn_radiation.wavelength_id
+     _diffrn_radiation.monochromator
+     _diffrn_radiation.polarizn_source_ratio
+     _diffrn_radiation.polarizn_source_norm
+     _diffrn_radiation.div_x_source
+     _diffrn_radiation.div_y_source
+     _diffrn_radiation.div_x_y_source
+      P6MB WAVELENGTH1 'Si 111' 0.8 0.0 0.08 0.01 0.00
+
+     # category DIFFRN_RADIATION_WAVELENGTH
+     loop_
+    _diffrn_radiation_wavelength.id
+    _diffrn_radiation_wavelength.wavelength
+    _diffrn_radiation_wavelength.wt
+      WAVELENGTH1 0.98 1.0
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+
+     # category DIFFRN_DETECTOR_ELEMENT
+     loop_
+     _diffrn_detector_element.id
+     _diffrn_detector_element.detector_id
+      ELEMENT1 MAR345-SN26
+
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+
+     # category DIFFRN_MEASUREMENT
+     loop_
+     _diffrn_measurement.diffrn_id
+     _diffrn_measurement.id
+     _diffrn_measurement.number_of_axes
+     _diffrn_measurement.method
+      P6MB GONIOMETER 3 rotation
+
+     # category DIFFRN_MEASUREMENT_AXIS
+     loop_
+     _diffrn_measurement_axis.measurement_id
+     _diffrn_measurement_axis.axis_id
+      GONIOMETER GONIOMETER_PHI
+      GONIOMETER GONIOMETER_KAPPA
+      GONIOMETER GONIOMETER_OMEGA
+
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_ROT      translation detector DETECTOR_PITCH 0 0 1 0 0 0
+      ELEMENT_RAD      translation detector ELEMENT_ROT 0 1 0 0 0 0
+
+     # category ARRAY_STRUCTURE_LIST
+     loop_
+     _array_structure_list.array_id
+     _array_structure_list.index
+     _array_structure_list.dimension
+     _array_structure_list.precedence
+     _array_structure_list.direction
+     _array_structure_list.axis_set_id
+      ARRAY1 1 8309900 1 increasing ELEMENT_SPIRAL
+
+     # category ARRAY_STRUCTURE_LIST_AXIS
+     loop_
+     _array_structure_list_axis.axis_set_id
+     _array_structure_list_axis.axis_id
+     _array_structure_list_axis.angle
+     _array_structure_list_axis.displacement
+     _array_structure_list_axis.angular_pitch
+     _array_structure_list_axis.radial_pitch
+      ELEMENT_SPIRAL ELEMENT_ROT 0    .  0.075   .
+      ELEMENT_SPIRAL ELEMENT_RAD . 172.5  .    -0.150
+
+     # category ARRAY_ELEMENT_SIZE
+     # the actual pixels are 0.075 by 0.150 mm
+     # We give the coarser dimension here.
+     loop_
+     _array_element_size.array_id
+     _array_element_size.index
+     _array_element_size.size
+      ARRAY1 1 150e-6
+
+     # category ARRAY_INTENSITIES
+     loop_
+     _array_intensities.array_id
+     _array_intensities.binary_id
+     _array_intensities.linearity
+     _array_intensities.gain
+     _array_intensities.gain_esd
+     _array_intensities.overload
+     _array_intensities.undefined_value
+      ARRAY1 1 linear 1.15 0.2 240000 0
+
+      # category ARRAY_STRUCTURE
+     loop_
+      _array_structure.id
+      _array_structure.encoding_type
+      _array_structure.compression_type
+      _array_structure.byte_order
+      ARRAY1 "signed 32-bit integer" packed little_endian
+
+     # category ARRAY_DATA
+     loop_
+     _array_data.array_id
+     _array_data.binary_id
+     _array_data.data
+      ARRAY1 1
+     ;
+     --CIF-BINARY-FORMAT-SECTION--
+     Content-Type: application/octet-stream;
+         conversions="X-CBF_PACKED"
+     Content-Transfer-Encoding: BASE64
+     X-Binary-Size: 3801324
+     X-Binary-ID: 1
+     X-Binary-Element-Type: "signed 32-bit integer"
+     Content-MD5: 07lZFvF+aOcW85IN7usl8A==
+
+     AABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBQSr1sKNBOeOe9HITdMdDUnbq7bg
+     ...
+     8REo6TtBrxJ1vKqAvx9YDMD6J18Qg83OMr/tgssjMIJMXATDsZobL90AEXc4KigE
+
+     --CIF-BINARY-FORMAT-SECTION----
+     ;
+;
+;
+         Example 3. Example 2 revised for a spiral scan (R. M. Sweet,
+          P. J. Ellis & H. J. Bernstein).
+
+         A detector is placed 240 mm along the Z axis from the
+         goniometer, as in Example 2 above, but in this example the
+         image plate is scanned in a spiral pattern from the outside edge in.
+
+         The axis for positioning the detector in the Y direction depends
+         on the detector Z axis.  This axis is called DETECTOR_Y.
+
+         The axis for positioning the detector in the X direction depends
+         on the detector Y axis (and therefore on the detector Z axis).
+         This axis is called DETECTOR_X.
+
+         This detector may be rotated around the Y axis.  This rotation axis
+         depends on the three translation axes.  It is called DETECTOR_PITCH.
+
+         A coordinate system is defined on the face of the detector in
+         terms of a coupled rotation axis and radial scan axis to form
+         a spiral scan.  The rotation axis is called  ELEMENT_ROT  and the
+         radial axis is called ELEMENT_RAD.  A 150 micrometre radial pitch
+         and a 75 micrometre 'constant velocity' angular pitch are assumed.
+
+         Indexing is carried out first on the rotation axis and the radial axis
+         is made to be dependent on it.
+
+         The two axes are coupled to form an axis set ELEMENT_SPIRAL.
+;
+
+save_
+
+save_diffrn_scan.variant
+
+    _definition.id                '_diffrn_scan.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan.variant gives the variant
+              to which the given DIFFRN_SCAN row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_AXIS
+
+    _definition.id                diffrn_scan_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_AXIS category describe the settings of
+     axes for particular scans.  Unspecified axes are assumed to be at
+     their zero points.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan_axis
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_axis.scan_id'
+         '_diffrn_scan_axis.axis_id'
+         '_diffrn_scan_axis.variant'
+
+save_
+
+save_diffrn_scan_axis.variant
+
+    _definition.id                '_diffrn_scan_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_COLLECTION
+
+    _definition.id                diffrn_scan_collection
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_COLLECTION category describe
+     the collection strategy for each scan.
+
+     This category is a preliminary version being developed as
+     synchrotron and XFEL collection strategies evolve.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan_collection
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_collection.scan_id'
+         '_diffrn_scan_collection.variant'
+
+    _description_example.case
+        'Example 1 - Describing a multi-wedge raster scan.'
+    _description_example.detail
+;
+        loop_
+        _diffrn_scan_collection.scan_id
+        _diffrn_scan_collection.details
+       
+        multi_wedge
+    ;   scan 20 micrometre beam in 100 micrometre steps on 31
+        by 46 alternating raster of 20 degree wedges 
+    ;
+;
+
+save_
+
+save_diffrn_scan_collection.variant
+
+    _definition.id                '_diffrn_scan_collection.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan_collection.variant gives the variant
+              to which the given DIFFRN_SCAN_COLLECTION row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_collection
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME
+
+    _definition.id                diffrn_scan_frame
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME category describe
+     the relationships of particular frames to scans.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan_frame
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame.scan_id'
+         '_diffrn_scan_frame.frame_id'
+         '_diffrn_scan_frame.variant'
+
+save_
+
+save_diffrn_scan_frame.variant
+
+    _definition.id                '_diffrn_scan_frame.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan_frame.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME_AXIS
+
+    _definition.id                diffrn_scan_frame_axis
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME_AXIS category describe the
+     settings of axes for particular frames.  Unspecified axes are
+     assumed to be at their zero points.  If, for any given frame,
+     nonzero values apply for any of the data items in this category,
+     those values should be given explicitly in this category and not
+     simply inferred from values in DIFFRN_SCAN_AXIS.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan_frame_axis
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame_axis.frame_id'
+         '_diffrn_scan_frame_axis.axis_id'
+         '_diffrn_scan_frame_axis.variant'
+
+save_
+
+save_diffrn_scan_frame_axis.variant
+
+    _definition.id                '_diffrn_scan_frame_axis.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan_frame_axis.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame_axis
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_DIFFRN_SCAN_FRAME_MONITOR
+
+    _definition.id                diffrn_scan_frame_monitor
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the DIFFRN_SCAN_FRAME_MONITOR category record
+     the values and details about each monitor for each frame of data
+     during a scan.
+
+     Each monitor value is uniquely identified by the combination of
+     the scan id given by _diffrn_scan_frame.scan_id,
+     the frame id given by _diffrn_scan_frame_monitor.frame_id,
+     the monitor's detector id given by
+     _diffrn_scan_frame_monitor.detector_id,
+     and a 1-based ordinal given by _diffrn_scan_frame_monitor.id.
+
+     If there is only one frame for the scan, the value of
+     _diffrn_scan_frame_monitor.frame_id may be omitted.
+
+     A single frame may have more than one monitor value, and each
+     monitor value may be the result of integration over the entire
+     frame integration time given by the value of
+     _diffrn_scan_frame.integration_time,
+     or many monitor values may be reported over shorter times given
+     by the value of _diffrn_scan_frame_monitor.integration_time.  If
+     only one monitor value for a given monitor is collected during
+     the integration time of the frame, the value of
+     _diffrn_scan_frame_monitor.id may be
+     omitted.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               diffrn_scan_frame_monitor
+
+    loop_
+      _category_key.name
+         '_diffrn_scan_frame_monitor.id'
+         '_diffrn_scan_frame_monitor.detector_id'
+         '_diffrn_scan_frame_monitor.scan_id'
+         '_diffrn_scan_frame_monitor.frame_id'
+         '_diffrn_scan_frame_monitor.variant'
+
+    _description_example.case
+;
+
+     # category DIFFRN_DETECTOR
+     loop_
+     _diffrn_detector.diffrn_id
+     _diffrn_detector.id
+     _diffrn_detector.type
+     _diffrn_detector.number_of_axes
+      P6MB MAR345-SN26 'MAR 345' 4
+      P6MB BSM01 'metal foil and PIN diode' 1
+
+     # category DIFFRN_DETECTOR_AXIS
+     loop_
+     _diffrn_detector_axis.detector_id
+     _diffrn_detector_axis.axis_id
+      MAR345-SN26 DETECTOR_X
+      MAR345-SN26 DETECTOR_Y
+      MAR345-SN26 DETECTOR_Z
+      MAR345-SN26 DETECTOR_PITCH
+      BSM01 MONITOR_Z
+     # category DIFFRN_DATA_FRAME
+     loop_
+     _diffrn_data_frame.id
+     _diffrn_data_frame.detector_element_id
+     _diffrn_data_frame.array_id
+     _diffrn_data_frame.binary_id
+      FRAME1 ELEMENT1 ARRAY1 1
+     # category DIFFRN_SCAN
+     loop_
+     _diffrn_scan.id
+     _diffrn_scan.frame_id_start
+     _diffrn_scan.frame_id_end
+     _diffrn_scan.frames
+      SCAN1 FRAME1 FRAME1 1
+
+     # category DIFFRN_SCAN_AXIS
+     loop_
+     _diffrn_scan_axis.scan_id
+     _diffrn_scan_axis.axis_id
+     _diffrn_scan_axis.angle_start
+     _diffrn_scan_axis.angle_range
+     _diffrn_scan_axis.angle_increment
+     _diffrn_scan_axis.displacement_start
+     _diffrn_scan_axis.displacement_range
+     _diffrn_scan_axis.displacement_increment
+      SCAN1 GONIOMETER_OMEGA 12.0 1.0 1.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_KAPPA 23.3 0.0 0.0 0.0 0.0 0.0
+      SCAN1 GONIOMETER_PHI -165.8 0.0 0.0 0.0 0.0 0.0
+      SCAN1 DETECTOR_Z 0.0 0.0 0.0 -240.0 0.0 0.0
+      SCAN1 DETECTOR_Y 0.0 0.0 0.0 0.6 0.0 0.0
+      SCAN1 DETECTOR_X 0.0 0.0 0.0 -0.5 0.0 0.0
+      SCAN1 DETECTOR_PITCH 0.0 0.0 0.0 0.0 0.0 0.0
+      SCAN1 MONITOR_Z 0.0 0.0 0.0 -220.0 0.0 0.0
+
+     # category DIFFRN_SCAN_FRAME
+     loop_
+     _diffrn_scan_frame.frame_id
+     _diffrn_scan_frame.frame_number
+     _diffrn_scan_frame.integration_time
+     _diffrn_scan_frame.scan_id
+     _diffrn_scan_frame.date
+      FRAME1 1 20.0 SCAN1 1997-12-04T10:23:48
+
+     # category DIFFRN_SCAN_FRAME_MONITOR
+     loop_
+     _diffrn_scan_frame_monitor.id
+     _diffrn_scan_frame_monitor.detector_id
+     _diffrn_scan_frame_monitor.scan_id
+     _diffrn_scan_frame_monitor.frame_id
+     _diffrn_scan_frame_monitor.integration_time
+     _diffrn_scan_frame_monitor.monitor_value
+      1  BSM01 SCAN1 FRAME1 2.0 23838345642
+      2  BSM01 SCAN1 FRAME1 2.0 23843170669
+      3  BSM01 SCAN1 FRAME1 2.0 23839478690
+      4  BSM01 SCAN1 FRAME1 2.0 23856642085
+      5  BSM01 SCAN1 FRAME1 2.0 23781717656
+      6  BSM01 SCAN1 FRAME1 2.0 23788850775
+      7  BSM01 SCAN1 FRAME1 2.0 23815576677
+      8  BSM01 SCAN1 FRAME1 2.0 23789299964
+      9  BSM01 SCAN1 FRAME1 2.0 23830195536
+      10 BSM01 SCAN1 FRAME1 2.0 23673082270
+
+     # category DIFFRN_SCAN_FRAME_AXIS
+     loop_
+     _diffrn_scan_frame_axis.frame_id
+     _diffrn_scan_frame_axis.axis_id
+     _diffrn_scan_frame_axis.angle
+     _diffrn_scan_frame_axis.displacement
+      FRAME1 GONIOMETER_OMEGA 12.0 0.0
+      FRAME1 GONIOMETER_KAPPA 23.3 0.0
+      FRAME1 GONIOMETER_PHI -165.8 0.0
+      FRAME1 DETECTOR_Z 0.0 -240.0
+      FRAME1 DETECTOR_Y 0.0 0.6
+      FRAME1 DETECTOR_X 0.0 -0.5
+      FRAME1 DETECTOR_PITCH 0.0 0.0
+      FRAME1 MONITOR_Z 0.0 -220.0
+
+     # category AXIS
+     loop_
+     _axis.id
+     _axis.type
+     _axis.equipment
+     _axis.depends_on
+     _axis.vector[1] _axis.vector[2] _axis.vector[3]
+     _axis.offset[1] _axis.offset[2] _axis.offset[3]
+      GONIOMETER_OMEGA rotation goniometer . 1 0 0 . . .
+      GONIOMETER_KAPPA rotation goniometer GONIOMETER_OMEGA 0.64279
+      0 0.76604 . . .
+      GONIOMETER_PHI   rotation goniometer GONIOMETER_KAPPA 1 0 0
+     . . .
+      SOURCE           general source . 0 0 1 . . .
+      GRAVITY          general gravity . 0 -1 0 . . .
+      DETECTOR_Z       translation detector . 0 0 1 0 0 0
+      DETECTOR_Y       translation detector DETECTOR_Z 0 1 0 0 0 0
+      DETECTOR_X       translation detector DETECTOR_Y 1 0 0 0 0 0
+      DETECTOR_PITCH   rotation    detector DETECTOR_X 0 1 0 0 0 0
+      ELEMENT_X        translation detector DETECTOR_PITCH
+     1 0 0 172.43 -172.43 0
+      ELEMENT_Y        translation detector ELEMENT_X
+     0 1 0 0 0 0
+      MONITOR_Z        translation detector . 0 0 1 0 0 0
+
+;
+    _description_example.detail
+;
+    Example 1. The beam intensity for frame FRAME1 is being tracked
+        by a beamstop monitor detector BSM01, made from metal foil and
+        a PIN diode, located 20 mm in front of a MAR345 detector and being
+        sampled every 2 seconds in a 20 second scan.
+;
+
+save_
+
+save_diffrn_scan_frame_monitor.variant
+
+    _definition.id                '_diffrn_scan_frame_monitor.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _diffrn_scan_frame_monitor.variant gives the variant
+              to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             diffrn_scan_frame_monitor
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_MAP
+
+    _definition.id                map
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the MAP category record
+     the details of maps. Maps record values of parameters,
+     such as density, that are functions of position within
+     a cell or are functions of orthogonal coordinates in
+     three space.
+
+     A map is composed of one or more map segments
+     specified in the MAP_SEGMENT category.
+
+     Examples are given in the MAP_SEGMENT category.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               map
+
+    loop_
+      _category_key.name
+         '_map.id'
+         '_map.diffrn_id'
+         '_map.entry_id'
+         '_map.variant'
+
+    _description_example.case
+;
+
+        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+   ;
+        density calculated from F_calc derived from the ATOM_SITE
+        list
+   ;
+        rho_obs
+   ;
+        density combining the observed structure factors with the
+        calculated phases
+   ;
+;
+    _description_example.detail
+;
+   Example 1. Identifying an observed density map
+                and a calculated density map
+;
+
+save_
+
+save_map.variant
+
+    _definition.id                '_map.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _map.variant gives the variant
+              to which the given map row is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             map
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_MAP_SEGMENT
+
+    _definition.id                map_segment
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the MAP_SEGMENT category record
+     the details about each segment (section or brick) of a map.
+;
+    _name.category_id             CIF_IMG_HEAD
+    _name.object_id               map_segment
+
+    loop_
+      _category_key.name
+         '_map_segment.id'
+         '_map_segment.map_id'
+         '_map_segment.variant'
+
+    _description_example.case
+;
+
+        loop_
+        _map.id
+        _map.details
+
+        rho_calc
+     ;
+        density calculated from F_calc derived from the ATOM_SITE list
+     ;
+        rho_obs
+     ;
+        density combining the observed structure factors with the
+        calculated phases
+     ;
+
+        loop_
+        _map_segment.map_id
+        _map_segment.id
+        _map_segment.array_id
+        _map_segment.binary_id
+        _map_segment.mask_array_id
+        _map_segment.mask_binary_id
+        rho_calc rho_calc map_structure 1 mask_structure 1
+        rho_obs  rho_obs  map_structure 2 mask_structure 1
+;
+    _description_example.detail
+;
+   Example 1. Identifying an observed density map
+                and a calculated density map, each consisting of one
+                segment, both using the same array structure
+                and mask.
+;
+
+save_
+
+save_map_segment.variant
+
+    _definition.id                '_map_segment.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _map_segment.variant gives the variant
+              to which the given map segment is related.
+
+              If this value is not given, the variant is assumed to be
+              the default null variant.
+
+              This item is a pointer to _variant.variant in the
+              VARIANT category.
+;
+    _name.category_id             map_segment
+    _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_VARIANT
+
+    _definition.id                variant
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2026-05-14
+    _description.text
+;
+    Data items in the VARIANT category record
+     the details about sets of variants of data items.
+
+     There is sometimes a need to allow for multiple versions of the
+     same data items in order to allow for refinements and corrections
+     to earlier assumptions, observations and calculations.  In order
+     to allow data sets to contain more than one variant of the same
+     information, an optional *.variant data item as a pointer to
+     _variant.variant has been added to the key of every category,
+     as an implicit data item with a null (empty) default value.
+
+     All rows in a category with the same variant value are considered
+     to be related to one another and to all rows in other categories
+     with the same variant value.  For a given variant, all such rows
+     are also considered to be related to all rows with a null variant
+     value, except that a row with a null variant value for which all
+     other components of its key are identical to those entries in
+     another row with a non-null variant value is not related the
+     the rows with that non-null variant value.  This behaviour is
+     similar to the convention for identifying alternate conformers
+     in an atom list.
+
+     An optional role may be specified for a variant as the value of
+     _variant.role.  Possible roles are null, 'preferred',
+     'raw data', 'unsuccessful trial'.
+
+     variants may carry an optional timestamp as the value of
+     _variant.timestamp.
+
+     variants may be related to other variants from which they were
+     derived by the value of _variant.variant_of.
+
+     Further details about the variant may be specified as the value
+     of _variant.details.
+
+     In order to allow variant information from multiple datasets to
+     be combined, _variant.diffrn_id and/or _variant.entry_id may
+     be used.
+;
+    _name.category_id             variant_head
+    _name.object_id               variant
+    _category_key.name            '_variant.variant'
+    _description_example.case
+;
+
+        loop_
+        _variant.variant
+        _variant.role
+        _variant.timestamp
+        _variant.variant_of
+        _variant.details
+            . "raw data" 2007-08-03T23:20:00 . .
+            indexed "preferred" 2007-08-04T01:17:28 .
+              "indexed cell and refined beam centre"
+
+        loop_
+        _diffrn_detector_element.detector_id
+        _diffrn_detector_element.id
+        _diffrn_detector_element.reference_center_fast
+        _diffrn_detector_element.reference_center_slow
+        _diffrn_detector_element.reference_center_units
+        _diffrn_detector_element.variant
+        d1     d1_ccd_1  201.5 201.5  mm  .
+        d1     d1_ccd_2  -1.8  201.5  mm  .
+        d1     d1_ccd_3  201.6  -1.4  mm  .
+        d1     d1_ccd_4  -1.7   -1.5  mm  .
+        d1     d1_ccd_1  201.3 201.6  mm  indexed
+        d1     d1_ccd_2  -2.0  201.6  mm  indexed
+        d1     d1_ccd_3  201.3  -1.5  mm  indexed
+        d1     d1_ccd_4  -1.9   -1.6  mm  indexed
+;
+    _description_example.detail
+;
+   Example 1. Distinguishing between a raw beam centre and a refined beam
+       centre inferred after indexing.  Detector d1 is composed of
+       four CCD detector elements, each 200 mm by 200 mm, arranged
+       in a square, in the pattern
+
+                   1     2
+                      *
+                   3     4
+
+       Note that the beam centre is slightly displaced from each of the
+       detector elements, just beyond the lower right corner of 1,
+       the lower left corner of 2, the upper right corner of 3 and
+       the upper left corner of 4.  For each element, the detector
+       face coordinate system is assumed to have the fast axis
+       running from left to right and the slow axis running from
+       top to bottom with the origin at the top left corner.
+
+       After indexing and refinement, the centre is shifted by 0.2 mm
+       left and 0.1 mm down.
+;
+
+save_
+
+save_variant.details
+
+    _definition.id                '_variant.details'
+    _definition.update            2026-05-14
+    _description.text
+;
+             A description of special aspects of the variant.
+;
+    _name.category_id             variant
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+        '                                indexed cell and refined beam centre'
+
+save_
+
+save_variant.diffrn_id
+
+    _definition.id                '_variant.diffrn_id'
+    _definition.update            2026-05-14
+    _description.text
+;
+             This item is a pointer to _diffrn.id in the
+              diffrn category.
+;
+    _name.category_id             variant
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_variant.entry_id
+
+    _definition.id                '_variant.entry_id'
+    _definition.update            2026-05-14
+    _description.text
+;
+             This item is a pointer to _entry.id in the
+              entry category
+;
+    _name.category_id             variant
+    _name.object_id               entry_id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_variant.role
+
+    _definition.id                '_variant.role'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _variant.role  specified a role
+              for this variant.  Possible roles are null, 'preferred',
+              'raw data', and 'unsuccessful trial'.
+
+              A null value for _variant.role leaves the
+              precise role of the variant unspecified.  No inference should
+              be made that the variant with the latest time stamp is
+              preferred.
+;
+    _name.category_id             variant
+    _name.object_id               role
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         'preferred'
+;
+    A value of 'preferred' indicates that rows of any categories specifying
+     this variant should be used in preference to rows with the same key
+     specifying other variants or the null variant.  It is an error to specify
+     two variants that appear in the same category with the same key as being
+     preferred, but it is not an error to specify more than one variant as
+     preferred in other cases.
+;
+         'raw data'
+;
+    A value of 'raw data' indicates data prior to any corrections, 
+     calculations or refinements.  It is not necessarily an error for raw data
+     also to be a variant of an earlier variant.  It may be replacement raw 
+     data for earlier data believed to be erroneous.
+;
+         'unsuccessful trial'
+;
+    A value of 'unsuccessful trial' indicates data that should not be used
+     for further calculation.
+;
+
+save_
+
+save_variant.timestamp
+
+    _definition.id                '_variant.timestamp'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The date and time identifying a variant.  This is not 
+              necessarily the precise time of the measurement or calculation
+              of the individual related data items, but a timestamp that 
+              reflects the order in which the variants were defined.
+;
+    _name.category_id             variant
+    _name.object_id               timestamp
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_variant.variant
+
+    _definition.id                '_variant.variant'
+    _definition.update            2026-05-14
+    _description.text
+;
+             The value of _variant.variant must uniquely identify
+              each variant for the given diffraction experiment and/or entry
+
+              This item has been made implicit and given a default value of 
+              null.
+;
+    _name.category_id             variant
+    _name.object_id               variant
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.default          .
+
+save_
+
+save_variant.variant_of
+
+    _definition.id                '_variant.variant_of'
+    _definition.update            2026-05-14
+    _description.text
+;
+            The value of _variant.variant_of gives the variant
+             from which this variant was derived.  If this value is not given,
+             the variant is assumed to be derived from the default null 
+             variant.
+
+             This item is a pointer to _variant.variant in the
+             VARIANT category.
+;
+    _name.category_id             variant
+    _name.object_id               variant_of
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_

--- a/expanded/cif_img_expanded.dic
+++ b/expanded/cif_img_expanded.dic
@@ -5,11 +5,12 @@ data_CIF_IMG.DIC
     _dictionary.title             cif_img.dic
     _dictionary.class             Instance
     _dictionary.version           1.8.9
-    _dictionary.date              2025-09-16
-    _dictionary.ddl_conformance   3.14.0
-    _dictionary.namespace         ddlm
+    _dictionary.date              2026-05-14
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         CifCore
     _description.text
-;##############################################################################
+;
+##############################################################################
 #                                                                            #
 #                       Image CIF Dictionary (imgCIF)                        #
 #             and Crystallographic Binary File Dictionary (CBF)              #
@@ -943,7 +944,9 @@ save_ARRAY_DATA
 ;
 
     _nx_mapping.details
-;    _array_data.array_id ARRAYID
+;
+
+    _array_data.array_id ARRAYID
     _array_data.binary_id BINARYID
     _array_data.data  DATAARRAY
     _array_data.header_contents HEADER
@@ -974,7 +977,8 @@ save_array_data.array_id
 
     _definition.id                '_array_data.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 
               If not given, it defaults to 1.
@@ -997,7 +1001,8 @@ save_array_data.binary_id
 
     _definition.id                '_array_data.binary_id'
     _description.text
-;             This item is an integer identifier which, along with
+;
+             This item is an integer identifier which, along with
               _array_data.array_id, should uniquely identify the
               particular block of array data.
 
@@ -1036,7 +1041,8 @@ save_array_data.data
 
     _definition.id                '_array_data.data'
     _description.text
-;             The value of _array_data.data contains the array data
+;
+             The value of _array_data.data contains the array data
               encapsulated in a STAR string.  The value of this item is 
               required unless a value is given for 
                _array_data.external_data_id instead, in which 
@@ -1286,7 +1292,8 @@ save_array_data.external_data_id
 
     _definition.id                '_array_data.external_data_id'
     _description.text
-;             This item is a pointer to _array_data_external_data.id in the
+;
+             This item is a pointer to _array_data_external_data.id in the
               ARRAY_DATA_EXTERNAL_DATA category.
 
               If not given, then the actual array data should be specified as
@@ -1312,7 +1319,8 @@ save_array_data.header_contents
 
     _definition.id                '_array_data.header_contents'
     _description.text
-;             This item is a text field for use in minimal CBF files to carry
+;
+             This item is a text field for use in minimal CBF files to carry
               essential header information to be kept with image data
               in _array_data.data when the tags that normally carry the
               structured metadata for the image have not been populated.
@@ -1336,7 +1344,8 @@ save_array_data.header_convention
 
     _definition.id                '_array_data.header_convention'
     _description.text
-;             This item is an identifier for the convention followed in
+;
+             This item is an identifier for the convention followed in
               constructing the contents of _array_data.header_contents
 
               The permitted values are of an image creator identifier
@@ -1361,7 +1370,8 @@ save_array_data.variant
 
     _definition.id                '_array_data.variant'
     _description.text
-;             The value of _array_data.variant gives the variant
+;
+             The value of _array_data.variant gives the variant
               to which the given ARRAY_DATA row is related.
 
               If this value is not given, the variant is assumed to be
@@ -1399,7 +1409,9 @@ save_ARRAY_DATA_EXTERNAL_DATA
     _name.ddl2_mandatory          no
     _category_key.name            '_array_data_external_data.id'
     _nx_mapping.details
-;    _array_data.array_id ARRAYID
+;
+
+    _array_data.array_id ARRAYID
     _array_data.binary_id BINARYID
     _array_data.external_data_id EXTERNAL_DATA_ID
     _array_data.header_contents HEADER
@@ -1451,6 +1463,11 @@ save_array_data_external_data.archive_format
 ;
     _name.category_id             array_data_external_data
     _name.object_id               archive_format
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
 
     loop_
       _enumeration_set.state
@@ -1493,6 +1510,11 @@ save_array_data_external_data.file_compression
     _name.category_id             array_data_external_data
     _name.object_id               file_compression
     _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
 
     loop_
       _enumeration_set.state
@@ -1537,6 +1559,11 @@ save_array_data_external_data.format
     _name.category_id             array_data_external_data
     _name.object_id               format
     _name.ddl2_mandatory          no
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _type.ddl2_code               code
 
     loop_
       _enumeration_set.state
@@ -1649,7 +1676,8 @@ save_array_data_external_data.format
          Frames with SMV format are contained at data.proteindiffraction.org in
          a tarred archive compressed with bzip2.
 ;
-; 
+;
+ 
     loop_
     _array_data_external_data.id
     _array_data_external_data.format
@@ -1715,7 +1743,8 @@ save_array_data_external_data.id
 
     _definition.id                '_array_data_external_data.id'
     _description.text
-;             The value of _array_data_external_data.id must uniquely identify
+;
+             The value of _array_data_external_data.id must uniquely identify
               each item of array_data_external_data.              
 
               This item has been made implicit and given a default value of 1
@@ -1783,7 +1812,8 @@ save_array_data_external_data.variant
 
     _definition.id                '_array_data_external_data.variant'
     _description.text
-;             The value of _array_data_external_data.variant gives the variant
+;
+             The value of _array_data_external_data.variant gives the variant
               to which the given ARRAY_DATA_EXTERNAL_DATA row is related.
 
               If this value is not given, the variant is assumed to be
@@ -1794,9 +1824,10 @@ save_array_data_external_data.variant
 ;
     _name.category_id             array_data_external_data
     _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Word
     _type.ddl2_code               code
@@ -1843,7 +1874,8 @@ save_ARRAY_ELEMENT_SIZE
          '_array_element_size.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
        _array_element_size.array_id
        _array_element_size.index
        _array_element_size.size
@@ -1851,11 +1883,14 @@ save_ARRAY_ELEMENT_SIZE
         image_1   2    1.22e-6
 ;
     _description_example.detail
-;      Example 1. A regular 2D array with a uniform element dimension
+;
+      Example 1. A regular 2D array with a uniform element dimension
                     of 1220 nanometres.
 ;
     _nx_mapping.details
-;    _array_element_size.array_id ARRAYID 
+;
+
+    _array_element_size.array_id ARRAYID 
     _array_element_size.index INDEX   (See _array_element_size.array_id)
     _array_element_size.size SIZE
 
@@ -1871,6 +1906,7 @@ save_ARRAY_ELEMENT_SIZE
             @CBF_array_id="ARRAYID"
     where "?" is "x", "y", "z" for
     _array_element_size.index == 1,2, or 3 respectively
+
 ;
 
     loop_
@@ -1884,7 +1920,8 @@ save_array_element_size.array_id
 
     _definition.id                '_array_element_size.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_element_size
@@ -1902,7 +1939,8 @@ save_array_element_size.index
 
     _definition.id                '_array_element_size.index'
     _description.text
-;             This item is a pointer to _array_structure_list.index in
+;
+             This item is a pointer to _array_structure_list.index in
               the ARRAY_STRUCTURE_LIST category.
 ;
     _name.category_id             array_element_size
@@ -1923,7 +1961,8 @@ save_array_element_size.size
 
     _definition.id                '_array_element_size.size'
     _description.text
-;             The size in metres of an image element in this
+;
+             The size in metres of an image element in this
               dimension. This supposes that the elements are arranged
               on a regular grid.
 ;
@@ -1946,7 +1985,8 @@ save_array_element_size.variant
 
     _definition.id                '_array_element_size.variant'
     _description.text
-;             The value of _array_element_size.variant gives the variant
+;
+             The value of _array_element_size.variant gives the variant
               to which the given ARRAY_ELEMENT_SIZE row is related.
 
               If this value is not given, the variant is assumed to be
@@ -2000,7 +2040,8 @@ save_ARRAY_INTENSITIES
          '_array_intensities.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _array_intensities.array_id
         _array_intensities.linearity
         _array_intensities.gain
@@ -2013,10 +2054,12 @@ save_ARRAY_INTENSITIES
 ;
     _description_example.detail
 ;
-    Example 1
+        Example 1
 ;
     _nx_mapping.details
-;    _array_intensities.array_id ARRAYID
+;
+
+    _array_intensities.array_id ARRAYID
     _array_intensities.binary_id BINARYID
     _array_intensities.details DETAILS
     _array_intensities.gain GAIN
@@ -2082,7 +2125,8 @@ save_array_intensities.array_id
 
     _definition.id                '_array_intensities.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_intensities
@@ -2102,7 +2146,8 @@ save_array_intensities.binary_id
 
     _definition.id                '_array_intensities.binary_id'
     _description.text
-;             This item is a pointer to _array_data.binary_id in the
+;
+             This item is a pointer to _array_data.binary_id in the
               ARRAY_DATA category.
 ;
     _name.category_id             array_intensities
@@ -2124,7 +2169,8 @@ save_array_intensities.details
 
     _definition.id                '_array_intensities.details'
     _description.text
-;             A description of special aspects of the calculation of array 
+;
+             A description of special aspects of the calculation of array 
               intensities.
 ;
     _name.category_id             array_intensities
@@ -2143,7 +2189,8 @@ save_array_intensities.gain
 
     _definition.id                '_array_intensities.gain'
     _description.text
-;             Detector 'gain'. The factor by which linearized
+;
+             Detector 'gain'. The factor by which linearized
               intensity count values should be divided to produce
               true photon counts.
 ;
@@ -2168,7 +2215,8 @@ save_array_intensities.gain_esd
 
     _definition.id                '_array_intensities.gain_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of detector 'gain'.
 ;
     _name.category_id             array_intensities
@@ -2193,7 +2241,8 @@ save_array_intensities.linearity
 
     _definition.id                '_array_intensities.linearity'
     _description.text
-;             The intensity linearity scaling method used to convert
+;
+             The intensity linearity scaling method used to convert
               from the raw intensity to the stored element value:
 
              'linear' is linear.
@@ -2241,19 +2290,23 @@ save_array_intensities.linearity
          linear
              .
          offset
-;            The value defined by  _array_intensities.offset should
+;
+            The value defined by  _array_intensities.offset should
              be added to each element value.
 ;
          scaling
-;            The value defined by _array_intensities.scaling should be
+;
+            The value defined by _array_intensities.scaling should be
              multiplied with each element value.
 ;
          scaling_offset
-;            The combination of the scaling and offset
+;
+            The combination of the scaling and offset
              with the scale factor applied before the offset value.
 ;
          sqrt_scaled
-;            The square root of raw intensities multiplied by
+;
+            The square root of raw intensities multiplied by
              _array_intensities.scaling is calculated and stored,
              perhaps rounded to the nearest integer. Thus,
              linearization involves dividing the stored
@@ -2261,7 +2314,8 @@ save_array_intensities.linearity
              result.
 ;
          logarithmic_scaled
-;            The logarithm base 10 of raw intensities multiplied by
+;
+            The logarithm base 10 of raw intensities multiplied by
              _array_intensities.scaling  is calculated and stored,
              perhaps rounded to the nearest integer. Thus,
              linearization involves dividing the stored values by
@@ -2269,7 +2323,8 @@ save_array_intensities.linearity
              power of this number.
 ;
          raw
-;            The array consists of raw values to which no corrections have
+;
+            The array consists of raw values to which no corrections have
              been applied.  While the handling of the data is similar to
              that given for 'linear' data with no offset, the meaning of
              the data differs in that the number of incident photons is
@@ -2286,7 +2341,8 @@ save_array_intensities.offset
 
     _definition.id                '_array_intensities.offset'
     _description.text
-;             Offset value to add to array element values in the manner
+;
+             Offset value to add to array element values in the manner
               described by the item _array_intensities.linearity.
 ;
     _name.category_id             array_intensities
@@ -2305,7 +2361,8 @@ save_array_intensities.overload
 
     _definition.id                '_array_intensities.overload'
     _description.text
-;             The saturation intensity level for this data array, i.e. the
+;
+             The saturation intensity level for this data array, i.e. the
               value at or above which correct intensities may not be recorded.
 
               The valid pixel values are those less than
@@ -2329,7 +2386,8 @@ save_array_intensities.pixel_binning_method
 
     _definition.id                '_array_intensities.pixel_binning_method'
     _description.text
-;             The value of _array_intensities.pixel_binning_method specifies
+;
+             The value of _array_intensities.pixel_binning_method specifies
               the method used to derive array elements from multiple pixels.
 ;
     _name.category_id             array_intensities
@@ -2345,22 +2403,26 @@ save_array_intensities.pixel_binning_method
       _enumeration_set.state
       _enumeration_set.detail
          hardware
-;              The element intensities were derived from the raw data of one
+;
+              The element intensities were derived from the raw data of one
                or more pixels by use of hardware in the detector, e.g. by use
                of shift registers in a CCD to combine pixels into super-pixels.
 ;
          software
-;              The element intensities were derived from the raw data of more
+;
+              The element intensities were derived from the raw data of more
                than one pixel by use of software.
 ;
          combined
-;              The element intensities were derived from the raw data of more
+;
+              The element intensities were derived from the raw data of more
                than one pixel by use of both hardware and software, as when
                hardware binning is used in one direction and software in the
                other.
 ;
          none
-;              In both directions, the data have not been binned.  The
+;
+              In both directions, the data have not been binned.  The
                number of pixels is equal to the number of elements.
 
                When the value of _array_intensities.pixel_binning_method is
@@ -2368,7 +2430,8 @@ save_array_intensities.pixel_binning_method
                and _array_intensities.pixel_slow_bin_size both must be 1.
 ;
          unspecified
-;              The method used to derive element intensities is not specified.
+;
+              The method used to derive element intensities is not specified.
 ;
 
     _enumeration.default          unspecified
@@ -2379,7 +2442,8 @@ save_array_intensities.pixel_fast_bin_size
 
     _definition.id                '_array_intensities.pixel_fast_bin_size'
     _description.text
-;             The value of _array_intensities.pixel_fast_bin_size specifies
+;
+             The value of _array_intensities.pixel_fast_bin_size specifies
               the number of pixels that compose one element in the direction
               of the most rapidly varying array dimension.
 
@@ -2412,7 +2476,8 @@ save_array_intensities.pixel_slow_bin_size
 
     _definition.id                '_array_intensities.pixel_slow_bin_size'
     _description.text
-;             The value of _array_intensities.pixel_slow_bin_size specifies
+;
+             The value of _array_intensities.pixel_slow_bin_size specifies
               the number of pixels that compose one element in the direction
               of the second most rapidly varying array dimension.
 
@@ -2445,7 +2510,8 @@ save_array_intensities.scaling
 
     _definition.id                '_array_intensities.scaling'
     _description.text
-;             Multiplicative scaling value to be applied to array data
+;
+             Multiplicative scaling value to be applied to array data
               in the manner described by the item
               _array_intensities.linearity.
 ;
@@ -2465,7 +2531,8 @@ save_array_intensities.undefined_value
 
     _definition.id                '_array_intensities.undefined_value'
     _description.text
-;             A value to be substituted for undefined values in
+;
+             A value to be substituted for undefined values in
               the data array.
 ;
     _name.category_id             array_intensities
@@ -2484,7 +2551,8 @@ save_array_intensities.underload
 
     _definition.id                '_array_intensities.underload'
     _description.text
-;             The lowest value at which pixels for this detector are
+;
+             The lowest value at which pixels for this detector are
               measured.
 
               The valid pixel values are those less than 
@@ -2509,7 +2577,8 @@ save_array_intensities.variant
 
     _definition.id                '_array_intensities.variant'
     _description.text
-;             The value of _array_intensities.variant gives the variant
+;
+             The value of _array_intensities.variant gives the variant
               to which the given ARRAY_INTENSITIES row is related.
 
               If this value is not given, the variant is assumed to be
@@ -2551,7 +2620,8 @@ save_ARRAY_STRUCTURE
          '_array_structure.variant'
 
     _description_example.case
-;     loop_
+;
+     loop_
     _array_structure.id
     _array_structure.encoding_type
     _array_structure.compression_type
@@ -2562,16 +2632,16 @@ save_ARRAY_STRUCTURE
     _nx_mapping.details
 ;
     Note that this is essentially a type that may apply to multiple
-    binary images, and corresponds to some of the detailed HDF5
-    information about an array.   The following mapping is a placeholder
-    for the names given for future reference, if needed.
+        binary images, and corresponds to some of the detailed HDF5
+        information about an array.   The following mapping is a placeholder
+        for the names given for future reference, if needed.
 
-    The information in this category is the byte order, the compression
-    information, and the encoding, which is carried in and retrievable
-    from the HDF5 types, properties lists, etc.
+        The information in this category is the byte order, the compression
+        information, and the encoding, which is carried in and retrievable
+        from the HDF5 types, properties lists, etc.
 
-    At present NeXus does not expose this information.  This should be
-    discussed.
+        At present NeXus does not expose this information.  This should be
+        discussed.
 ;
 
     loop_
@@ -2585,7 +2655,8 @@ save_array_structure.byte_order
 
     _definition.id                '_array_structure.byte_order'
     _description.text
-;             The order of bytes for integer values which require more
+;
+             The order of bytes for integer values which require more
               than 1 byte.
 
               (IBM-PCs and compatibles, and DEC VAXs use low-byte-first
@@ -2607,11 +2678,13 @@ save_array_structure.byte_order
       _enumeration_set.state
       _enumeration_set.detail
          big_endian
-;       The first byte in the byte stream of the bytes which make up an
+;
+       The first byte in the byte stream of the bytes which make up an
         integer value is the most significant byte of an integer.
 ;
          little_endian
-;       The last byte in the byte stream of the bytes which make up an
+;
+       The last byte in the byte stream of the bytes which make up an
         integer value is the most significant byte of an integer.
 ;
 
@@ -2621,7 +2694,8 @@ save_array_structure.compression_type
 
     _definition.id                '_array_structure.compression_type'
     _description.text
-;             Type of data-compression method used to compress the array
+;
+             Type of data-compression method used to compress the array
               data.
 ;
     _name.category_id             array_structure
@@ -2637,29 +2711,35 @@ save_array_structure.compression_type
       _enumeration_set.state
       _enumeration_set.detail
          byte_offset
-;       Using the 'byte_offset' compression scheme as per A. Hammersley
+;
+       Using the 'byte_offset' compression scheme as per A. Hammersley
         and the CBFlib manual, section 3.3.3
 ;
          canonical
-;       Using the 'canonical' compression scheme (International Tables
+;
+       Using the 'canonical' compression scheme (International Tables
         for Crystallography Volume G, Section 5.6.3.1) and CBFlib
         manual section 3.3.1
 ;
          nibble_offset
-;       Using the 'nibble_offset' compression scheme as per H. Bernstein
+;
+       Using the 'nibble_offset' compression scheme as per H. Bernstein
         and the CBFlib manual, section 3.3.4
 ;
          none
-;       Data are stored in normal format as defined by
+;
+       Data are stored in normal format as defined by
         _array_structure.encoding_type and
         _array_structure.byte_order.
 ;
          packed
-;       Using the 'packed' compression scheme, a CCP4-style packing
+;
+       Using the 'packed' compression scheme, a CCP4-style packing
         as per J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
          packed_v2
-;       Using the 'packed' compression scheme, version 2, as per
+;
+       Using the 'packed' compression scheme, version 2, as per
         J. P. Abrahams pack_c.c and CBFlib manual, section 3.3.2.
 ;
 
@@ -2671,7 +2751,8 @@ save_array_structure.compression_type_flag
 
     _definition.id                '_array_structure.compression_type_flag'
     _description.text
-;             Flags modifying the type of data-compression method used to 
+;
+             Flags modifying the type of data-compression method used to 
               compress the arraydata.
 ;
     _name.category_id             array_structure
@@ -2687,12 +2768,14 @@ save_array_structure.compression_type_flag
       _enumeration_set.state
       _enumeration_set.detail
          uncorrelated_sections
-;       When applying packed or packed_v2 compression on an array with
+;
+       When applying packed or packed_v2 compression on an array with
         uncorrelated sections, do not average in points from the prior
         section.
 ;
          flat
-;       When applying packed or packed_v2 compression on an array that
+;
+       When applying packed or packed_v2 compression on an array that
         treats the entire image as a single line set the maximum number
         of bits for an offset to 65 bits.
 
@@ -2706,7 +2789,8 @@ save_array_structure.encoding_type
 
     _definition.id                '_array_structure.encoding_type'
     _description.text
-;             Data encoding of a single element of array data.
+;
+             Data encoding of a single element of array data.
 
               The type 'unsigned 1-bit integer' is used for
               packed Boolean arrays for masks.  Each element
@@ -2748,7 +2832,8 @@ save_array_structure.id
 
     _definition.id                '_array_structure.id'
     _description.text
-;             The value of _array_structure.id must uniquely identify
+;
+             The value of _array_structure.id must uniquely identify
               each item of array data.              
 
               This item has been made implicit and given a default value of 1
@@ -2771,7 +2856,8 @@ save_array_structure.variant
 
     _definition.id                '_array_structure.variant'
     _description.text
-;             The value of _array_structure.variant gives the variant
+;
+             The value of _array_structure.variant gives the variant
               to which the given ARRAY_STRUCTURE row is related.
 
               If this value is not given, the variant is assumed to be
@@ -2799,7 +2885,8 @@ save_ARRAY_STRUCTURE_LIST
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;    Data items in the ARRAY_STRUCTURE_LIST category record the size
+;
+    Data items in the ARRAY_STRUCTURE_LIST category record the size
      and organization of each array dimension.
 
      The relationship to physical axes may be given.
@@ -2815,7 +2902,8 @@ save_ARRAY_STRUCTURE_LIST
          '_array_structure_list.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
        _array_structure_list.array_id
        _array_structure_list.index
        _array_structure_list.dimension
@@ -2826,13 +2914,16 @@ save_ARRAY_STRUCTURE_LIST
         image_1   2    1200    2     decreasing  ELEMENY_Y
 ;
     _description_example.detail
-;       Example 1. An image array of 1300 x 1200 elements.  The raster
+;
+       Example 1. An image array of 1300 x 1200 elements.  The raster
                     order of the image is left to right (increasing) in the
                     first dimension and bottom to top (decreasing) in
                     the second dimension.
 ;
     _nx_mapping.details
-;    _array_structure_list.axis_set_id AXISSETID
+;
+
+    _array_structure_list.axis_set_id AXISSETID
     _array_structure_list.array_id ARRAYID
     _array_structure_list.array_section_id ARRAYSECTIONID
     _array_structure_list.dimension DIM
@@ -3009,7 +3100,8 @@ save_array_structure_list.array_id
 
     _definition.id                '_array_structure_list.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list
@@ -3029,7 +3121,8 @@ save_array_structure_list.array_section_id
 
     _definition.id                '_array_structure_list.array_section_id'
     _description.text
-;             This item is a pointer to _array_structure_list_section.id in the
+;
+             This item is a pointer to _array_structure_list_section.id in the
               ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             array_structure_list
@@ -3047,7 +3140,8 @@ save_array_structure_list.axis_set_id
 
     _definition.id                '_array_structure_list.axis_set_id'
     _description.text
-;             This is a descriptor for the physical axis or set of axes
+;
+             This is a descriptor for the physical axis or set of axes
               corresponding to an array index.
 
               This data item is related to the axes of the detector
@@ -3063,9 +3157,10 @@ save_array_structure_list.axis_set_id
 ;
     _name.category_id             array_structure_list
     _name.object_id               axis_set_id
+    _name.linked_item_id          '_array_structure_list_axis.axis_set_id'
     _name.ddl2_mandatory          yes
-    _type.purpose                 Describe
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Word
     _type.ddl2_code               code
@@ -3076,7 +3171,8 @@ save_array_structure_list.dimension
 
     _definition.id                '_array_structure_list.dimension'
     _description.text
-;             The number of elements stored in the array structure in 
+;
+             The number of elements stored in the array structure in 
               this dimension.
 ;
     _name.category_id             array_structure_list
@@ -3102,7 +3198,8 @@ save_array_structure_list.direction
 
     _definition.id                '_array_structure_list.direction'
     _description.text
-;             Identifies the direction in which this array index changes.
+;
+             Identifies the direction in which this array index changes.
 ;
     _name.category_id             array_structure_list
     _name.object_id               direction
@@ -3117,10 +3214,12 @@ save_array_structure_list.direction
       _enumeration_set.state
       _enumeration_set.detail
          increasing
-;       Indicates the index changes from 1 to the maximum dimension.
+;
+       Indicates the index changes from 1 to the maximum dimension.
 ;
          decreasing
-;       Indicates the index changes from the maximum dimension to 1.
+;
+       Indicates the index changes from the maximum dimension to 1.
 ;
 
 save_
@@ -3129,7 +3228,8 @@ save_array_structure_list.index
 
     _definition.id                '_array_structure_list.index'
     _description.text
-;             Identifies the one-based index of the row or column in the
+;
+             Identifies the one-based index of the row or column in the
               array structure.
 ;
     _name.category_id             array_structure_list
@@ -3155,7 +3255,8 @@ save_array_structure_list.precedence
 
     _definition.id                '_array_structure_list.precedence'
     _description.text
-;             Identifies the rank order in which this array index changes
+;
+             Identifies the rank order in which this array index changes
               with respect to other array indices.  The precedence of 1
               indicates the index which changes fastest.
 ;
@@ -3182,7 +3283,8 @@ save_array_structure_list.variant
 
     _definition.id                '_array_structure_list.variant'
     _description.text
-;             The value of _array_structure_list.variant gives the variant
+;
+             The value of _array_structure_list.variant gives the variant
               to which the given ARRAY_STRUCTURE_LIST row is related.
 
               If this value is not given, the variant is assumed to be
@@ -3239,7 +3341,9 @@ save_ARRAY_STRUCTURE_LIST_AXIS
          '_array_structure_list_axis.variant'
 
     _nx_mapping.details
-;    _array_structure_list.axis_set_id AXISSETID
+;
+
+    _array_structure_list.axis_set_id AXISSETID
     _array_structure_list.array_id ARRAYID
     _array_structure_list.array_section_id ARRAYSECTIONID
     _array_structure_list.dimension DIM
@@ -3409,7 +3513,8 @@ save_array_structure_list_axis.angle
 
     _definition.id                '_array_structure_list_axis.angle'
     _description.text
-;             The setting of the specified axis in degrees for the first
+;
+             The setting of the specified axis in degrees for the first
                data point of the array index with the corresponding value
                of _array_structure_list.axis_set_id.  If the index is
                specified as 'increasing', this will be the centre of the
@@ -3435,7 +3540,8 @@ save_array_structure_list_axis.angle_increment
 
     _definition.id                '_array_structure_list_axis.angle_increment'
     _description.text
-;             The pixel-centre-to-pixel-centre increment in the angular
+;
+             The pixel-centre-to-pixel-centre increment in the angular
                setting of the specified axis in degrees.  This is not
                meaningful in the case of 'constant velocity' spiral scans
                and should not be specified for this case.
@@ -3461,7 +3567,8 @@ save_array_structure_list_axis.angular_pitch
 
     _definition.id                '_array_structure_list_axis.angular_pitch'
     _description.text
-;             The pixel-centre-to-pixel-centre distance for a one-step
+;
+             The pixel-centre-to-pixel-centre distance for a one-step
                change in the setting of the specified axis in millimetres.
 
                This is meaningful only for 'constant velocity' spiral scans
@@ -3490,7 +3597,8 @@ save_array_structure_list_axis.axis_id
 
     _definition.id                '_array_structure_list_axis.axis_id'
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes in the set of axes for which settings are being
               specified.
 
@@ -3516,7 +3624,8 @@ save_array_structure_list_axis.axis_set_id
 
     _definition.id                '_array_structure_list_axis.axis_set_id'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
                set of axes for which axis settings are being specified.
 
                Multiple axes may be specified for the same value of
@@ -3531,10 +3640,9 @@ save_array_structure_list_axis.axis_set_id
 ;
     _name.category_id             array_structure_list_axis
     _name.object_id               axis_set_id
-    _name.linked_item_id          '_array_structure_list.axis_set_id'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Link
-    _type.source                  Related
+    _type.purpose                 Key
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
     _type.ddl2_code               code
@@ -3545,7 +3653,8 @@ save_array_structure_list_axis.displacement
 
     _definition.id                '_array_structure_list_axis.displacement'
     _description.text
-;             The setting of the specified axis in millimetres for the first
+;
+             The setting of the specified axis in millimetres for the first
                data point of the array index with the corresponding value
                of _array_structure_list.axis_set_id.  If the index is
                specified as 'increasing', this will be the centre of the
@@ -3572,7 +3681,8 @@ save_array_structure_list_axis.displacement_increment
     _definition.id
         '_array_structure_list_axis.displacement_increment'
     _description.text
-;             The pixel-centre-to-pixel-centre increment for the displacement
+;
+             The pixel-centre-to-pixel-centre increment for the displacement
                setting of the specified axis in millimetres.
 ;
     _name.category_id             array_structure_list_axis
@@ -3594,7 +3704,8 @@ save_array_structure_list_axis.fract_displacement
     _definition.id
         '_array_structure_list_axis.fract_displacement'
     _description.text
-;             The setting of the specified axis as a decimal fraction of 
+;
+             The setting of the specified axis as a decimal fraction of 
                the axis unit vector for the first data point of the array 
                index with the corresponding value of 
                _array_structure_list.axis_set_id.  
@@ -3622,7 +3733,8 @@ save_array_structure_list_axis.fract_displacement_increment
     _definition.id
         '_array_structure_list_axis.fract_displacement_increment'
     _description.text
-;             The pixel-centre-to-pixel-centre increment for the displacement
+;
+             The pixel-centre-to-pixel-centre increment for the displacement
                setting of the specified axis as a decimal fraction of the
                axis unit vector.
 ;
@@ -3644,7 +3756,8 @@ save_array_structure_list_axis.radial_pitch
 
     _definition.id                '_array_structure_list_axis.radial_pitch'
     _description.text
-;             The radial distance from one 'cylinder' of pixels to the
+;
+             The radial distance from one 'cylinder' of pixels to the
                next in millimetres.  If the scan is a 'constant velocity'
                scan with differing angular displacements between pixels,
                the value of this item may differ significantly from the
@@ -3668,7 +3781,8 @@ save_array_structure_list_axis.reference_angle
 
     _definition.id                '_array_structure_list_axis.reference_angle'
     _description.text
-;             The value of _array_structure_list_axis.reference_angle
+;
+             The value of _array_structure_list_axis.reference_angle
                specifies the setting of the angle of this axis used for 
                determining a reference beam centre and a reference detector 
                distance.  It is normally expected to be identical to the 
@@ -3693,7 +3807,8 @@ save_array_structure_list_axis.reference_displacement
     _definition.id
         '_array_structure_list_axis.reference_displacement'
     _description.text
-;             The value of _array_structure_list_axis.reference_displacement
+;
+             The value of _array_structure_list_axis.reference_displacement
                specifies the setting of the displacement of this axis used 
                for determining a reference beam centre and a reference detector
                distance.  It is normally expected to be identical to the value
@@ -3717,7 +3832,8 @@ save_array_structure_list_axis.variant
 
     _definition.id                '_array_structure_list_axis.variant'
     _description.text
-;            The value of _array_structure_list_axis.variant gives the variant
+;
+            The value of _array_structure_list_axis.variant gives the variant
               to which the given ARRAY_STRUCTURE_LIST_AXIS row is related.
 
               If this value is not given, the variant is assumed to be
@@ -3745,7 +3861,8 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
+;
+   Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
     the dimension-by-dimension start, end and stride of each section of an
     array that is to be referenced.
 
@@ -3779,7 +3896,9 @@ save_ARRAY_STRUCTURE_LIST_SECTION
          '_array_structure_list_section.variant'
 
     _description_example.case
-;     loop_
+;
+
+     loop_
     _array_structure_list.array_id
     _array_structure_list.index
     _array_structure_list.dimension
@@ -3800,9 +3919,11 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     "myarray(101:1200,101:1100,1:700:10)"  myarray 1 101 1200   .
     "myarray(101:1200,101:1100,1:700:10)"  myarray 2 101 1100   .
     "myarray(101:1200,101:1100,1:700:10)"  myarray 3   1  700  10
+
 ;
     _description_example.detail
-;       Example 1. An image array, myarray, of 1300 x 1200 elements, and
+;
+       Example 1. An image array, myarray, of 1300 x 1200 elements, and
                     700 frames is defined in ARRAY_STRUCTURE_LIST, and
                     the array section identifier
 
@@ -3814,7 +3935,9 @@ save_ARRAY_STRUCTURE_LIST_SECTION
                     will actually be included is only 691.
 ;
     _nx_mapping.details
-;    _array_structure_list_section.array_id ARRAYID -->
+;
+
+    _array_structure_list_section.array_id ARRAYID -->
     _array_structure_list_section.id SECTIONID -->
     _array_structure_list_section.index INDEX-->
     _array_structure_list_section.end END -->
@@ -3835,6 +3958,7 @@ save_ARRAY_STRUCTURE_LIST_SECTION
              /data_origin=[...] -- the 0-based origins indices of ARRAYSECTIONID
              /data_size=[...] the sizes in pixels of ARRAYSECTIONID
              /data_stride[...] the strides of ARRAYSECTIONID
+
 ;
 
     loop_
@@ -3848,7 +3972,8 @@ save_array_structure_list_section.array_id
 
     _definition.id                '_array_structure_list_section.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             array_structure_list_section
@@ -3868,7 +3993,8 @@ save_array_structure_list_section.end
 
     _definition.id                '_array_structure_list_section.end'
     _description.text
-;             Identifies the ending ordinal, numbered from 1, for an array
+;
+             Identifies the ending ordinal, numbered from 1, for an array
               element of index _array_structure_list_section.index in the
               section.
 
@@ -3904,7 +4030,8 @@ save_array_structure_list_section.id
 
     _definition.id                '_array_structure_list_section.id'
     _description.text
-;             Uniquely identifies the array section chosen.
+;
+             Uniquely identifies the array section chosen.
 
               To avoid confusion array section IDs that contain parentheses
               should conform to the default syntax
@@ -3926,7 +4053,8 @@ save_array_structure_list_section.index
 
     _definition.id                '_array_structure_list_section.index'
     _description.text
-;             This item is a pointer to _array_structure_list.index
+;
+             This item is a pointer to _array_structure_list.index
               in the ARRAY_STRUCTURE_LIST category.
 
               Identifies the one-based index of the row, column, sheet ...
@@ -3955,7 +4083,8 @@ save_array_structure_list_section.start
 
     _definition.id                '_array_structure_list_section.start'
     _description.text
-;             Identifies the starting ordinal, numbered from 1,
+;
+             Identifies the starting ordinal, numbered from 1,
               for an array element of index _array_structure_list_section.index
               in the section.
 
@@ -4001,7 +4130,8 @@ save_array_structure_list_section.stride
 
     _definition.id                '_array_structure_list_section.stride'
     _description.text
-;             Identifies the incremental steps to be taken when moving
+;
+             Identifies the incremental steps to be taken when moving
               element to element in the section in that particular
               dimension.  The value of _array_structure_list_section.stride
               may be positive or negative.  If the stride is zero, the section
@@ -4031,7 +4161,8 @@ save_array_structure_list_section.variant
 
     _definition.id                '_array_structure_list_section.variant'
     _description.text
-;             The value of _array_structure_list_section.variant gives the
+;
+             The value of _array_structure_list_section.variant gives the
               variant to which the given ARRAY_STRUCTURE_LIST_SECTION row
               is related.
 
@@ -4043,9 +4174,10 @@ save_array_structure_list_section.variant
 ;
     _name.category_id             array_structure_list_section
     _name.object_id               variant
+    _name.linked_item_id          '_variant.variant'
     _name.ddl2_mandatory          implicit
-    _type.purpose                 Key
-    _type.source                  Assigned
+    _type.purpose                 Link
+    _type.source                  Related
     _type.container               Single
     _type.contents                Word
     _type.ddl2_code               code
@@ -4059,7 +4191,8 @@ save_AXIS
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;   Data items in the AXIS category record the information required
+;
+   Data items in the AXIS category record the information required
      to describe the various goniometer, detector, source and other
      axes needed to specify a data collection or the axes defining the
      coordinate system of an image.  
@@ -4419,7 +4552,8 @@ save_AXIS
         kappa rotation goniometer omega    -.64279  0       -.76604
         phi   rotation goniometer kappa    1        0        0
 ;
-;      Example 1.
+;
+      Example 1.
 
         This example shows the axis specification of the axes of a
         kappa-geometry goniometer [see Stout, G. H. & Jensen, L. H.
@@ -4450,7 +4584,8 @@ save_AXIS
         roty      rotation    detector twotheta  0     1     0   0 0 -68
         rotz      rotation    detector roty      0     0     1   0 0 -68
 ;
-;      Example 2.
+;
+      Example 2.
 
         This example shows the axis specification of the axes of a
         detector, source and gravity.  The order has been changed as a
@@ -4486,7 +4621,8 @@ save_AXIS
         CELL_B_AXIS 0.01 0.02
         CELL_C_AXIS 0.01 0.02
 ;
-;      Example 3.
+;
+      Example 3.
 
         This example shows the axis specification of the axes for a map,
         using fractional coordinates.  Each cell edge has been divided
@@ -4529,7 +4665,8 @@ save_AXIS
         Y 7.5e-8 1.5e-7
         Z 7.5e-8 1.5e-7
 ;
-;      Example 4.
+;
+      Example 4.
 
         This example shows the axis specification of the axes for a map,
         this time as orthogonal \%angstr\"oms, using the same coordinate system 
@@ -4961,7 +5098,8 @@ save_AXIS
     AXIS_D0Q3S7A1_F translation detector FS_D0Q3S7A1 1 0 0 -10.615000 10.120000 0.0 detector_asic . .
     AXIS_D0Q3S7A1_S translation detector AXIS_D0Q3S7A1_F 0 -1 0 0 0 0.0 detector_asic . .
 ;
-;       Example 5.
+;
+       Example 5.
 
     This example shows an excerpt from the axis specification of an FEL detector
     provided by N. Sauter and A. Brewster.
@@ -5779,7 +5917,8 @@ save_AXIS
                         AXIS_D0Q3S7A1 0 1 0 0 0 0 . .
 
 ;
-;       Example 6.
+;
+       Example 6.
 
     This example shows an excerpt from the axis specification of an FEL detector
     provided by N. Sauter and A. Brewster, using _axis.rotation_axis and
@@ -5818,7 +5957,8 @@ save_AXIS
 ;
 
     _nx_mapping.details
-;    _axis.id                  AXISID
+;
+    _axis.id                  AXISID
     _axis.type                AXISTYPE
     _axis.equipment           AXISEQUIPMENT
     _axis.equipment_component AXISEQUIPCOMP
@@ -5857,6 +5997,7 @@ for AXISEQUIPMENT=="general"}
               @offset=offsetxform([O1,O2,O3])
               @offset_inits="mm"
               @vector=coordxform([V1,V2,V3])
+
 ;
 
     loop_
@@ -5871,7 +6012,8 @@ save_axis.depends_on
 
     _definition.id                '_axis.depends_on'
     _description.text
-;            The value of _axis.depends_on specifies the next outermost
+;
+            The value of _axis.depends_on specifies the next outermost
               axis upon which this axis depends, unless
               _axis.rotation_axis is specified, in which case,
               _axis.rotation_axis is next outermost and
@@ -5894,7 +6036,8 @@ save_axis.equipment
 
     _definition.id                '_axis.equipment'
     _description.text
-;            The value of  _axis.equipment specifies the type of
+;
+            The value of  _axis.equipment specifies the type of
               equipment using the axis:  'goniometer', 'detector',
              'gravity', 'source' or 'general'.
 ;
@@ -5924,7 +6067,8 @@ save_axis.equipment_component
 
     _definition.id                '_axis.equipment_component'
     _description.text
-;            The value of  _axis.equipment_component specifies
+;
+            The value of  _axis.equipment_component specifies
               an arbitrary identifier of a component of the equipment to which
               the axis belongs, such as 'detector_arm' or 'detector_module'.
 
@@ -5944,7 +6088,8 @@ save_axis.id
 
     _definition.id                '_axis.id'
     _description.text
-;            The value of _axis.id must uniquely identify
+;
+            The value of _axis.id must uniquely identify
               each axis relevant to the experiment.  Note that multiple
               pieces of equipment may share the same axis (e.g. a twotheta
               arm), so the category key for AXIS also includes the
@@ -5965,13 +6110,14 @@ save_axis.offset[1]
 
     _definition.id                '_axis.offset[1]'
     _description.text
-;             The [1] element of the three-element vector used to specify
+;
+             The [1] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
 ;
     _name.category_id             axis
-    _name.object_id               'offset[1]'
+    _name.object_id               offset_1_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -5989,13 +6135,14 @@ save_axis.offset[2]
 
     _definition.id                '_axis.offset[2]'
     _description.text
-;             The [2] element of the three-element vector used to specify
+;
+             The [2] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
 ;
     _name.category_id             axis
-    _name.object_id               'offset[2]'
+    _name.object_id               offset_2_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -6013,13 +6160,14 @@ save_axis.offset[3]
 
     _definition.id                '_axis.offset[3]'
     _description.text
-;             The [3] element of the three-element vector used to specify
+;
+             The [3] element of the three-element vector used to specify
                the offset to the base of a rotation or translation axis.
 
                The vector is specified in millimetres.
 ;
     _name.category_id             axis
-    _name.object_id               'offset[3]'
+    _name.object_id               offset_3_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -6037,7 +6185,8 @@ save_axis.rotation
 
     _definition.id                '_axis.rotation'
     _description.text
-;            The value of _axis.rotation specifies
+;
+            The value of _axis.rotation specifies
               the fixed base rotation angle for _axis.rotation_axis
               to which the value of any frame-by-frame setting, if any, should
               be added.  Normally, only the fixed value would be given.
@@ -6060,7 +6209,8 @@ save_axis.rotation_axis
 
     _definition.id                '_axis.rotation_axis'
     _description.text
-;            The value of _axis.rotation_axis specifies
+;
+            The value of _axis.rotation_axis specifies
               an optional additional dependency for this axis to be applied
               after applying _axis.depends_on.
 
@@ -6081,7 +6231,8 @@ save_axis.system
 
     _definition.id                '_axis.system'
     _description.text
-;            The value of  _axis.system specifies the coordinate
+;
+            The value of  _axis.system specifies the coordinate
               system used to define the axis: 'laboratory', 'McStas', 'direct', 
              'orthogonal', 'reciprocal' or 'abstract'.
 ;
@@ -6132,7 +6283,8 @@ save_axis.type
 
     _definition.id                '_axis.type'
     _description.text
-;            The value of _axis.type specifies the type of
+;
+            The value of _axis.type specifies the type of
               axis:  'rotation' or 'translation' (or 'general' when
               the type is not relevant, as for gravity).
 ;
@@ -6160,7 +6312,8 @@ save_axis.variant
 
     _definition.id                '_axis.variant'
     _description.text
-;            The value of _axis.variant gives the variant
+;
+            The value of _axis.variant gives the variant
               to which the given AXIS row is related.
 
               If this value is not given, the variant is assumed to be
@@ -6186,13 +6339,14 @@ save_axis.vector[1]
 
     _definition.id                '_axis.vector[1]'
     _description.text
-;             The [1] element of the three-element vector used to specify
+;
+             The [1] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
 ;
     _name.category_id             axis
-    _name.object_id               'vector[1]'
+    _name.object_id               vector_1_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -6209,13 +6363,14 @@ save_axis.vector[2]
 
     _definition.id                '_axis.vector[2]'
     _description.text
-;             The [2] element of the three-element vector used to specify
+;
+             The [2] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
 ;
     _name.category_id             axis
-    _name.object_id               'vector[2]'
+    _name.object_id               vector_2_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -6232,13 +6387,14 @@ save_axis.vector[3]
 
     _definition.id                '_axis.vector[3]'
     _description.text
-;             The [3] element of the three-element vector used to specify
+;
+             The [3] element of the three-element vector used to specify
                the direction of a rotation or translation axis.
                The vector should be normalized to be a unit vector and
                is dimensionless.
 ;
     _name.category_id             axis
-    _name.object_id               'vector[3]'
+    _name.object_id               vector_3_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -6256,9 +6412,10 @@ save_DIFFRN
     _definition.id                diffrn
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-16
+    _definition.update            2026-05-14
     _description.text
-;              Data items in the DIFFRN category record details about the
+;
+              Data items in the DIFFRN category record details about the
                diffraction data and their measurement.
 
                This is a stub category for the cif_img dicionary to
@@ -6286,7 +6443,8 @@ save_diffrn.id
     _alias.ddl2_version           5.385
     _alias.dictionary_uri         mmcif_pdbx.dic
     _description.text
-;              This data item uniquely identifies a set of diffraction
+;
+              This data item uniquely identifies a set of diffraction
                data.
 ;
     _name.category_id             diffrn
@@ -6306,7 +6464,8 @@ save_DIFFRN_DATA_FRAME
     _definition.scope             Category
     _definition.class             Loop
     _description.text
-;            Data items in the DIFFRN_DATA_FRAME category record
+;
+            Data items in the DIFFRN_DATA_FRAME category record
               the details about each frame of data.
 
               The items in this category were previously in a
@@ -6325,7 +6484,8 @@ save_DIFFRN_DATA_FRAME
          '_diffrn_data_frame.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _diffrn_data_frame.id
         _diffrn_data_frame.detector_element_id
         _diffrn_data_frame.array_id
@@ -6336,7 +6496,8 @@ save_DIFFRN_DATA_FRAME
         frame_1   d1_ccd_4  array_1  4
 ;
     _description_example.detail
-;     Example 1. a frame containing data from four frame elements.
+;
+     Example 1. a frame containing data from four frame elements.
 
                        Each frame element has a common array configuration
                        'array_1' described in ARRAY_STRUCTURE and related
@@ -6346,7 +6507,9 @@ save_DIFFRN_DATA_FRAME
                        binary_id.
 ;
     _nx_mapping.details
-;    _diffrn_data_frame.array_id ARRAYID
+;
+
+    _diffrn_data_frame.array_id ARRAYID
     _diffrn_data_frame.array_section_id SECTIONID
     _diffrn_data_frame.binary_id BINID
     _diffrn_data_frame.center_fast CENF
@@ -6419,9 +6582,10 @@ save_diffrn_data_frame.array_id
     _alias.definition_id          '_diffrn_frame_data.array_id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;            This item is a pointer to _array_structure.id in the
+;
+            This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 ;
     _name.category_id             diffrn_data_frame
@@ -6441,7 +6605,8 @@ save_diffrn_data_frame.array_section_id
 
     _definition.id                '_diffrn_data_frame.array_section_id'
     _description.text
-;            This item is a pointer to _array_structure_list_section.id
+;
+            This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             diffrn_data_frame
@@ -6462,9 +6627,10 @@ save_diffrn_data_frame.binary_id
     _alias.definition_id          '_diffrn_frame_data.binary_id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;            This item is a pointer to _array_data.binary_id in the
+;
+            This item is a pointer to _array_data.binary_id in the
               ARRAY_DATA category.
 ;
     _name.category_id             diffrn_data_frame
@@ -6486,7 +6652,8 @@ save_diffrn_data_frame.center_derived
 
     _definition.id                '_diffrn_data_frame.center_derived'
     _description.text
-;             The value of _diffrn_data_frame.center_derived
+;
+             The value of _diffrn_data_frame.center_derived
               is assumed to be 'yes', i.e. that values of
               _diffrn_data_frame.center_fast and
               _diffrn_data_frame.center_slow 
@@ -6508,7 +6675,8 @@ save_diffrn_data_frame.center_fast
 
     _definition.id                '_diffrn_data_frame.center_fast'
     _description.text
-;            The value of _diffrn_data_frame.center_fast is 
+;
+            The value of _diffrn_data_frame.center_fast is 
               the fast index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_data_frame.center_units along the fast
@@ -6539,7 +6707,8 @@ save_diffrn_data_frame.center_slow
 
     _definition.id                '_diffrn_data_frame.center_slow'
     _description.text
-;             The value of _diffrn_data_frame.center_slow is
+;
+             The value of _diffrn_data_frame.center_slow is
               the slow index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_data_frame.center_units along the slow
@@ -6568,7 +6737,8 @@ save_diffrn_data_frame.center_units
 
     _definition.id                '_diffrn_data_frame.center_units'
     _description.text
-;             The value of _diffrn_data_frame.center_units
+;
+             The value of _diffrn_data_frame.center_units
               specifies the units in which the values of 
               _diffrn_data_frame.center_fast and
               _diffrn_data_frame.center_slow
@@ -6609,9 +6779,13 @@ save_diffrn_data_frame.details
     _alias.definition_id          '_diffrn_frame_data.details'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.4
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri
+;\
+https://github.com/dials/cbflib/raw/refs/heads/main/doc/cif_img_1.4_4Jul06_draft.dic
+;
     _description.text
-;             The value of _diffrn_data_frame.details should give a
+;
+             The value of _diffrn_data_frame.details should give a
               description of special aspects of each frame of data.
 
               This is an appropriate location in which to record
@@ -6660,7 +6834,8 @@ save_diffrn_data_frame.details
     BEAM CENTRE = 157.5 157.5;
 ;
     _description_example.detail
-;              Example of header information extracted from an ADSC Quantum
+;
+              Example of header information extracted from an ADSC Quantum
                315 detector header by CBFlib_0.7.6.  Image provided by Chris
                Nielsen of ADSC from a data collection at SSRL beamline 1-5.
 ;
@@ -6673,9 +6848,10 @@ save_diffrn_data_frame.detector_element_id
     _alias.definition_id          '_diffrn_frame_data.detector_element_id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;             This item is a pointer to _diffrn_detector_element.id
+;
+             This item is a pointer to _diffrn_detector_element.id
               in the DIFFRN_DETECTOR_ELEMENT category.
 ;
     _name.category_id             diffrn_data_frame
@@ -6694,7 +6870,8 @@ save_diffrn_data_frame.diffrn_id
 
     _definition.id                '_diffrn_data_frame.diffrn_id'
     _description.text
-;             This item is a pointer to '_diffrn.id'
+;
+             This item is a pointer to '_diffrn.id'
               in the DIFFRN category.
 ;
     _name.category_id             diffrn_data_frame
@@ -6715,9 +6892,10 @@ save_diffrn_data_frame.id
     _alias.definition_id          '_diffrn_frame_data.id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;             The value of _diffrn_data_frame.id must uniquely identify
+;
+             The value of _diffrn_data_frame.id must uniquely identify
               each complete frame of data.
 ;
     _name.category_id             diffrn_data_frame
@@ -6735,7 +6913,8 @@ save_diffrn_data_frame.variant
 
     _definition.id                '_diffrn_data_frame.variant'
     _description.text
-;             The value of _diffrn_data_frame.variant gives the variant
+;
+             The value of _diffrn_data_frame.variant gives the variant
               to which the given DIFFRN_DATA_FRAME row is related.
 
               If this value is not given, the variant is assumed to be
@@ -6762,7 +6941,7 @@ save_DIFFRN_DETECTOR
     _definition.id                diffrn_detector
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-16
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR category describe the
@@ -6780,16 +6959,20 @@ save_DIFFRN_DETECTOR
          '_diffrn_detector.variant'
 
     _description_example.case
-;    _diffrn_detector.diffrn_id             'd1'
+;
+    _diffrn_detector.diffrn_id             'd1'
     _diffrn_detector.detector              'multiwire'
     _diffrn_detector.type                  'Siemens'
 ;
     _description_example.detail
-;   Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
                 structure corresponding to PDB entry 5HVP.
 ;
     _nx_mapping.details
-;    _diffrn_detector.diffrn_id DIFFRNID 
+;
+
+    _diffrn_detector.diffrn_id DIFFRNID 
     _diffrn_detector.id DETECTORNAME 
     _diffrn_detector.details DETAILS
     _diffrn_detector.detector DETECTOR
@@ -6812,6 +6995,7 @@ save_DIFFRN_DETECTOR
               /number_of_axes=NAXES
               /description="DETTYPE"
               /gain_setting="GAINSETTING"
+
 ;
 
     loop_
@@ -6827,9 +7011,11 @@ save_diffrn_detector.details
     _alias.definition_id          '_diffrn_detector_details'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             A description of special aspects of the radiation detector.
+;
+             A description of special aspects of the radiation detector.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               details
@@ -6852,11 +7038,14 @@ save_diffrn_detector.detector
       _alias.deprecation_date
       _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_radiation_detector'        .        1.0        cifdic.c91
-         '_diffrn_detector'                  .        2.0        cif_core.dic
+         '_diffrn_radiation_detector'                   .                   1.0
+         ftp://ftp.iucr.org/pub/cifdics/cifdic.C91
+         '_diffrn_detector'                             .                   2.0
+         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.dic
 
     _description.text
-;             The general class of the radiation detector.
+;
+             The general class of the radiation detector.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               detector
@@ -6880,7 +7069,8 @@ save_diffrn_detector.diffrn_id
 
     _definition.id                '_diffrn_detector.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in the DIFFRN
+;
+             This data item is a pointer to '_diffrn.id' in the DIFFRN
               category.
 
               The value of _diffrn.id uniquely defines a set of
@@ -6907,11 +7097,14 @@ save_diffrn_detector.dtime
       _alias.deprecation_date
       _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_radiation_detector_dtime'      .      1.0      cifdic.c91
-         '_diffrn_detector_dtime'                .      2.0      cif_core.dic
+         '_diffrn_radiation_detector_dtime'                .                1.0
+         ftp://ftp.iucr.org/pub/cifdics/cifdic.C91
+         '_diffrn_detector_dtime'                          .                2.0
+         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.dic
 
     _description.text
-;             The deadtime in microseconds of the detector(s) used to
+;
+             The deadtime in microseconds of the detector(s) used to
               measure the diffraction intensities.
 ;
     _name.category_id             diffrn_detector
@@ -6938,7 +7131,8 @@ save_diffrn_detector.gain_setting
 
     _definition.id                '_diffrn_detector.gain_setting'
     _description.text
-;             The gain setting for detector.   This is a text string usually
+;
+             The gain setting for detector.   This is a text string usually
               reflecting a detector setting that may have a simple or very
               complex relationship with the value of
               _array_intensities.gain
@@ -6964,7 +7158,8 @@ save_diffrn_detector.id
 
     _definition.id                '_diffrn_detector.id'
     _description.text
-;             The value of _diffrn_detector.id must uniquely identify
+;
+             The value of _diffrn_detector.id must uniquely identify
               each detector used to collect each diffraction data set.
 
               If the value of _diffrn_detector.id is not given, it is
@@ -6986,7 +7181,8 @@ save_diffrn_detector.layer_thickness
 
     _definition.id                '_diffrn_detector.layer_thickness'
     _description.text
-;             The thickness in mm of the sensing layer of the detector
+;
+             The thickness in mm of the sensing layer of the detector
               for use in angular corrections.
 ;
     _name.category_id             diffrn_detector
@@ -7013,7 +7209,8 @@ save_diffrn_detector.number_of_axes
 
     _definition.id                '_diffrn_detector.number_of_axes'
     _description.text
-;             The value of _diffrn_detector.number_of_axes gives the
+;
+             The value of _diffrn_detector.number_of_axes gives the
               number of axes of the positioner for the detector identified
               by _diffrn_detector.id.
 
@@ -7054,9 +7251,11 @@ save_diffrn_detector.type
     _alias.definition_id          '_diffrn_detector_type'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The make, model or name of the detector device used.
+;
+             The make, model or name of the detector device used.
 ;
     _name.category_id             diffrn_detector
     _name.object_id               type
@@ -7073,7 +7272,8 @@ save_diffrn_detector.variant
 
     _definition.id                '_diffrn_detector.variant'
     _description.text
-;             The value of _diffrn_detector.variant gives the variant
+;
+             The value of _diffrn_detector.variant gives the variant
               to which the given DIFFRN_DETECTOR row is related.
 
               If this value is not given, the variant is assumed to be
@@ -7116,7 +7316,9 @@ save_DIFFRN_DETECTOR_AXIS
          '_diffrn_detector_axis.variant'
 
     _nx_mapping.details
-;    _diffrn_detector_axis.axis_id AXISID --> 
+;
+
+    _diffrn_detector_axis.axis_id AXISID --> 
     _diffrn_detector_axis.detector_id DETECTORNAME -->
         /instrument:NXinstrument
          /DETECTORNAME:NXdetector_group
@@ -7139,7 +7341,8 @@ save_diffrn_detector_axis.axis_id
 
     _definition.id                '_diffrn_detector_axis.axis_id'
     _description.text
-;             This data item is a pointer to _axis.id in
+;
+             This data item is a pointer to _axis.id in
                the AXIS category.
 ;
     _name.category_id             diffrn_detector_axis
@@ -7160,9 +7363,10 @@ save_diffrn_detector_axis.detector_id
     _alias.definition_id          '_diffrn_detector_axis.id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;             This data item is a pointer to _diffrn_detector.id in
+;
+             This data item is a pointer to _diffrn_detector.id in
               the DIFFRN_DETECTOR category.
 
               This item was previously named _diffrn_detector_axis.id
@@ -7185,7 +7389,8 @@ save_diffrn_detector_axis.diffrn_id
 
     _definition.id                '_diffrn_detector_axis.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_axis
@@ -7204,7 +7409,8 @@ save_diffrn_detector_axis.id
 
     _definition.id                '_diffrn_detector_axis.id'
     _description.text
-;             This data item is a pointer to _diffrn_detector.id in
+;
+             This data item is a pointer to _diffrn_detector.id in
               the DIFFRN_DETECTOR category.
 
               DEPRECATED -- DO NOT USE
@@ -7224,7 +7430,8 @@ save_diffrn_detector_axis.variant
 
     _definition.id                '_diffrn_detector_axis.variant'
     _description.text
-;            The value of _diffrn_detector_axis.variant gives the variant
+;
+            The value of _diffrn_detector_axis.variant gives the variant
              to which the given DIFFRN_DETECTOR_AXIS row is related.
 
              If this value is not given, the variant is assumed to be
@@ -7273,7 +7480,8 @@ save_DIFFRN_DETECTOR_ELEMENT
          '_diffrn_detector_element.variant'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _diffrn_detector_element.detector_id
         _diffrn_detector_element.id
         _diffrn_detector_element.reference_center_fast
@@ -7285,7 +7493,8 @@ save_DIFFRN_DETECTOR_ELEMENT
         d1     d1_ccd_4  -1.7   -1.5  mm
 ;
     _description_example.detail
-;      Example 1. Detector d1 is composed of four CCD detector elements,
+;
+      Example 1. Detector d1 is composed of four CCD detector elements,
         each 200 mm by 200 mm, arranged in a square, in the pattern
 
                    1     2
@@ -7301,7 +7510,9 @@ save_DIFFRN_DETECTOR_ELEMENT
         top to bottom with the origin at the top left corner.
 ;
     _nx_mapping.details
-;    _diffrn_detector_element.id ELEMENTID
+;
+
+    _diffrn_detector_element.id ELEMENTID
     _diffrn_detector_element.detector_id DETECTORNAME
     _diffrn_detector_element.reference_center_fast RCF
     _diffrn_detector_element.reference_center_slow RCS
@@ -7327,6 +7538,7 @@ save_DIFFRN_DETECTOR_ELEMENT
      inserts RCF into the array of reference centres
      inserts RCS into the array of reference centres
      inserts ELEMENTID into the colon-separated list of units
+
 ;
 
     loop_
@@ -7341,7 +7553,8 @@ save_diffrn_detector_element.center[1]
 
     _definition.id                '_diffrn_detector_element.center[1]'
     _description.text
-;             The value of _diffrn_detector_element.center[1] is the X
+;
+             The value of _diffrn_detector_element.center[1] is the X
               component of the distortion-corrected beam centre in
               millimetres from the (0, 0) (lower-left) corner of the
               detector element viewed from the sample side.
@@ -7361,7 +7574,7 @@ save_diffrn_detector_element.center[1]
 
 ;
     _name.category_id             diffrn_detector_element
-    _name.object_id               'center[1]'
+    _name.object_id               center_1_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -7381,7 +7594,8 @@ save_diffrn_detector_element.center[2]
 
     _definition.id                '_diffrn_detector_element.center[2]'
     _description.text
-;             The value of _diffrn_detector_element.center[2] is the Y
+;
+             The value of _diffrn_detector_element.center[2] is the Y
               component of the distortion-corrected beam centre in
               millimetres from the (0, 0) (lower-left) corner of the
               detector element viewed from the sample side.
@@ -7401,7 +7615,7 @@ save_diffrn_detector_element.center[2]
 
 ;
     _name.category_id             diffrn_detector_element
-    _name.object_id               'center[2]'
+    _name.object_id               center_2_
     _name.ddl2_mandatory          no
     _type.purpose                 Number
     _type.source                  Assigned
@@ -7421,7 +7635,8 @@ save_diffrn_detector_element.detector_id
 
     _definition.id                '_diffrn_detector_element.detector_id'
     _description.text
-;             This item is a pointer to _diffrn_detector.id
+;
+             This item is a pointer to _diffrn_detector.id
               in the DIFFRN_DETECTOR category.
 ;
     _name.category_id             diffrn_detector_element
@@ -7439,7 +7654,8 @@ save_diffrn_detector_element.diffrn_id
 
     _definition.id                '_diffrn_detector_element.diffrn_id'
     _description.text
-;             This item is a pointer to _diffrn.id
+;
+             This item is a pointer to _diffrn.id
               in the DIFFRN category.
 ;
     _name.category_id             diffrn_detector_element
@@ -7458,7 +7674,8 @@ save_diffrn_detector_element.id
 
     _definition.id                '_diffrn_detector_element.id'
     _description.text
-;            The value of _diffrn_detector_element.id must uniquely
+;
+            The value of _diffrn_detector_element.id must uniquely
              identify each element of a detector.
 ;
     _name.category_id             diffrn_detector_element
@@ -7477,7 +7694,8 @@ save_diffrn_detector_element.reference_center_fast
     _definition.id
         '_diffrn_detector_element.reference_center_fast'
     _description.text
-;             The value of _diffrn_detector_element.reference_center_fast is 
+;
+             The value of _diffrn_detector_element.reference_center_fast is 
               the fast index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_detector_element.reference_center_units along the fast
@@ -7512,7 +7730,8 @@ save_diffrn_detector_element.reference_center_slow
     _definition.id
         '_diffrn_detector_element.reference_center_slow'
     _description.text
-;             The value of _diffrn_detector_element.reference_center_slow is
+;
+             The value of _diffrn_detector_element.reference_center_slow is
               the slow index axis beam centre position relative to the detector
               element face in the units specified in the data item
               _diffrn_detector_element.reference_center_units along the slow
@@ -7545,7 +7764,8 @@ save_diffrn_detector_element.reference_center_units
     _definition.id
         '_diffrn_detector_element.reference_center_units'
     _description.text
-;             The value of _diffrn_detector_element.reference_center_units
+;
+             The value of _diffrn_detector_element.reference_center_units
               specifies the units in which the values of 
               _diffrn_detector_element.reference_center_fast and
               _diffrn_detector_element.reference_center_slow
@@ -7584,7 +7804,8 @@ save_diffrn_detector_element.variant
 
     _definition.id                '_diffrn_detector_element.variant'
     _description.text
-;             The value of _diffrn_detector_element.variant gives the variant
+;
+             The value of _diffrn_detector_element.variant gives the variant
               to which the given DIFFRN_DETECTOR_ELEMENT row is related.
 
               If this value is not given, the variant is assumed to be
@@ -7646,7 +7867,7 @@ save_DIFFRN_FRAME_DATA
 
     _description_example.case
 ;
-    # EXAMPLE REMOVED #
+       # EXAMPLE REMOVED #
 ;
     _description_example.detail
 ;
@@ -7664,7 +7885,8 @@ save_diffrn_frame_data.array_id
 
     _definition.id                '_diffrn_frame_data.array_id'
     _description.text
-;             This item is a pointer to _array_structure.id in the
+;
+             This item is a pointer to _array_structure.id in the
               ARRAY_STRUCTURE category.
 
               DEPRECATED -- DO NOT USE
@@ -7686,7 +7908,8 @@ save_diffrn_frame_data.binary_id
 
     _definition.id                '_diffrn_frame_data.binary_id'
     _description.text
-;             This item is a pointer to _array_data.binary_id in the
+;
+             This item is a pointer to _array_data.binary_id in the
               ARRAY_STRUCTURE category.
 
               DEPRECATED -- DO NOT USE
@@ -7709,7 +7932,8 @@ save_diffrn_frame_data.details
 
     _definition.id                '_diffrn_frame_data.details'
     _description.text
-;             The value of _diffrn_frame_data.details should give a
+;
+             The value of _diffrn_frame_data.details should give a
               description of special aspects of each frame of data.
 
               DEPRECATED -- DO NOT USE
@@ -7731,7 +7955,8 @@ save_diffrn_frame_data.detector_element_id
 
     _definition.id                '_diffrn_frame_data.detector_element_id'
     _description.text
-;             This item is a pointer to _diffrn_detector_element.id
+;
+             This item is a pointer to _diffrn_detector_element.id
               in the DIFFRN_DETECTOR_ELEMENT category.
 
               DEPRECATED -- DO NOT USE
@@ -7753,7 +7978,8 @@ save_diffrn_frame_data.id
 
     _definition.id                '_diffrn_frame_data.id'
     _description.text
-;             The value of _diffrn_frame_data.id must uniquely identify
+;
+             The value of _diffrn_frame_data.id must uniquely identify
               each complete frame of data.
 
               DEPRECATED -- DO NOT USE
@@ -7776,7 +8002,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id                diffrn_measurement
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-16
+    _definition.update            2026-05-14
     _description.text
 ;
     Data items in the DIFFRN_MEASUREMENT category record details
@@ -7809,7 +8035,8 @@ save_DIFFRN_MEASUREMENT
       detector angle 22.5 degrees
     ;
 ;
-;    Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+    Example 1. based on PDB entry 5HVP and laboratory records for the
                  structure corresponding to PDB entry 5HVP
 ;
 ;
@@ -7817,12 +8044,15 @@ save_DIFFRN_MEASUREMENT
     _diffrn_measurement.device_type     'Philips PW1100/20 diffractometer'
     _diffrn_measurement.method          'theta/2theta (\q/2\q)'
 ;
-;     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+;
+     Example 2. based on data set TOZ of Willis, Beckwith & Tozer
                   [Acta Cryst. (1991), C47, 2276-2277].
 ;
 
     _nx_mapping.details
-;    _diffrn_measurement.diffrn_id DIFFRNID
+;
+
+    _diffrn_measurement.diffrn_id DIFFRNID
     _diffrn_measurement.details DETAILS
     _diffrn_measurement.device DEVICE
     _diffrn_measurement.device_details DEVDETAILS
@@ -7870,9 +8100,11 @@ save_diffrn_measurement.details
     _alias.definition_id          '_diffrn_measurement_details'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             A description of special aspects of the intensity
+;
+             A description of special aspects of the intensity
               measurement.
 ;
     _name.category_id             diffrn_measurement
@@ -7884,7 +8116,8 @@ save_diffrn_measurement.details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;                                 440 frames, 0.20 degrees, 150 sec, detector
+;
+                                 440 frames, 0.20 degrees, 150 sec, detector
                                   distance 12 cm, detector angle 22.5 degrees
 ;
 
@@ -7896,9 +8129,11 @@ save_diffrn_measurement.device
     _alias.definition_id          '_diffrn_measurement_device'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The general class of goniometer or device used to support
+;
+             The general class of goniometer or device used to support
               and orient the specimen.
 
               If the value of _diffrn_measurement.device is not given,
@@ -7936,9 +8171,11 @@ save_diffrn_measurement.device_details
     _alias.definition_id          '_diffrn_measurement_device_details'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             A description of special aspects of the device used to
+;
+             A description of special aspects of the device used to
               measure the diffraction intensities.
 ;
     _name.category_id             diffrn_measurement
@@ -7950,7 +8187,8 @@ save_diffrn_measurement.device_details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;                                 commercial goniometer modified locally to
+;
+                                 commercial goniometer modified locally to
                                   allow for 90\% \t arc
 ;
 
@@ -7962,9 +8200,11 @@ save_diffrn_measurement.device_type
     _alias.definition_id          '_diffrn_measurement_device_type'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The make, model or name of the measurement device
+;
+             The make, model or name of the measurement device
               (goniometer) used.
 ;
     _name.category_id             diffrn_measurement
@@ -7989,7 +8229,8 @@ save_diffrn_measurement.diffrn_id
 
     _definition.id                '_diffrn_measurement.diffrn_id'
     _description.text
-;             This data item is a pointer to _diffrn.id in the DIFFRN
+;
+             This data item is a pointer to _diffrn.id in the DIFFRN
               category.
 ;
     _name.category_id             diffrn_measurement
@@ -8008,7 +8249,8 @@ save_diffrn_measurement.id
 
     _definition.id                '_diffrn_measurement.id'
     _description.text
-;             The value of _diffrn_measurement.id must uniquely identify
+;
+             The value of _diffrn_measurement.id must uniquely identify
               the set of mechanical characteristics of the device used to
               orient and/or position the sample used during the collection
               of each diffraction data set.
@@ -8040,9 +8282,11 @@ save_diffrn_measurement.method
     _alias.definition_id          '_diffrn_measurement_method'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             Method used to measure intensities.
+;
+             Method used to measure intensities.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               method
@@ -8061,7 +8305,8 @@ save_diffrn_measurement.number_of_axes
 
     _definition.id                '_diffrn_measurement.number_of_axes'
     _description.text
-;             The value of _diffrn_measurement.number_of_axes gives the
+;
+             The value of _diffrn_measurement.number_of_axes gives the
               number of axes of the positioner for the goniometer or
               other sample orientation or positioning device identified
               by _diffrn_measurement.id.
@@ -8092,7 +8337,8 @@ save_diffrn_measurement.sample_detector_distance
 
     _definition.id                '_diffrn_measurement.sample_detector_distance'
     _description.text
-;             The value of _diffrn_measurement.sample_detector_distance gives
+;
+             The value of _diffrn_measurement.sample_detector_distance gives
               the unsigned distance in millimetres from the sample to the 
               detector along the beam.  Normally this distance is derived
               from the axis settings.
@@ -8117,7 +8363,8 @@ save_diffrn_measurement.sample_detector_distance_derived
     _definition.id
         '_diffrn_measurement.sample_detector_distance_derived'
     _description.text
-;             The value of _diffrn_measurement.sample_detector_distance_derived
+;
+             The value of _diffrn_measurement.sample_detector_distance_derived
               is assumed to be 'yes', i.e. that value of 
               _diffrn_measurement.sample_detector_distance
               is derived from the axis settings rather than measured.               
@@ -8138,7 +8385,8 @@ save_diffrn_measurement.sample_detector_voffset
 
     _definition.id                '_diffrn_measurement.sample_detector_voffset'
     _description.text
-;             The value of _diffrn_measurement.sample_detector_voffset gives
+;
+             The value of _diffrn_measurement.sample_detector_voffset gives
               the signed distance in millimetres in the vertical
               direction (positive for up) from the centre of
               the beam to the centre of the detector. 
@@ -8152,10 +8400,7 @@ save_diffrn_measurement.sample_detector_voffset
     _type.contents                Real
     _type.ddl2_code               float
     _type.ddl2_units              millimetres
-    _enumeration.range            :
     _units.code                   millimetres
-    _ddl2_enumeration_range.minimum .
-    _ddl2_enumeration_range.maximum .
 
 save_
 
@@ -8165,9 +8410,11 @@ save_diffrn_measurement.specimen_support
     _alias.definition_id          '_diffrn_measurement_specimen_support'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The physical device used to support the crystal during data
+;
+             The physical device used to support the crystal during data
               collection.
 ;
     _name.category_id             diffrn_measurement
@@ -8192,7 +8439,8 @@ save_diffrn_measurement.variant
 
     _definition.id                '_diffrn_measurement.variant'
     _description.text
-;            The value of _diffrn_measurement.variant gives the variant
+;
+            The value of _diffrn_measurement.variant gives the variant
              to which the given DIFFRN_MEASUREMENT row is related.
 
              If this value is not given, the variant is assumed to be
@@ -8236,7 +8484,9 @@ save_DIFFRN_MEASUREMENT_AXIS
          '_diffrn_measurement_axis.variant'
 
     _nx_mapping.details
-;    _diffrn_measurement_axis.axis_id AXISID
+;
+
+    _diffrn_measurement_axis.axis_id AXISID
     _diffrn_measurement_axis.measurement_device DEVICE
     _diffrn_measurement_axis.measurement_id GONIOMETER
 
@@ -8264,7 +8514,8 @@ save_diffrn_measurement_axis.axis_id
 
     _definition.id                '_diffrn_measurement_axis.axis_id'
     _description.text
-;             This data item is a pointer to _axis.id in
+;
+             This data item is a pointer to _axis.id in
               the AXIS category.
 ;
     _name.category_id             diffrn_measurement_axis
@@ -8297,7 +8548,8 @@ save_diffrn_measurement_axis.id
 
     _definition.id                '_diffrn_measurement_axis.id'
     _description.text
-;             This data item is a pointer to _diffrn_measurement.id in
+;
+             This data item is a pointer to _diffrn_measurement.id in
               the DIFFRN_MEASUREMENT category.
 
               DEPRECATED -- DO NOT USE
@@ -8319,7 +8571,8 @@ save_diffrn_measurement_axis.measurement_device
 
     _definition.id                '_diffrn_measurement_axis.measurement_device'
     _description.text
-;             This data item is a pointer to _diffrn_measurement.device
+;
+             This data item is a pointer to _diffrn_measurement.device
               in the DIFFRN_MEASUREMENT category.
 ;
     _name.category_id             diffrn_measurement_axis
@@ -8340,9 +8593,10 @@ save_diffrn_measurement_axis.measurement_id
     _alias.definition_id          '_diffrn_measurement_axis.id'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.0
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri         ftp://ftp.iucr.org/pub/cifdics/cif_img_1.0.dic
     _description.text
-;             This data item is a pointer to _diffrn_measurement.id in
+;
+             This data item is a pointer to _diffrn_measurement.id in
               the DIFFRN_MEASUREMENT category.
 
               This item was previously named _diffrn_measurement_axis.id,
@@ -8365,7 +8619,8 @@ save_diffrn_measurement_axis.variant
 
     _definition.id                '_diffrn_measurement_axis.variant'
     _description.text
-;             The value of _diffrn_measurement_axis.variant gives the variant
+;
+             The value of _diffrn_measurement_axis.variant gives the variant
               to which the given DIFFRN_MEASUREMENT_AXIS row is related.
 
               If this value is not given, the variant is assumed to be
@@ -8392,9 +8647,10 @@ save_DIFFRN_RADIATION
     _definition.id                diffrn_radiation
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-16
+    _definition.update            2026-05-14
     _description.text
-;             Data items in the DIFFRN_RADIATION category describe
+;
+             Data items in the DIFFRN_RADIATION category describe
               the radiation used for measuring diffraction intensities,
               its collimation and monochromatization before the sample.
 
@@ -8421,7 +8677,8 @@ save_DIFFRN_RADIATION
     _diffrn_radiation.type                 'Cu K\a'
     _diffrn_radiation.wavelength_id         1
 ;
-;   Example 1. based on PDB entry 5HVP and laboratory records for the
+;
+   Example 1. based on PDB entry 5HVP and laboratory records for the
                 structure corresponding to PDB entry 5HVP
 ;
 ;
@@ -8429,12 +8686,15 @@ save_DIFFRN_RADIATION
     _diffrn_radiation.type             'Cu K\a'
     _diffrn_radiation.monochromator    'graphite'
 ;
-;    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
+;
+    Example 2. based on data set TOZ of Willis, Beckwith & Tozer
                 [Acta Cryst. (1991), C47, 2276-2277].
 ;
 
     _nx_mapping.details
-;    _diffrn_radiation.collimation    COLLIMATION
+;
+
+    _diffrn_radiation.collimation    COLLIMATION
     _diffrn_radiation.diffrn_id      DIFFRNID
     _diffrn_radiation.div_x_source   DIVX
     _diffrn_radiation.div_y_source   DIVY
@@ -8521,6 +8781,7 @@ save_DIFFRN_RADIATION
              /CBF_diffrn_radiation__xray_symbol="IUPACXRAYSYMB"
 
          With the incident_polarisation_stokes array indexed by FRAMENO
+
 ;
 
     loop_
@@ -8534,7 +8795,8 @@ save_diffrn_radiation.beam_flux
 
     _definition.id                '_diffrn_radiation.beam_flux'
     _description.text
-;             The instantaneous flux spacially integrated over the portion
+;
+             The instantaneous flux spacially integrated over the portion
               of the beam available to be incident on a sample (e.g. after 
               collimation).  If the flux varies over the course of the 
               experiment, the average over the time of the experiment should 
@@ -8548,8 +8810,8 @@ save_diffrn_radiation.beam_flux
     _type.container               Single
     _type.contents                Real
     _type.ddl2_code               float
-    _type.ddl2_units              photons_per_second'
-    _units.code                   photons_per_second'
+    _type.ddl2_units              photons_per_second
+    _units.code                   photons_per_second
 
 save_
 
@@ -8557,7 +8819,8 @@ save_diffrn_radiation.beam_flux_density
 
     _definition.id                '_diffrn_radiation.beam_flux_density'
     _description.text
-;             The instantaneous flux per unit area orhtogonal to the beam.
+;
+             The instantaneous flux per unit area orhtogonal to the beam.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               beam_flux_density
@@ -8577,7 +8840,8 @@ save_diffrn_radiation.beam_flux_density_integrated
     _definition.id
         '_diffrn_radiation.beam_flux_density_integrated'
     _description.text
-;             The time integral of the flux density.  The time over 
+;
+             The time integral of the flux density.  The time over 
               which the beam flux density is integrated is given in 
               _diffrn_radiation.beam_flux_integration_time
 ;
@@ -8598,7 +8862,8 @@ save_diffrn_radiation.beam_flux_integrated
 
     _definition.id                '_diffrn_radiation.beam_flux_integrated'
     _description.text
-;             The time integral of the flux spacially integrated over the 
+;
+             The time integral of the flux spacially integrated over the 
               portion of the beam available to be incident on a sample 
               (e.g. after collimation).  The time over which the beam flux
               is integrated is given in 
@@ -8621,7 +8886,8 @@ save_diffrn_radiation.beam_flux_integration_time
 
     _definition.id                '_diffrn_radiation.beam_flux_integration_time'
     _description.text
-;             The time interval over which beam flux, beam incident flux
+;
+             The time interval over which beam flux, beam incident flux
               beam density is integrated.  
 ;
     _name.category_id             diffrn_radiation
@@ -8641,7 +8907,8 @@ save_diffrn_radiation.beam_incident_flux
 
     _definition.id                '_diffrn_radiation.beam_incident_flux'
     _description.text
-;             The instantaneous flux spacially integrated over the portion of 
+;
+             The instantaneous flux spacially integrated over the portion of 
               the beam actually incident on the sample.  If the incident flux 
               varies over the course of the experiment, the average over the 
               time of the experiment should be reported.
@@ -8664,7 +8931,8 @@ save_diffrn_radiation.beam_incident_flux_integrated
     _definition.id
         '_diffrn_radiation.beam_incident_flux_integrated'
     _description.text
-;             The time integral of the flux spacially integrated over the
+;
+             The time integral of the flux spacially integrated over the
               portion of the beam actually incident on the sample.  The 
               time over which the beam flux is integrated is given in
 
@@ -8687,7 +8955,8 @@ save_diffrn_radiation.beam_width
 
     _definition.id                '_diffrn_radiation.beam_width'
     _description.text
-;             Full width at half maximum of the beam incident on the sample
+;
+             Full width at half maximum of the beam incident on the sample
               in the plane of polarization (or horizontally if unpolarized).
 ;
     _name.category_id             diffrn_radiation
@@ -8709,9 +8978,11 @@ save_diffrn_radiation.collimation
     _alias.definition_id          '_diffrn_radiation_collimation'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The collimation or focusing applied to the radiation.
+;
+             The collimation or focusing applied to the radiation.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               collimation
@@ -8734,7 +9005,8 @@ save_diffrn_radiation.diffrn_id
 
     _definition.id                '_diffrn_radiation.diffrn_id'
     _description.text
-;             This data item is a pointer to _diffrn.id in the DIFFRN
+;
+             This data item is a pointer to _diffrn.id in the DIFFRN
               category.
 ;
     _name.category_id             diffrn_radiation
@@ -8753,7 +9025,8 @@ save_diffrn_radiation.div_x_source
 
     _definition.id                '_diffrn_radiation.div_x_source'
     _description.text
-;             Beam crossfire in degrees parallel to the laboratory X axis
+;
+             Beam crossfire in degrees parallel to the laboratory X axis
               (see AXIS category).
 
               This is a characteristic of the X-ray beam as it illuminates
@@ -8786,7 +9059,8 @@ save_diffrn_radiation.div_x_y_source
 
     _definition.id                '_diffrn_radiation.div_x_y_source'
     _description.text
-;             Beam crossfire correlation in degrees squared between the
+;
+             Beam crossfire correlation in degrees squared between the
               crossfire laboratory X-axis component and the crossfire
               laboratory Y-axis component (see AXIS category).
 
@@ -8823,7 +9097,8 @@ save_diffrn_radiation.div_y_source
 
     _definition.id                '_diffrn_radiation.div_y_source'
     _description.text
-;             Beam crossfire in degrees parallel to the laboratory Y axis
+;
+             Beam crossfire in degrees parallel to the laboratory Y axis
               (see AXIS category).
 
               This is a characteristic of the X-ray beam as it illuminates
@@ -8859,9 +9134,11 @@ save_diffrn_radiation.filter_edge
     _alias.definition_id          '_diffrn_radiation_filter_edge'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;              Absorption edge in \%angstr\"oms of the radiation filter used.
+;
+              Absorption edge in \%angstr\"oms of the radiation filter used.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               filter_edge
@@ -8889,9 +9166,11 @@ save_diffrn_radiation.inhomogeneity
     _alias.definition_id          '_diffrn_radiation_inhomogeneity'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             Half-width in millimetres of the incident beam in the
+;
+             Half-width in millimetres of the incident beam in the
               direction perpendicular to the diffraction plane.
 ;
     _name.category_id             diffrn_radiation
@@ -8920,9 +9199,11 @@ save_diffrn_radiation.monochromator
     _alias.definition_id          '_diffrn_radiation_monochromator'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The method used to obtain monochromatic radiation. If a
+;
+             The method used to obtain monochromatic radiation. If a
               monochromator crystal is used, the material and the
               indices of the Bragg reflection are specified.
 ;
@@ -8950,9 +9231,11 @@ save_diffrn_radiation.polarisn_norm
     _alias.definition_id          '_diffrn_radiation_polarisn_norm'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The angle in degrees, as viewed from the specimen, between the
+;
+             The angle in degrees, as viewed from the specimen, between the
               perpendicular component of the polarization and the diffraction
               plane. See _diffrn_radiation_polarisn_ratio.
 ;
@@ -8981,7 +9264,8 @@ save_diffrn_radiation.polarisn_norm_esd
 
     _definition.id                '_diffrn_radiation.polarisn_norm_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.) of
               _diffrn_radiation.polarisn_norm,
               the angle in degrees, as viewed from the specimen, between the
               perpendicular component of the polarization and the diffraction
@@ -9016,9 +9300,11 @@ save_diffrn_radiation.polarisn_ratio
     _alias.definition_id          '_diffrn_radiation_polarisn_ratio'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             Polarization ratio of the diffraction beam incident on the
+;
+             Polarization ratio of the diffraction beam incident on the
               crystal. This is the ratio of the perpendicularly polarized to
               the parallel polarized component of the radiation. The
               perpendicular component forms an angle of
@@ -9049,7 +9335,8 @@ save_diffrn_radiation.polarisn_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarisn_ratio_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.) of
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.) of
               _diffrn_radiation.polarisn_ratio,
               the polarization ratio of the diffraction beam incident on the
               crystal. 
@@ -9080,7 +9367,8 @@ save_diffrn_radiation.polarizn_source_norm
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm'
     _description.text
-;             The angle in degrees, as viewed from the specimen, between
+;
+             The angle in degrees, as viewed from the specimen, between
               the normal to the polarization plane and the laboratory
               Y-axis as defined in the AXIS category.
 
@@ -9127,7 +9415,8 @@ save_diffrn_radiation.polarizn_source_norm_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_norm_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_source_norm,
               the angle in degrees, as viewed from the specimen, between
               the normal to the polarization plane and the laboratory
@@ -9160,7 +9449,8 @@ save_diffrn_radiation.polarizn_source_ratio
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio'
     _description.text
-;             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
+;
+             The quantity (Ip-In)/(Ip+In), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared)
               of the electric vector in the plane of the normal to the
@@ -9222,7 +9512,8 @@ save_diffrn_radiation.polarizn_source_ratio_esd
 
     _definition.id                '_diffrn_radiation.polarizn_source_ratio_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_source_ratio,
               (Ip-In)/(Ip+In), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -9256,7 +9547,8 @@ save_diffrn_radiation.polarizn_stokes_i
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I'
     _description.text
-;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+;
+             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
               squared) of the electric vector in the plane of polarization,
               In is the intensity (amplitude squared) of the electric vector
               in the plane of the normal to the plane of polarization,
@@ -9307,7 +9599,8 @@ save_diffrn_radiation.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_I_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_I,
               Ip+In+Inp, where Ip is the intensity (amplitude squared)
               of the electric vector in the plane of polarization,
@@ -9342,7 +9635,8 @@ save_diffrn_radiation.polarizn_stokes_q
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q'
     _description.text
-;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -9384,7 +9678,8 @@ save_diffrn_radiation.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_Q_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_Q,
               (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -9421,7 +9716,8 @@ save_diffrn_radiation.polarizn_stokes_u
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U'
     _description.text
-;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -9463,7 +9759,8 @@ save_diffrn_radiation.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_U_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_U,
               (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -9500,7 +9797,8 @@ save_diffrn_radiation.polarizn_stokes_v
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V'
     _description.text
-;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+;
+             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
               circular polarization, where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared) of
@@ -9543,7 +9841,8 @@ save_diffrn_radiation.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_radiation.polarizn_Stokes_V_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_radiation.polarizn_Stokes_V,
               +/-2*sqrt(IpIn), with a + sign for right-handed circular
               polarization, where Ip is the intensity
@@ -9583,9 +9882,11 @@ save_diffrn_radiation.probe
     _alias.definition_id          '_diffrn_radiation_probe'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             Name of the type of radiation used. It is strongly
+;
+             Name of the type of radiation used. It is strongly
               recommended that this be given so that the
               probe radiation is clearly specified.
 ;
@@ -9613,9 +9914,11 @@ save_diffrn_radiation.type
     _alias.definition_id          '_diffrn_radiation_type'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The nature of the radiation. This is typically a description
+;
+             The nature of the radiation. This is typically a description
               of the X-ray wavelength in Siegbahn notation.
 ;
     _name.category_id             diffrn_radiation
@@ -9640,7 +9943,8 @@ save_diffrn_radiation.variant
 
     _definition.id                '_diffrn_radiation.variant'
     _description.text
-;             The value of _diffrn_radiation.variant gives the variant
+;
+             The value of _diffrn_radiation.variant gives the variant
               to which the given DIFFRN_RADIATION row is related.
 
               If this value is not given, the variant is assumed to be
@@ -9666,7 +9970,8 @@ save_diffrn_radiation.wavelength_id
 
     _definition.id                '_diffrn_radiation.wavelength_id'
     _description.text
-;             This data item is a pointer to
+;
+             This data item is a pointer to
               _diffrn_radiation_wavelength.id in the
               DIFFRN_RADIATION_WAVELENGTH category.
 ;
@@ -9687,9 +9992,11 @@ save_diffrn_radiation.xray_symbol
     _alias.definition_id          '_diffrn_radiation_xray_symbol'
     _alias.deprecation_date       .
     _alias.ddl2_version           2.0.1
-    _alias.dictionary_uri         cif_core.dic
+    _alias.dictionary_uri
+        ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
     _description.text
-;             The IUPAC symbol for the X-ray wavelength for the probe
+;
+             The IUPAC symbol for the X-ray wavelength for the probe
               radiation.
 ;
     _name.category_id             diffrn_radiation
@@ -9760,7 +10067,8 @@ save_diffrn_refln.diffrn_id
 
     _definition.id                '_diffrn_refln.diffrn_id'
     _description.text
-;             This item is a placeholder for the definition in the
+;
+             This item is a placeholder for the definition in the
               PDBx/mmCIF dictionary
 ;
     _name.category_id             diffrn_refln
@@ -9779,7 +10087,8 @@ save_diffrn_refln.frame_id
 
     _definition.id                '_diffrn_refln.frame_id'
     _description.text
-;             This item is a pointer to _diffrn_data_frame.id
+;
+             This item is a pointer to _diffrn_data_frame.id
               in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_refln
@@ -9798,7 +10107,8 @@ save_diffrn_refln.id
 
     _definition.id                '_diffrn_refln.id'
     _description.text
-;             This item is a placeholder for the definition in the
+;
+             This item is a placeholder for the definition in the
               PDBx/mmCIF dictionary.
 ;
     _name.category_id             diffrn_refln
@@ -9816,7 +10126,8 @@ save_diffrn_refln.variant
 
     _definition.id                '_diffrn_refln.variant'
     _description.text
-;             The value of _diffrn_refln.variant gives the variant
+;
+             The value of _diffrn_refln.variant gives the variant
               to which the given DIFFRN_REFLN row is related.
 
               If this value is not given, the variant is assumed to be
@@ -9950,7 +10261,8 @@ save_DIFFRN_SCAN
          is data that can be estimated at the same time, and *.date_end which
          can only be logged exactly if the data collection completes normally.
 ;
-;    ###CBF: VERSION 1.1
+;
+    ###CBF: VERSION 1.1
 
      data_image_1
 
@@ -10202,7 +10514,8 @@ save_DIFFRN_SCAN
           are 0.150mm x 0.150mm, the centre of the first pixel is at (0.075,
           0.075) in this coordinate system.
 ;
-;    ###CBF: VERSION 1.1
+;
+    ###CBF: VERSION 1.1
 
      data_image_1
 
@@ -10457,7 +10770,8 @@ save_DIFFRN_SCAN
 ;
 
     _nx_mapping.details
-;    _diffrn_scan.id SCANID
+;
+    _diffrn_scan.id SCANID
     _diffrn_scan.date_end ENDDATETIME
     _diffrn_scan.date_end_estimated ENDDATETIMEEST
     _diffrn_scan.date_start STARTDATETIME
@@ -10504,7 +10818,8 @@ save_diffrn_scan.date_end
 
     _definition.id                '_diffrn_scan.date_end'
     _description.text
-;             The date and time of the end of the scan.  Note that this
+;
+             The date and time of the end of the scan.  Note that this
               may be an estimate generated during the scan, before the
               precise time of the end of the scan is known, in which
               case _diffrn_scan.date_end_estimated should be used instead.
@@ -10524,7 +10839,8 @@ save_diffrn_scan.date_end_estimated
 
     _definition.id                '_diffrn_scan.date_end_estimated'
     _description.text
-;             The estimated date and time of the end of the scan.  Note 
+;
+             The estimated date and time of the end of the scan.  Note 
               that this may be generated at the start or during the scan,
               before the precise time of the end of the scan is known.
 ;
@@ -10543,7 +10859,8 @@ save_diffrn_scan.date_start
 
     _definition.id                '_diffrn_scan.date_start'
     _description.text
-;             The date and time of the start of the scan.
+;
+             The date and time of the start of the scan.
 ;
     _name.category_id             diffrn_scan
     _name.object_id               date_start
@@ -10574,7 +10891,8 @@ save_diffrn_scan.frame_id_end
 
     _definition.id                '_diffrn_scan.frame_id_end'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               last frame in the scan.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -10596,7 +10914,8 @@ save_diffrn_scan.frame_id_start
 
     _definition.id                '_diffrn_scan.frame_id_start'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               first frame in the scan.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -10618,7 +10937,8 @@ save_diffrn_scan.frames
 
     _definition.id                '_diffrn_scan.frames'
     _description.text
-;             The value of this data item is the number of frames in
+;
+             The value of this data item is the number of frames in
               the scan.
 ;
     _name.category_id             diffrn_scan
@@ -10644,7 +10964,8 @@ save_diffrn_scan.id
 
     _definition.id                '_diffrn_scan.id'
     _description.text
-;             The value of _diffrn_scan.id uniquely identifies each
+;
+             The value of _diffrn_scan.id uniquely identifies each
               scan.  The identifier is used to tie together all the
               information about the scan.
 ;
@@ -10663,7 +10984,8 @@ save_diffrn_scan.integration_time
 
     _definition.id                '_diffrn_scan.integration_time'
     _description.text
-;             Approximate average time in seconds to integrate each
+;
+             Approximate average time in seconds to integrate each
               step of the scan.  The precise time for integration
               of each particular step must be provided in
               _diffrn_scan_frame.integration_time, even
@@ -10688,7 +11010,8 @@ save_diffrn_scan.time_period
 
     _definition.id                '_diffrn_scan.time_period'
     _description.text
-;             Approximate average time in seconds between the start
+;
+             Approximate average time in seconds between the start
               of each step of the scan.  The precise start-to-start
               time increment of each particular step may be provided in
               _diffrn_scan_frame.time_period.
@@ -10712,7 +11035,8 @@ save_diffrn_scan.time_rstrt_incr
 
     _definition.id                '_diffrn_scan.time_rstrt_incr'
     _description.text
-;             Approximate average time in seconds between the end
+;
+             Approximate average time in seconds between the end
               of integration of each step of the scan and the start
               of integration of the next step.
 
@@ -10748,7 +11072,8 @@ save_diffrn_scan.variant
 
     _definition.id                '_diffrn_scan.variant'
     _description.text
-;             The value of _diffrn_scan.variant gives the variant
+;
+             The value of _diffrn_scan.variant gives the variant
               to which the given DIFFRN_SCAN row is related.
 
               If this value is not given, the variant is assumed to be
@@ -10792,7 +11117,9 @@ save_DIFFRN_SCAN_AXIS
          '_diffrn_scan_axis.variant'
 
     _nx_mapping.details
-;    _diffrn_scan_axis.axis_id AXISID-->
+;
+
+    _diffrn_scan_axis.axis_id AXISID-->
     _diffrn_scan_axis.angle_start ANGSTART
     _diffrn_scan_axis.angle_range ANGRANGE 
     _diffrn_scan_axis.angle_increment ANGINC 
@@ -10844,7 +11171,8 @@ save_diffrn_scan_axis.angle_increment
 
     _definition.id                '_diffrn_scan_axis.angle_increment'
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in degrees.  In general, this will agree with
               _diffrn_scan_frame_axis.angle_increment. The
               sum of the values of _diffrn_scan_frame_axis.angle and
@@ -10876,7 +11204,8 @@ save_diffrn_scan_axis.angle_range
 
     _definition.id                '_diffrn_scan_axis.angle_range'
     _description.text
-;             The total range covered during the scan from the starting position 
+;
+             The total range covered during the scan from the starting position 
               to the end of the final step for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
@@ -10897,7 +11226,8 @@ save_diffrn_scan_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.angle_rstrt_incr'
     _description.text
-;             The increment after each step for the specified axis
+;
+             The increment after each step for the specified axis
               in degrees.  In general, this will agree with
               _diffrn_scan_frame_axis.angle_rstrt_incr.  The
               sum of the values of _diffrn_scan_frame_axis.angle,
@@ -10932,7 +11262,8 @@ save_diffrn_scan_axis.angle_start
 
     _definition.id                '_diffrn_scan_axis.angle_start'
     _description.text
-;             The starting position for the specified axis in degrees.
+;
+             The starting position for the specified axis in degrees.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               angle_start
@@ -10952,7 +11283,8 @@ save_diffrn_scan_axis.axis_id
 
     _definition.id                '_diffrn_scan_axis.axis_id'
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes for the scan for which settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -10977,7 +11309,8 @@ save_diffrn_scan_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_axis.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_axis
@@ -10995,7 +11328,8 @@ save_diffrn_scan_axis.displacement_increment
 
     _definition.id                '_diffrn_scan_axis.displacement_increment'
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in millimetres.  In general, this will agree with
               _diffrn_scan_frame_axis.displacement_increment.
               The sum of the values of
@@ -11027,7 +11361,8 @@ save_diffrn_scan_axis.displacement_range
 
     _definition.id                '_diffrn_scan_axis.displacement_range'
     _description.text
-;             The range from the starting position for the specified axis
+;
+             The range from the starting position for the specified axis
               in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
@@ -11048,7 +11383,8 @@ save_diffrn_scan_axis.displacement_rstrt_incr
 
     _definition.id                '_diffrn_scan_axis.displacement_rstrt_incr'
     _description.text
-;             The increment for each step for the specified axis
+;
+             The increment for each step for the specified axis
               in millimetres.  In general, this will agree with
               _diffrn_scan_frame_axis.displacement_rstrt_incr.
               The sum of the values of
@@ -11083,7 +11419,8 @@ save_diffrn_scan_axis.displacement_start
 
     _definition.id                '_diffrn_scan_axis.displacement_start'
     _description.text
-;             The starting position for the specified axis in millimetres.
+;
+             The starting position for the specified axis in millimetres.
 ;
     _name.category_id             diffrn_scan_axis
     _name.object_id               displacement_start
@@ -11103,7 +11440,8 @@ save_diffrn_scan_axis.reference_angle
 
     _definition.id                '_diffrn_scan_axis.reference_angle'
     _description.text
-;             The setting of the specified axis in degrees
+;
+             The setting of the specified axis in degrees
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -11136,7 +11474,8 @@ save_diffrn_scan_axis.reference_displacement
 
     _definition.id                '_diffrn_scan_axis.reference_displacement'
     _description.text
-;             The setting of the specified axis in millimetres
+;
+             The setting of the specified axis in millimetres
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -11167,7 +11506,8 @@ save_diffrn_scan_axis.scan_id
 
     _definition.id                '_diffrn_scan_axis.scan_id'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               scan for which axis settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -11192,7 +11532,8 @@ save_diffrn_scan_axis.variant
 
     _definition.id                '_diffrn_scan_axis.variant'
     _description.text
-;             The value of _diffrn_scan_axis.variant gives the variant
+;
+             The value of _diffrn_scan_axis.variant gives the variant
               to which the given DIFFRN_SCAN_AXIS row is related.
 
               If this value is not given, the variant is assumed to be
@@ -11239,7 +11580,8 @@ save_DIFFRN_SCAN_COLLECTION
     _description_example.case
         'Example 1 - Describing a multi-wedge raster scan.'
     _description_example.detail
-;        loop_
+;
+        loop_
         _diffrn_scan_collection.scan_id
         _diffrn_scan_collection.details
        
@@ -11249,7 +11591,9 @@ save_DIFFRN_SCAN_COLLECTION
     ;
 ;
     _nx_mapping.details
-;    _diffrn_scan_collection.type  COLLECTIONTYPE
+;
+
+    _diffrn_scan_collection.type  COLLECTIONTYPE
     _diffrn_scan_collection.translation_width TRANSLATION_WIDTH
 
     --> 
@@ -11275,7 +11619,8 @@ save_diffrn_scan_collection.details
 
     _definition.id                '_diffrn_scan_collection.details'
     _description.text
-;             The value of _diffrn_scan_collection.details should give a
+;
+             The value of _diffrn_scan_collection.details should give a
               description of special aspects of each collection strategy.
 ;
     _name.category_id             diffrn_scan_collection
@@ -11293,7 +11638,8 @@ save_diffrn_scan_collection.diffrn_id
 
     _definition.id                '_diffrn_scan_collection.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_collection
@@ -11312,7 +11658,8 @@ save_diffrn_scan_collection.scan_id
 
     _definition.id                '_diffrn_scan_collection.scan_id'
     _description.text
-;             The value of _diffrn_scan_collection.scan_id identifies the scan
+;
+             The value of _diffrn_scan_collection.scan_id identifies the scan
               containing this frame.
 
               This item is a pointer to _diffrn_scan.id in the
@@ -11335,7 +11682,8 @@ save_diffrn_scan_collection.translation_width
 
     _definition.id                '_diffrn_scan_collection.translation_width'
     _description.text
-;             The value of _diffrn_scan_collection.translation_width
+;
+             The value of _diffrn_scan_collection.translation_width
               gives the average single step translation in micrometres
               in collection strategies for which this information is
                appropriate, e.g. 'vector'.
@@ -11358,7 +11706,8 @@ save_diffrn_scan_collection.type
 
     _definition.id                '_diffrn_scan_collection.type'
     _description.text
-;             The value of _diffrn_scan_collection.type identifies
+;
+             The value of _diffrn_scan_collection.type identifies
               the strategy used in this scan, e.g. `rotation', 'raster',
               'vector', 'still', etc.
 
@@ -11380,7 +11729,8 @@ save_diffrn_scan_collection.variant
 
     _definition.id                '_diffrn_scan_collection.variant'
     _description.text
-;             The value of _diffrn_scan_collection.variant gives the variant
+;
+             The value of _diffrn_scan_collection.variant gives the variant
               to which the given DIFFRN_SCAN_COLLECTION row is related.
 
               If this value is not given, the variant is assumed to be
@@ -11423,7 +11773,8 @@ save_DIFFRN_SCAN_FRAME
          '_diffrn_scan_frame.variant'
 
     _nx_mapping.details
-;    _diffrn_scan_frame.date  DATETIME
+;
+    _diffrn_scan_frame.date  DATETIME
     _diffrn_scan_frame.frame_id ID
     _diffrn_scan_frame.frame_number FRAMENUMBER
     _diffrn_scan_frame.integration_time COUNTTIME
@@ -11465,7 +11816,8 @@ save_diffrn_scan_frame.date
 
     _definition.id                '_diffrn_scan_frame.date'
     _description.text
-;             The date and time of the start of the frame being scanned.
+;
+             The date and time of the start of the frame being scanned.
 ;
     _name.category_id             diffrn_scan_frame
     _name.object_id               date
@@ -11482,7 +11834,8 @@ save_diffrn_scan_frame.diffrn_id
 
     _definition.id                '_diffrn_scan_frame.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame
@@ -11501,7 +11854,8 @@ save_diffrn_scan_frame.frame_id
 
     _definition.id                '_diffrn_scan_frame.frame_id'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               frame being examined.
 
               This item is a pointer to _diffrn_data_frame.id in the
@@ -11523,7 +11877,8 @@ save_diffrn_scan_frame.frame_number
 
     _definition.id                '_diffrn_scan_frame.frame_number'
     _description.text
-;             The value of this data item is the number of the frame
+;
+             The value of this data item is the number of the frame
               within the scan, starting with 1.  It is not necessarily
               the same as the value of _diffrn_scan_frame.frame_id,
               but it may be.
@@ -11552,7 +11907,8 @@ save_diffrn_scan_frame.integration_time
 
     _definition.id                '_diffrn_scan_frame.integration_time'
     _description.text
-;             The time in seconds to integrate this step of the scan.
+;
+             The time in seconds to integrate this step of the scan.
               This should be the precise time of integration of each
               particular frame.  The value of this data item should
               be given explicitly for each frame and not inferred
@@ -11577,7 +11933,8 @@ save_diffrn_scan_frame.polarizn_stokes_i
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I'
     _description.text
-;             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
+;
+             The quantity Ip+In+Inp, where Ip is the intensity (amplitude
               squared) of the electric vector in the plane of polarization,
               In is the intensity (amplitude squared) of the electric vector
               in the plane of the normal to the plane of polarization,
@@ -11628,7 +11985,8 @@ save_diffrn_scan_frame.polarizn_stokes_i_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_I_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_I,
               Ip+In+Inp, where Ip is the intensity (amplitude squared)
               of the electric vector in the plane of polarization,
@@ -11663,7 +12021,8 @@ save_diffrn_scan_frame.polarizn_stokes_q
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q'
     _description.text
-;             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -11705,7 +12064,8 @@ save_diffrn_scan_frame.polarizn_stokes_q_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_Q_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_Q,
               (Ip-In)*cos(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -11742,7 +12102,8 @@ save_diffrn_scan_frame.polarizn_stokes_u
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U'
     _description.text
-;             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
+;
+             The quantity (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization, In is the intensity (amplitude squared) of
               the electric vector in the plane of the normal to the
@@ -11784,7 +12145,8 @@ save_diffrn_scan_frame.polarizn_stokes_u_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_U_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_U,
               (Ip-In)*sin(2*theta), where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
@@ -11821,7 +12183,8 @@ save_diffrn_scan_frame.polarizn_stokes_v
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V'
     _description.text
-;             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
+;
+             The quantity +/-2*sqrt(IpIn), with a + sign for right-handed
               circular polarization, where Ip is the intensity
               (amplitude squared) of the electric vector in the plane of
               polarization and In is the intensity (amplitude squared) of
@@ -11864,7 +12227,8 @@ save_diffrn_scan_frame.polarizn_stokes_v_esd
 
     _definition.id                '_diffrn_scan_frame.polarizn_Stokes_V_esd'
     _description.text
-;             The standard uncertainty (estimated standard deviation, e.s.d.)
+;
+             The standard uncertainty (estimated standard deviation, e.s.d.)
               of _diffrn_scan_frame.polarizn_Stokes_V,
               +/-2*sqrt(IpIn), with a + sign for right-handed circular
               polarization, where Ip is the intensity
@@ -11902,7 +12266,8 @@ save_diffrn_scan_frame.scan_id
 
     _definition.id                '_diffrn_scan_frame.scan_id'
     _description.text
-;             The value of _diffrn_scan_frame.scan_id identifies the scan
+;
+             The value of _diffrn_scan_frame.scan_id identifies the scan
               containing this frame.
 
               This item is a pointer to _diffrn_scan.id in the
@@ -11924,7 +12289,8 @@ save_diffrn_scan_frame.time_period
 
     _definition.id                '_diffrn_scan_frame.time_period'
     _description.text
-;             The time in seconds between the start of this frame and the
+;
+             The time in seconds between the start of this frame and the
               start of the next frame, if any.  If there is no next frame,
               a null value should be given.
 ;
@@ -11947,7 +12313,8 @@ save_diffrn_scan_frame.time_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame.time_rstrt_incr'
     _description.text
-;             The time in seconds between the end of integration of this step of the scan
+;
+             The time in seconds between the end of integration of this step of the scan
               and the start of integration of the next step.
 
               The sum of the values of _diffrn_scan_frame.integration_time
@@ -11981,7 +12348,8 @@ save_diffrn_scan_frame.variant
 
     _definition.id                '_diffrn_scan_frame.variant'
     _description.text
-;             The value of _diffrn_scan_frame.variant gives the variant
+;
+             The value of _diffrn_scan_frame.variant gives the variant
               to which the given DIFFRN_SCAN_FRAME row is related.
 
               If this value is not given, the variant is assumed to be
@@ -12028,7 +12396,9 @@ save_DIFFRN_SCAN_FRAME_AXIS
          '_diffrn_scan_frame_axis.variant'
 
     _nx_mapping.details
-;    _diffrn_scan_frame_axis.axis_id AXISID
+;
+
+    _diffrn_scan_frame_axis.axis_id AXISID
     _diffrn_scan_frame_axis.angle ANGLE
     _diffrn_scan_frame_axis.angle_increment ANGLEINCREMENT
     _diffrn_scan_frame_axis.angle_rstrt_incr ANGLERSTRTINCREMENT
@@ -12085,7 +12455,8 @@ save_diffrn_scan_frame_axis.angle
 
     _definition.id                '_diffrn_scan_frame_axis.angle'
     _description.text
-;             The setting of the specified axis in degrees for this frame.
+;
+             The setting of the specified axis in degrees for this frame.
               This is the setting at the start of the integration time.
 ;
     _name.category_id             diffrn_scan_frame_axis
@@ -12106,7 +12477,8 @@ save_diffrn_scan_frame_axis.angle_increment
 
     _definition.id                '_diffrn_scan_frame_axis.angle_increment'
     _description.text
-;             The increment for this frame for the angular setting of
+;
+             The increment for this frame for the angular setting of
               the specified axis in degrees.  The sum of the values
               of _diffrn_scan_frame_axis.angle and
               _diffrn_scan_frame_axis.angle_increment is the
@@ -12131,7 +12503,8 @@ save_diffrn_scan_frame_axis.angle_rstrt_incr
 
     _definition.id                '_diffrn_scan_frame_axis.angle_rstrt_incr'
     _description.text
-;             The increment after this frame for the angular setting of
+;
+             The increment after this frame for the angular setting of
               the specified axis in degrees.  The sum of the values
               of _diffrn_scan_frame_axis.angle,
               _diffrn_scan_frame_axis.angle_increment and
@@ -12158,7 +12531,8 @@ save_diffrn_scan_frame_axis.axis_id
 
     _definition.id                '_diffrn_scan_frame_axis.axis_id'
     _description.text
-;             The value of this data item is the identifier of one of
+;
+             The value of this data item is the identifier of one of
               the axes for the frame for which settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -12183,7 +12557,8 @@ save_diffrn_scan_frame_axis.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_axis.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_axis
@@ -12202,7 +12577,8 @@ save_diffrn_scan_frame_axis.displacement
 
     _definition.id                '_diffrn_scan_frame_axis.displacement'
     _description.text
-;             The setting of the specified axis in millimetres for this
+;
+             The setting of the specified axis in millimetres for this
               frame.  This is the setting at the start of the integration
               time.
 ;
@@ -12225,7 +12601,8 @@ save_diffrn_scan_frame_axis.displacement_increment
     _definition.id
         '_diffrn_scan_frame_axis.displacement_increment'
     _description.text
-;             The increment for this frame for the displacement setting of
+;
+             The increment for this frame for the displacement setting of
               the specified axis in millimetres.  The sum of the values
               of _diffrn_scan_frame_axis.displacement and
               _diffrn_scan_frame_axis.displacement_increment is the
@@ -12251,7 +12628,8 @@ save_diffrn_scan_frame_axis.displacement_rstrt_incr
     _definition.id
         '_diffrn_scan_frame_axis.displacement_rstrt_incr'
     _description.text
-;             The increment for this frame for the displacement setting of
+;
+             The increment for this frame for the displacement setting of
               the specified axis in millimetres.  The sum of the values
               of _diffrn_scan_frame_axis.displacement,
               _diffrn_scan_frame_axis.displacement_increment and
@@ -12278,7 +12656,8 @@ save_diffrn_scan_frame_axis.frame_id
 
     _definition.id                '_diffrn_scan_frame_axis.frame_id'
     _description.text
-;             The value of this data item is the identifier of the
+;
+             The value of this data item is the identifier of the
               frame for which axis settings are being specified.
 
               Multiple axes may be specified for the same value of
@@ -12303,7 +12682,8 @@ save_diffrn_scan_frame_axis.reference_angle
 
     _definition.id                '_diffrn_scan_frame_axis.reference_angle'
     _description.text
-;             The setting of the specified axis in degrees
+;
+             The setting of the specified axis in degrees
               against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -12332,7 +12712,8 @@ save_diffrn_scan_frame_axis.reference_displacement
     _definition.id
         '_diffrn_scan_frame_axis.reference_displacement'
     _description.text
-;             The setting of the specified axis in millimetres for this
+;
+             The setting of the specified axis in millimetres for this
               frame against which measurements of the reference beam centre
               and reference detector distance should be made.
 
@@ -12360,7 +12741,8 @@ save_diffrn_scan_frame_axis.variant
 
     _definition.id                '_diffrn_scan_frame_axis.variant'
     _description.text
-;             The value of _diffrn_scan_frame_axis.variant gives the variant
+;
+             The value of _diffrn_scan_frame_axis.variant gives the variant
               to which the given DIFFRN_SCAN_FRAME_AXIS row is related.
 
               If this value is not given, the variant is assumed to be
@@ -12427,7 +12809,9 @@ save_DIFFRN_SCAN_FRAME_MONITOR
          '_diffrn_scan_frame_monitor.variant'
 
     _description_example.case
-;     # category DIFFRN_DETECTOR
+;
+
+     # category DIFFRN_DETECTOR
      loop_
      _diffrn_detector.diffrn_id
      _diffrn_detector.id
@@ -12546,16 +12930,19 @@ save_DIFFRN_SCAN_FRAME_MONITOR
       ELEMENT_Y        translation detector ELEMENT_X
      0 1 0 0 0 0
       MONITOR_Z        translation detector . 0 0 1 0 0 0
+
 ;
     _description_example.detail
 ;
     Example 1. The beam intensity for frame FRAME1 is being tracked
-     by a beamstop monitor detector BSM01, made from metal foil and
-     a PIN diode, located 20 mm in front of a MAR345 detector and being
-     sampled every 2 seconds in a 20 second scan.
+        by a beamstop monitor detector BSM01, made from metal foil and
+        a PIN diode, located 20 mm in front of a MAR345 detector and being
+        sampled every 2 seconds in a 20 second scan.
 ;
     _nx_mapping.details
-;    _diffrn_scan_frame_monitor.id MONID -->
+;
+
+    _diffrn_scan_frame_monitor.id MONID -->
     _diffrn_scan_frame_monitor.detector_id DETECTORNAME -->
     _diffrn_scan_frame_monitor.scan_id SCANID -->
     _diffrn_scan_frame_monitor.frame_id FRAMEID -->
@@ -12585,7 +12972,8 @@ save_diffrn_scan_frame_monitor.detector_id
 
     _definition.id                '_diffrn_scan_frame_monitor.detector_id'
     _description.text
-;             This data item is a pointer to _diffrn_detector.id in
+;
+             This data item is a pointer to _diffrn_detector.id in
               the DIFFRN_DETECTOR category.
 
 ;
@@ -12605,7 +12993,8 @@ save_diffrn_scan_frame_monitor.diffrn_id
 
     _definition.id                '_diffrn_scan_frame_monitor.diffrn_id'
     _description.text
-;             This data item is a pointer to '_diffrn.id' in
+;
+             This data item is a pointer to '_diffrn.id' in
               the DIFFRN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -12624,7 +13013,8 @@ save_diffrn_scan_frame_monitor.frame_id
 
     _definition.id                '_diffrn_scan_frame_monitor.frame_id'
     _description.text
-;             This item is a pointer to _diffrn_data_frame.id
+;
+             This item is a pointer to _diffrn_data_frame.id
               in the DIFFRN_DATA_FRAME category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -12643,7 +13033,8 @@ save_diffrn_scan_frame_monitor.id
 
     _definition.id                '_diffrn_scan_frame_monitor.id'
     _description.text
-;             This item is an integer identifier which, along with
+;
+             This item is an integer identifier which, along with
               _diffrn_scan_frame_monitor.detector_id,
               _diffrn_scan_frame_monitor.scan_id, and
               _diffrn_scan_frame_monitor.frame_id
@@ -12676,7 +13067,8 @@ save_diffrn_scan_frame_monitor.integration_time
 
     _definition.id                '_diffrn_scan_frame_monitor.integration_time'
     _description.text
-;             The precise time for integration of the monitor value given in
+;
+             The precise time for integration of the monitor value given in
               _diffrn_scan_frame_monitor.monitor_value
               must be given in _diffrn_scan_frame_monitor.integration_time.
 ;
@@ -12701,9 +13093,13 @@ save_diffrn_scan_frame_monitor.monitor_value
     _alias.definition_id          '_diffrn_scan_frame_monitor.value'
     _alias.deprecation_date       .
     _alias.ddl2_version           1.8.2
-    _alias.dictionary_uri         cif_img.dic
+    _alias.dictionary_uri
+;\
+https://github.com/dials/cbflib/raw/refs/heads/main/doc/cif_img_1.8.2.dic
+;
     _description.text
-;             The value reported by the monitor detector should be given in
+;
+             The value reported by the monitor detector should be given in
               _diffrn_scan_frame_monitor.monitor_value.
 
               The value is typed as float to allow of monitors for very
@@ -12732,7 +13128,8 @@ save_diffrn_scan_frame_monitor.scan_id
 
     _definition.id                '_diffrn_scan_frame_monitor.scan_id'
     _description.text
-;             This item is a pointer to _diffrn_scan.id in
+;
+             This item is a pointer to _diffrn_scan.id in
               the DIFFRN_SCAN category.
 ;
     _name.category_id             diffrn_scan_frame_monitor
@@ -12750,7 +13147,8 @@ save_diffrn_scan_frame_monitor.value
 
     _definition.id                '_diffrn_scan_frame_monitor.value'
     _description.text
-;             This is a deprecated version of
+;
+             This is a deprecated version of
               _diffrn_scan_frame_monitor.monitor_value.
 
               The value is typed as float to allow of monitors for very
@@ -12779,7 +13177,8 @@ save_diffrn_scan_frame_monitor.variant
 
     _definition.id                '_diffrn_scan_frame_monitor.variant'
     _description.text
-;             The value of _diffrn_scan_frame_monitor.variant gives the variant
+;
+             The value of _diffrn_scan_frame_monitor.variant gives the variant
               to which the given DIFFRN_SCAN_FRAME_MONITOR row is related.
 
               If this value is not given, the variant is assumed to be
@@ -12806,9 +13205,10 @@ save_DIFFRN_SOURCE
     _definition.id                diffrn_source
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-09-16
+    _definition.update            2026-05-14
     _description.text
-;              Data items in the DIFFRN_SOURCE category record details of
+;
+              Data items in the DIFFRN_SOURCE category record details of
                the source of radiation used in the diffraction experiment.
 
                This is a stub category for use of DIFFRN_SOURCE which is
@@ -12832,9 +13232,11 @@ save_diffrn_source.diffrn_id
     _alias.definition_id          '_diffrn_source.diffrn_id'
     _alias.deprecation_date       .
     _alias.ddl2_version           5.384
-    _alias.dictionary_uri         mmcif_pdbx.dic
+    _alias.dictionary_uri
+        https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic
     _description.text
-;              This data item is a pointer to _diffrn.id in the DIFFRN
+;
+              This data item is a pointer to _diffrn.id in the DIFFRN
                category.
 ;
     _name.category_id             diffrn_source
@@ -12857,12 +13259,16 @@ save_diffrn_source.source
       _alias.deprecation_date
       _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_source.source'           .        5.384        mmcif_pdbx.dic
-         '_diffrn_radiation_source'        .        1.0          cifdic.c91
-         '_diffrn_source'                  .        2.0          cif_core.dic
+         '_diffrn_source.source'                      .                   5.384
+         https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic
+         '_diffrn_radiation_source'                   .                   1.0
+         ftp://ftp.iucr.org/pub/cifdics/cifdic.C91
+         '_diffrn_source'                             .                   2.0
+         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.dic
 
     _description.text
-;              The general class of the radiation source.
+;
+              The general class of the radiation source.
 ;
     _name.category_id             diffrn_source
     _name.object_id               source
@@ -12893,11 +13299,14 @@ save_diffrn_source.type
       _alias.deprecation_date
       _alias.ddl2_version
       _alias.dictionary_uri
-         '_diffrn_source.type'         .         5.384         mmcif_pdbx.dic
-         '_diffrn_source_type'         .         2.0.1         cif_core.dic
+         '_diffrn_source.type'                     .                     5.384
+         https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic
+         '_diffrn_source_type'                     .                     2.0.1
+         ftp://ftp.iucr.org/pub/cifdics/cif_core_2.0.1.dic
 
     _description.text
-;              The make, model or name of the source of radiation.
+;
+              The make, model or name of the source of radiation.
 ;
     _name.category_id             diffrn_source
     _name.object_id               type
@@ -12945,7 +13354,9 @@ save_MAP
          '_map.variant'
 
     _description_example.case
-;        loop_
+;
+
+        loop_
         _map.id
         _map.details
 
@@ -12961,7 +13372,8 @@ save_MAP
    ;
 ;
     _description_example.detail
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map
 ;
 
@@ -12977,7 +13389,8 @@ save_map.details
 
     _definition.id                '_map.details'
     _description.text
-;              The value of _map.details should give a
+;
+              The value of _map.details should give a
                description of special aspects of each map.
 
 ;
@@ -12990,11 +13403,13 @@ save_map.details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map
 ;
     _description_example.detail
-;        loop_
+;
+        loop_
         _map.id
         _map.details
 
@@ -13015,7 +13430,8 @@ save_map.diffrn_id
 
     _definition.id                '_map.diffrn_id'
     _description.text
-;             This item is a pointer to _diffrn.id in the
+;
+             This item is a pointer to _diffrn.id in the
               DIFFRN category.
 ;
     _name.category_id             map
@@ -13034,7 +13450,8 @@ save_map.entry_id
 
     _definition.id                '_map.entry_id'
     _description.text
-;             This item is a pointer to _entry.id in the
+;
+             This item is a pointer to _entry.id in the
               ENTRY category.
 ;
     _name.category_id             map
@@ -13052,7 +13469,8 @@ save_map.id
 
     _definition.id                '_map.id'
     _description.text
-;             The value of _map.id must uniquely identify
+;
+             The value of _map.id must uniquely identify
               each map for the given '_diffrn.id' or entry.id.
 ;
     _name.category_id             map
@@ -13070,7 +13488,8 @@ save_map.variant
 
     _definition.id                '_map.variant'
     _description.text
-;             The value of _map.variant gives the variant
+;
+             The value of _map.variant gives the variant
               to which the given map row is related.
 
               If this value is not given, the variant is assumed to be
@@ -13113,7 +13532,9 @@ save_MAP_SEGMENT
          '_map_segment.variant'
 
     _description_example.case
-;        loop_
+;
+
+        loop_
         _map.id
         _map.details
 
@@ -13138,7 +13559,8 @@ save_MAP_SEGMENT
         rho_obs  rho_obs  map_structure 2 mask_structure 1
 ;
     _description_example.detail
-;   Example 1. Identifying an observed density map
+;
+   Example 1. Identifying an observed density map
                 and a calculated density map, each consisting of one
                 segment, both using the same array structure
                 and mask.
@@ -13156,7 +13578,8 @@ save_map_segment.array_id
 
     _definition.id                '_map_segment.array_id'
     _description.text
-;             The value of _map_segment.array_id identifies the array 
+;
+             The value of _map_segment.array_id identifies the array 
               structure into which the map is organized.
 
               This item is a pointer to _array_structure.id in the
@@ -13177,7 +13600,8 @@ save_map_segment.array_section_id
 
     _definition.id                '_map_segment.array_section_id'
     _description.text
-;             This item is a pointer to _array_structure_list_section.id
+;
+             This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
@@ -13196,7 +13620,8 @@ save_map_segment.binary_id
 
     _definition.id                '_map_segment.binary_id'
     _description.text
-;             The value of _map_segment.binary_id distinguishes the particular 
+;
+             The value of _map_segment.binary_id distinguishes the particular 
               set of data organized according to _map_segment.array_id in 
               which the data values of the map are stored.
 
@@ -13219,7 +13644,8 @@ save_map_segment.details
 
     _definition.id                '_map_segment.details'
     _description.text
-;             The value of _map_segment.details should give a
+;
+             The value of _map_segment.details should give a
               description of special aspects of each segment of a map.
 ;
     _name.category_id             map_segment
@@ -13230,10 +13656,11 @@ save_map_segment.details
     _type.container               Single
     _type.contents                Text
     _type.ddl2_code               text
-    _description_example.case     'Example to be provided'
+    _description_example.case     '               Example to be provided'
     _description_example.detail
 ;
-    . . .
+               
+                . . .
 ;
 
 save_
@@ -13242,7 +13669,8 @@ save_map_segment.id
 
     _definition.id                '_map_segment.id'
     _description.text
-;             The value of _map_segment.id must uniquely
+;
+             The value of _map_segment.id must uniquely
               identify each segment of a map.
 ;
     _name.category_id             map_segment
@@ -13261,7 +13689,8 @@ save_map_segment.map_id
 
     _definition.id                '_map_segment.map_id'
     _description.text
-;             This item is a pointer to _map.id
+;
+             This item is a pointer to _map.id
               in the MAP category.
 ;
     _name.category_id             map_segment
@@ -13279,7 +13708,8 @@ save_map_segment.mask_array_id
 
     _definition.id                '_map_segment.mask_array_id'
     _description.text
-;             The value of _map_segment.mask_array_id, if given, describes
+;
+             The value of _map_segment.mask_array_id, if given, describes
               the array structure into which the mask for the map is
               organized.  If no value is given, then all elements of
               the map are valid.  If a value is given, then only
@@ -13311,7 +13741,8 @@ save_map_segment.mask_array_section_id
 
     _definition.id                '_map_segment.mask_array_section_id'
     _description.text
-;             This item is a pointer to _array_structure_list_section.id
+;
+             This item is a pointer to _array_structure_list_section.id
               in the ARRAY_STRUCTURE_LIST_SECTION category.
 ;
     _name.category_id             map_segment
@@ -13329,7 +13760,8 @@ save_map_segment.mask_binary_id
 
     _definition.id                '_map_segment.mask_binary_id'
     _description.text
-;             The value of _map_segment.mask_binary_id identifies the 
+;
+             The value of _map_segment.mask_binary_id identifies the 
               particular set of data organized according to 
               _map_segment.mask_array_id specifying the mask for the map.
 
@@ -13352,7 +13784,8 @@ save_map_segment.variant
 
     _definition.id                '_map_segment.variant'
     _description.text
-;             The value of _map_segment.variant gives the variant
+;
+             The value of _map_segment.variant gives the variant
               to which the given map segment is related.
 
               If this value is not given, the variant is assumed to be
@@ -13431,7 +13864,9 @@ save_VARIANT
          '_variant.entry_id'
 
     _description_example.case
-;        loop_
+;
+
+        loop_
         _variant.variant
         _variant.role
         _variant.timestamp
@@ -13458,7 +13893,8 @@ save_VARIANT
         d1     d1_ccd_4  -1.9   -1.6  mm  indexed
 ;
     _description_example.detail
-;   Example 1. Distinguishing between a raw beam centre and a refined beam
+;
+   Example 1. Distinguishing between a raw beam centre and a refined beam
        centre inferred after indexing.  Detector d1 is composed of
        four CCD detector elements, each 200 mm by 200 mm, arranged
        in a square, in the pattern
@@ -13490,7 +13926,8 @@ save_variant.details
 
     _definition.id                '_variant.details'
     _description.text
-;             A description of special aspects of the variant.
+;
+             A description of special aspects of the variant.
 ;
     _name.category_id             variant
     _name.object_id               details
@@ -13501,7 +13938,7 @@ save_variant.details
     _type.contents                Text
     _type.ddl2_code               text
     _description_example.case
-        'indexed cell and refined beam centre'
+        '                                indexed cell and refined beam centre'
 
 save_
 
@@ -13509,7 +13946,8 @@ save_variant.diffrn_id
 
     _definition.id                '_variant.diffrn_id'
     _description.text
-;             This item is a pointer to _diffrn.id in the
+;
+             This item is a pointer to _diffrn.id in the
               diffrn category.
 ;
     _name.category_id             variant
@@ -13528,7 +13966,8 @@ save_variant.entry_id
 
     _definition.id                '_variant.entry_id'
     _description.text
-;             This item is a pointer to _entry.id in the
+;
+             This item is a pointer to _entry.id in the
               entry category
 ;
     _name.category_id             variant
@@ -13546,7 +13985,8 @@ save_variant.role
 
     _definition.id                '_variant.role'
     _description.text
-;             The value of _variant.role  specified a role
+;
+             The value of _variant.role  specified a role
               for this variant.  Possible roles are null, 'preferred',
               'raw data', and 'unsuccessful trial'.
 
@@ -13568,7 +14008,8 @@ save_variant.role
       _enumeration_set.state
       _enumeration_set.detail
          'preferred'
-;    A value of 'preferred' indicates that rows of any categories specifying
+;
+    A value of 'preferred' indicates that rows of any categories specifying
      this variant should be used in preference to rows with the same key
      specifying other variants or the null variant.  It is an error to specify
      two variants that appear in the same category with the same key as being
@@ -13576,13 +14017,15 @@ save_variant.role
      preferred in other cases.
 ;
          'raw data'
-;    A value of 'raw data' indicates data prior to any corrections, 
+;
+    A value of 'raw data' indicates data prior to any corrections, 
      calculations or refinements.  It is not necessarily an error for raw data
      also to be a variant of an earlier variant.  It may be replacement raw 
      data for earlier data believed to be erroneous.
 ;
          'unsuccessful trial'
-;    A value of 'unsuccessful trial' indicates data that should not be used
+;
+    A value of 'unsuccessful trial' indicates data that should not be used
      for further calculation.
 ;
 
@@ -13592,7 +14035,8 @@ save_variant.timestamp
 
     _definition.id                '_variant.timestamp'
     _description.text
-;             The date and time identifying a variant.  This is not 
+;
+             The date and time identifying a variant.  This is not 
               necessarily the precise time of the measurement or calculation
               of the individual related data items, but a timestamp that 
               reflects the order in which the variants were defined.
@@ -13612,7 +14056,8 @@ save_variant.variant
 
     _definition.id                '_variant.variant'
     _description.text
-;             The value of _variant.variant must uniquely identify
+;
+             The value of _variant.variant must uniquely identify
               each variant for the given diffraction experiment and/or entry
 
               This item has been made implicit and given a default value of 
@@ -13634,7 +14079,8 @@ save_variant.variant_of
 
     _definition.id                '_variant.variant_of'
     _description.text
-;            The value of _variant.variant_of gives the variant
+;
+            The value of _variant.variant_of gives the variant
              from which this variant was derived.  If this value is not given,
              the variant is assumed to be derived from the default null 
              variant.
@@ -13657,8 +14103,9 @@ save_
       _dictionary_audit.version
       _dictionary_audit.date
       _dictionary_audit.revision
-         1.8.9                    2025-09-16
-;   Addition of missing diffrn.id pointers
+         1.8.9                    2026-05-14
+;
+   Addition of missing diffrn.id pointers
 
     + Add _diffrn_detector_element.diffrn_id
     + Add _diffrn_measurement_axis.diffrn_id
@@ -13681,7 +14128,8 @@ save_
        Minor corrections to 1.8.8 found while working on 1.8.9
 ;
          1.8.8                    2024-01-20
-;   Additional flux tags and change to ddl2 version being the master
+;
+   Additional flux tags and change to ddl2 version being the master
     instead of the html version being the master.  Make changes to
     support conversions to DDLm and back to DDL2.  Mark tags aliased
     from mmCIF_PDBx dictionary.
@@ -13705,7 +14153,8 @@ save_
     + Add _diffrn_source.type
 ;
          1.8.7                    2023-01-26
-;   Various additions
+;
+   Various additions
 
     + Add _array_data_external_data.file_compression
       2022-06-09 (jrh).
@@ -13738,7 +14187,8 @@ save_
         + Add _array_data_external_data.version
 ;
          1.8.4                    2021-04-15
-;   Copy-editing refinements (bm)
+;
+   Copy-editing refinements (bm)
 
     + Add _item_related.related_name and
       "_item_related.function_code replacedby" to deprecated items.
@@ -13763,7 +14213,8 @@ save_
 
 ;
          1.8.3                    2021-02-28
-;   Correction as per Brian McMahon
+;
+   Correction as per Brian McMahon
 
     + Fix _item.name for _array_structure_list.array_section_id
     + Remove spurious _item_aliases.alias_name from
@@ -13791,7 +14242,8 @@ save_
         + Fix wrong _item.mandatory_code in _variant.variant_of
 ;
          1.8.0                    2021-01-24
-;   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
+;
+   Changes for 2021 ITVG and conformance with Gold Standard and NXmx (HJB)
 
     + Add _diffrn_data_frame.center_derived as optional
     + Add _diffrn_measurement.sample_detector_distance_derived as optional
@@ -13844,7 +14296,8 @@ save_
          DIFFRN_SCAN_FRAME_AXIS.
 ;
          1.7.9                    2014-04-05
-;  Corrections to Stokes parameter description. (HJB)
+;
+  Corrections to Stokes parameter description. (HJB)
 
     + Clarify the meaning of _diffrn_radiation.polarizn_Stokes_I
     and _diffrn_scan_frame.polarizn_Stokes_I to explicitly include non-polarized
@@ -13855,7 +14308,8 @@ save_
 
 ;
          1.7.8                    2014-02-22
-;  Minor changes to NeXus mapping. (HJB)
+;
+  Minor changes to NeXus mapping. (HJB)
 
        + Conform NeXus mapping of DIFFRN_DETECTOR to neXus
        NXdetector base class terminology
@@ -13864,7 +14318,8 @@ save_
        the reverse mapping from NeXus of the equivalent field in NXdetector.
 ;
          1.7.7                    2014-02-22
-;  Major changes to NeXus mapping to conform to JS functional
+;
+  Major changes to NeXus mapping to conform to JS functional
     mapping prototype, add Stoke parameter tags for polarization
     and beam intensity, and add an new tag for FEL axes (HJB)
 
@@ -13900,7 +14355,8 @@ save_
          +  Change case of category names to conform to PDB conventions. (JW)
 ;
          1.7.3                    2013-10-15
-;  Major cleanup of dictionary typos, misplaced loops, etc
+;
+  Major cleanup of dictionary typos, misplaced loops, etc
        by John Westbrook
 
     +  Change _item.mandatory_code of all *.variant to implicit
@@ -13910,7 +14366,8 @@ save_
 
 ;
          1.7.2                    2013-10-07
-;  Add FEL detector positioning tags and change back to NXgoniometer
+;
+  Add FEL detector positioning tags and change back to NXgoniometer
 
     +  Add
        _axis.rotation_axis and
@@ -13919,7 +14376,8 @@ save_
 
 ;
          1.7.1                    2013-08-10
-;  Minor cleanup (HJB)
+;
+  Minor cleanup (HJB)
 
     +  Correction to description of
          _diffrn_data_frame.array_section_id
@@ -13928,7 +14386,8 @@ save_
 
 ;
          1.7                      2013-06-18
-;  Additions to start merge of CBF, HDF5 and NeXus (HJB)
+;
+  Additions to start merge of CBF, HDF5 and NeXus (HJB)
 
     +  Define new ARRAY_STRUCTURE_LIST_SECTION category
     +  Add new _category.NX_mapping_details DDL tag to carry
@@ -13947,7 +14406,8 @@ save_
 
 ;
          1.6.4                    2011-07-02
-;  Corrections to support DLS Dectris header as per G. Winter (HJB)
+;
+  Corrections to support DLS Dectris header as per G. Winter (HJB)
 
     +  Define new tags _diffrn_scan.time_period,
        _diffrn_scan.time_rstrt_incr,
@@ -13971,7 +14431,8 @@ save_
          +  add DIFFRN_SCAN_FRAME_MONITOR category
 ;
          1.5.4                    2007-07-28
-;  Typographics corrections (HJB)
+;
+  Typographics corrections (HJB)
 
      + Corrected embedded degree characters to \%
      + Corrected embedded Aring to \%A
@@ -13980,7 +14441,8 @@ save_
        in tag name.
 ;
          1.5.3                    2007-07-08
-;  Changes to support SLS miniCBF and suggestions
+;
+  Changes to support SLS miniCBF and suggestions
    from the 24 May 07 BNL imgCIF workshop (HJB)
 
      + Added new data items
@@ -14007,7 +14469,8 @@ save_
         and clean up more line folds (HJB)
 ;
          1.5                      2007-07-25
-;  This is a cumulative list of the changes proposed since the
+;
+  This is a cumulative list of the changes proposed since the
    imgCIF workshop in Hawaii in July 2006.  It is the result
    of contributions by H. J. Bernstein, A. Hammersley,
    J. Wright and W. Kabsch.
@@ -14047,7 +14510,8 @@ save_
 
 ;
          1.4                      2006-07-04
-;  This is a change to reintegrate all changes made in the course of
+;
+  This is a change to reintegrate all changes made in the course of
    publication of ITVG, by the RCSB from April 2005 through
    August 2008 and changes for the 2006 imgCIF workshop in
    Hawaii.
@@ -14087,7 +14551,8 @@ save_
                added sub_category 'vector' (JDW)
 ;
          1.3.2                    2005-06-25
-;  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
+;
+  2005-06-25 ITEM_TYPE_LIST: code, ucode, line, uline regexps updated
               to those of current mmCIF; float modified by allowing integers
               terminated by a point as valid. The 'time' part of
               yyyy-mm-dd types made optional in the regexp. (BM)
@@ -14400,35 +14865,40 @@ save_
 ;
        [_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*
 ;
-;              code item types/single words ...
+;
+              code item types/single words ...
 ;
          char
          ucode
 ;
        [_,.;:"&<>()/\{}'`~!@#$%A-Za-z0-9*|+-]*
 ;
-;              code item types/single words (case insensitive) ...
+;
+              code item types/single words (case insensitive) ...
 ;
          uchar
          line
 ;
        [][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
 ;
-;              char item types / multi-word items ...
+;
+              char item types / multi-word items ...
 ;
          char
          uline
 ;
        [][ \t_(),.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
 ;
-;              char item types / multi-word items (case insensitive)...
+;
+              char item types / multi-word items (case insensitive)...
 ;
          uchar
          text
 ;
        [][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*
 ;
-;              text item types / multi-line text ...
+;
+              text item types / multi-line text ...
 ;
          char
          binary
@@ -14436,7 +14906,8 @@ save_
        [][ \n\t()_,.;:"&<>/\{}'`~!@#$%?+=*A-Za-z0-9|^-]*\
        \n--CIF-BINARY-FORMAT-SECTION----
 ;
-;              binary items are presented as MIME-like ascii-encoded
+;
+              binary items are presented as MIME-like ascii-encoded
                sections in an imgCIF.  In a CBF, raw octet streams
                are used to convey the same information.
 ;
@@ -14445,7 +14916,8 @@ save_
 ;
        -?[0-9]+
 ;
-;              int item types are the subset of numbers that are the negative
+;
+              int item types are the subset of numbers that are the negative
                or positive integers.
 ;
          numb
@@ -14453,7 +14925,8 @@ save_
 ;
        -?(([0-9]+)[.]?|([0-9]*[.][0-9]+))([(][0-9]+[)])?([eE][+-]?[0-9]+)?
 ;
-;              float item types are the subset of numbers that are the floating
+;
+              float item types are the subset of numbers that are the floating
                point numbers.
 ;
          numb
@@ -14461,7 +14934,8 @@ save_
 ;
        .*
 ;
-;              A catch all for items that may take any form...
+;
+              A catch all for items that may take any form...
 ;
          char
          yyyy-mm-dd
@@ -14684,21 +15158,27 @@ save_
       _ddl2_category_group_list.description
       _ddl2_category_group_list.id
       _ddl2_category_group_list.parent_id
-;             Categories that belong to the dictionary extension.
+;
+             Categories that belong to the dictionary extension.
 ;
          inclusive_group          .
-;             Categories that describe array data.
+;
+             Categories that describe array data.
 ;
          array_data_group         inclusive_group
-;             Categories that describe axes.
+;
+             Categories that describe axes.
 ;
          axis_group               inclusive_group
-;             Categories that describe details of the diffraction experiment.
+;
+             Categories that describe details of the diffraction experiment.
 ;
          diffrn_group             inclusive_group
-;             Categories that describe details of map data.
+;
+             Categories that describe details of map data.
 ;
          map_group                inclusive_group
-;             Categories that describe details of variants.
+;
+             Categories that describe details of variants.
 ;
          variant_group            inclusive_group


### PR DESCRIPTION
The `variant` category creates a number of problems (e.g. [this one](https://github.com/COMCIFS/cif_pd/issues/275) and [these ones](https://github.com/COMCIFS/cif_multiblock/issues/42)) and is also not incorporated into the main mmCIF dictionary. This PR moves everything related to the `variant` category into `cif_img_variant.dic`, and at the same time bases the transformations off [a local fork of the DDL2 dictionary](https://github.com/COMCIFS/cbf_imgcif_dictionary).

The formatting of the output is slightly shifted due to improvements in output logic in the `CrystalInfoFramework.jl`.